### PR TITLE
Sdp refactor

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -28,7 +28,7 @@ from .symsos import (
 )
 
 from .sdpsos import (
-    SDPSOS, SDPProblem, RootSubspace
+    SDPSOS, SDPProblem, SOSProblem, RootSubspace
 )
 
 __all__ = [
@@ -46,5 +46,5 @@ __all__ = [
     'SymmetricSOS', 'sym_representation', 'TRANSLATION_POSITIVE', 'TRANSLATION_REAL',
     'prove_univariate', 'prove_univariate_interval', 'check_univariate',
     'SolutionSymmetric', 'SolutionSymmetricSimple',
-    'SDPSOS', 'SDPProblem', 'RootSubspace'
+    'SDPSOS', 'SDPProblem', 'SOSProblem', 'RootSubspace'
 ]

--- a/src/core/sdpsos/__init__.py
+++ b/src/core/sdpsos/__init__.py
@@ -1,15 +1,12 @@
-from .sdpsos import SDPSOS, SDPProblem
+from .sdpsos import SDPSOS, SOSProblem
 from .manifold import RootSubspace
 from .solver import (
     SDPResult,
-    # _sdp_solve_with_early_stop,
-    # _sdp_solver, _sdp_solver_partial_deflation, _sdp_solver_relax,
-    # _sdp_constructor, _add_sdp_eq,
-    sdp_solver,
+    SDPProblem
 )
 from .solution import SolutionSDP
 
 __all__ = [
-    'SDPSOS', 'SDPProblem', 'RootSubspace',
+    'SDPSOS', 'SDPProblem', 'SOSProblem', 'RootSubspace',
     'SDPResult', 'sdp_solver', 'SolutionSDP'
 ]

--- a/src/core/sdpsos/ipm.py
+++ b/src/core/sdpsos/ipm.py
@@ -1,0 +1,509 @@
+from typing import List, Optional, Tuple, Callable, Dict, Union, Any
+
+import numpy as np
+import sympy as sp
+import mpmath as mp
+
+
+class _functional:
+    """
+    Functional class that provides the basic operations for numpy, sympy and mpmath matrices.    
+    """
+    def __new__(cls, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        args : List[Any]
+            The arguments. It can be None, 'sp', 'mp', or 'np' or a matrix.
+            The dtype will be inferred from the first non-None argument.
+            If the dtype cannot be inferred, it defaults to numpy.
+        """
+        for x in args:
+            if x is None:
+                continue
+            elif isinstance(x, sp.Matrix):
+                return super().__new__(_functional_sp)
+            elif isinstance(x, mp.matrix):
+                return super().__new__(_functional_mp)
+            elif isinstance(x, str):
+                x = x.lower()
+                if x == 'sp' or x == 'sympy':
+                    return super().__new__(_functional_sp)
+                elif x == 'mp' or x == 'mpmath':
+                    return super().__new__(_functional_mp)
+                elif x == 'np' or x == 'numpy':
+                    return super().__new__(_functional_np)
+        return super().__new__(_functional_np)
+
+    @classmethod
+    def inner(cls, x: np.ndarray, y: np.ndarray) -> np.float64:
+        return cls.trace(x @ y)
+
+    @classmethod
+    def linsolve(cls, A: np.ndarray, b: np.ndarray) -> np.ndarray:
+        return np.linalg.solve(A, b)
+
+    @classmethod
+    def as_array(cls, x: List) -> np.ndarray:
+        return np.array(x, dtype = np.float64)
+
+    @classmethod
+    def vector_span(cls, x: np.ndarray, y: np.ndarray) -> np.ndarray:
+        return x @ y.T
+
+    @classmethod
+    def matrix_list_add(cls, x: List[np.ndarray]) -> np.ndarray:
+        s = x[0]
+        if len(x) > 1:
+            for xi in x[1:]:
+                s += xi
+        return s        
+
+    @classmethod
+    def shape(cls, x: np.ndarray) -> Tuple[int, int]:
+        return x.shape
+
+    @classmethod
+    def trace(cls, x: np.ndarray) -> np.float64:
+        return x.trace()
+
+    @classmethod
+    def isnan(cls, x: np.float64) -> bool:
+        return np.isnan(x)
+
+    @classmethod
+    def zeros(cls, rows: int, cols: int) -> np.ndarray:
+        return np.zeros((rows, cols), dtype = np.float64)
+
+    @classmethod
+    def eye(cls, n: int) -> np.ndarray:
+        return np.eye(n, dtype = np.float64)
+
+class _functional_np(_functional):
+    @classmethod
+    def inner(cls, x: np.ndarray, y: np.ndarray) -> np.float64:
+        if x.ndim == 1: # we assume y.ndim == 1 also
+            return np.inner(x, y)
+        return np.einsum("ij,ji->", x, y)
+
+    @classmethod
+    def as_array(cls, x: List) -> np.ndarray:
+        return np.array(x, dtype = np.float64)
+
+    @classmethod
+    def vector_span(cls, x: np.ndarray, y: np.ndarray) -> np.ndarray:
+        return x.reshape(-1, 1) @ y.reshape(1, -1)
+
+class _functional_sp(_functional):
+    linsolve = staticmethod(sp.Matrix.LUsolve)
+    as_array = staticmethod(sp.Matrix)
+    zeros = staticmethod(sp.zeros)
+    eye = staticmethod(sp.eye)
+
+    @classmethod
+    def inner(cls, x: sp.Matrix, y: sp.Matrix) -> sp.Float:
+        return sum((x.T).multiply_elementwise(y))
+
+    @classmethod
+    def isnan(cls, x: sp.Float) -> bool:
+        return x is sp.nan
+
+class _functional_mp(_functional):
+    linsolve = staticmethod(mp.lu_solve)
+    as_array = staticmethod(mp.matrix)
+    isnan = staticmethod(mp.isnan)
+    zeros = staticmethod(mp.zeros)
+    eye = staticmethod(mp.eye)
+
+    @classmethod
+    def inner(cls, x: mp.matrix, y: mp.matrix) -> mp.mpf:
+        return mp.fdot(x.T, y)
+
+    @classmethod
+    def shape(cls, x: mp.matrix) -> Tuple[int, int]:
+        return (x.rows, x.cols)
+
+    @classmethod
+    def trace(cls, x: mp.matrix) -> mp.mpf:
+        s = mp.mpf(0)
+        for i in range(x.rows):
+            s += x[i,i]
+        return s
+
+
+class SDPError(Exception): ...
+
+class SDPConvergenceError(SDPError, RuntimeError): ...
+
+class SDPNumericalError(SDPError, RuntimeError): ...
+
+class SDPInfeasibleError(SDPError, RuntimeError): ...
+
+class SDPRationalizeError(SDPError, RuntimeError): ...
+
+
+def _block_iterator(blocks: List[int]) -> Tuple[int, int]:
+    """
+    A generator that yields the start and end indices of the blocks.
+    """
+    i = 0
+    for b in blocks:
+        yield i, i + b
+        i += b
+
+
+def sdp_ipm(
+        A: List[Union[np.ndarray, sp.Matrix, mp.matrix]],
+        b: Union[np.ndarray, sp.Matrix, mp.matrix],
+        C: Union[np.ndarray, sp.Matrix, mp.matrix],
+        X0: Union[np.ndarray, sp.Matrix, mp.matrix],
+        dtype: Optional[str] = None,
+        rho: float = .5,
+        epsilon: float = 1e-8,
+        max_iter: int = 100,
+        blocks: Optional[List[int]] = None,
+        callback: Optional[Callable[[Dict[str, Any]], Any]] = None
+    ) -> Tuple[Union[np.ndarray, sp.Matrix, mp.matrix], Union[np.ndarray, sp.Matrix, mp.matrix]]:
+    """
+    Solve the semidefinite program
+    
+            min  <C, X>
+            s.t. <A[i], X> = b[i], i = 1, ..., m
+                X >= 0
+
+    using the interior point method. The initial point X0 must be feasible.
+    The method supports numpy, sympy and mpmath matrices, which indicates arbitrary precision.
+    All three libraries support @ for matrix multiplication.
+
+    The algorithm is based on [1]. However, the Cholesky decomposition can be omitted by
+    using the trick that tr(L'AL L'BL) = tr(A (LL') B (LL')), where LL' is the Cholesky
+    decomposition of Xk.
+
+    Parameters
+    ----------
+    A : List[matrix]
+        The constraint matrices A[i].
+    b : matrix
+        The constraint vector b.
+    C : matrix
+        The objective matrix C.
+    X0 : matrix
+        The initial point. It must be feasible.
+    dtype : Optional[str]
+        The type of the matrices. It can be 'np' for numpy, 'sp' for sympy, or 'mp' for mpmath.
+        If None, the type will be inferred from the type of the matrices in X0, A[0].
+    rho : float
+        The parameter rho for step size. It must lie in (0, 1). The default is .5.
+        Larger step size might lead to numerical instability, or stops too early.
+        Small step size might lead to slow convergence.
+    epsilon : float
+        The tolerance for convergence. When the difference of the objective function
+        between two iterations is less than epsilon, the algorithm stops. The default is 1e-8.
+    max_iter : int
+        The maximum number of iterations. The default is 100. SDPConvergenceError will be
+        raised if the algorithm does not converge within max_iter iterations.
+    blocks : List[int]
+        The block sizes of the matrices. For example, if all A and X0 are block diagonal matrices,
+        then computation can be sped up by specifying blocks = [n1, n2, ...], where n1, n2, ...
+        are the sizes of the blocks. It should satisfy sum(blocks) = n, where n is the size of X0.
+        The default is None, which means all matrices are treated as dense matrices.
+    callback : Optional[Callable[[Dict[str, Any], Any]]]
+        A callback function that will be called after each iteration. It takes a dictionary
+        as argument, containing k, X, diff, z, ..., where k is the iteration number,
+        X is the current point, diff is the difference of the objective function between
+        two iterations, z is the current objective function value. If the callback function
+        returns True, the algorithm will stop. The default is None.
+
+    Returns
+    ----------
+    Xk : matrix
+        The optimal solution.
+    lam : matrix
+        The dual solution.
+
+    References
+    ----------
+    [1] D. Benterki, J.-P. Crouzeix, and B. Merikhi, "A numerical feasible interior point method
+      for linear semidefinite programs" RAIRO - Operations Research, vol. 41, no. 1, pp. 49-59, 2007.
+    """
+    F = _functional(dtype, X0, A[0])
+    A = [F.as_array(Ai) for Ai in A]
+    b, C, Xk = F.as_array(b), F.as_array(C), F.as_array(X0)
+    bbT = F.vector_span(b, b)
+    n = F.shape(Xk)[0]
+
+    if blocks is not None:
+        if not sum(blocks) == n:
+            raise ValueError('The sum of block sizes must be equal to the size of X0.')
+    else:
+        blocks = [n]
+
+
+    for k in range(max_iter):
+
+        CX_blocks = [None] * len(blocks)
+        AX_blocks = [None] * len(blocks)
+        VX_blocks = [None] * len(blocks)
+        M_blocks = [None] * len(blocks)
+        cxax_blocks = [None] * len(blocks)
+
+        z = 0
+        cxcx = 0
+        for i, (start, end) in enumerate(_block_iterator(blocks)):
+            block = (slice(start, end), slice(start, end))
+            C_block = C[block]
+            Xk_block = Xk[block]
+            CX_block = C_block @ Xk_block
+            AX_block = [Ai[block] @ Xk_block for Ai in A]
+
+
+            M_blocks[i] = F.as_array([[F.inner(AXi, AXj) for AXj in AX_block] for AXi in AX_block])
+            cxax_blocks[i] = F.as_array([F.inner(CX_block, AXi) for AXi in AX_block])
+
+            z += F.inner(C_block, Xk_block)
+            cxcx += F.inner(CX_block, CX_block)
+
+            AX_blocks[i] = AX_block
+            CX_blocks[i] = CX_block
+
+
+        M = F.matrix_list_add(M_blocks)
+        cxax = F.matrix_list_add(cxax_blocks)
+
+        # # Original 1-block version:
+        # z = F.inner(C, Xk)
+        # CX = C @ Xk
+
+        # AX = [Ai @ Xk for Ai in A]
+        # M = F.as_array([[F.inner(AXi, AXj) for AXj in AX] for AXi in AX])
+        # cxax = F.as_array([F.inner(CX, AXi) for AXi in AX])
+        # cxcx = F.inner(CX, CX)
+
+        d = b * (-z) - cxax
+        lam = F.linsolve(M + bbT, d)
+        v = - F.inner(b.T, lam) - z
+
+
+        Vk2 = 0
+        eig_mean = 0
+        for i, (start, end) in enumerate(_block_iterator(blocks)):
+            block = (slice(start, end), slice(start, end))
+            VX_block = CX_blocks[i] # .copy()
+            for j in range(len(A)):
+                VX_block += lam[j] * AX_blocks[i][j]
+
+            Vk2 += F.inner(VX_block, VX_block)
+            eig_mean += F.trace(VX_block)
+            VX_blocks[i] = VX_block
+
+
+        eig_mean = eig_mean / n
+        eig_std = (Vk2 / n - eig_mean**2)**.5
+        beta = rho / max(v, eig_mean + eig_std*(n - 1)**.5)
+
+        # # If we use the cholesky decomposition (1-block version):
+        # L = np.linalg.cholesky(Xk)
+        # V = L.T @ C @ L
+        # for i in range(len(A)):
+        #     V += lam[i] * L.T @ A[i] @ L
+        # tau = (v**2 + F.inner(V, V))**.5
+        # eig_mean = F.trace(V) / n
+        # eig_std = (F.inner(V, V) / n - eig_mean**2)**.5
+
+        r = 1. / (1. - beta * v)
+
+        for i, (start, end) in enumerate(_block_iterator(blocks)):
+            block = (slice(start, end), slice(start, end))
+            Xk[block] *= r
+            Xk[block] -= beta * (Xk[block] @ VX_blocks[i])
+
+
+        # diff is the difference of the objective function between two iterations
+        # i.e. z_{k+1} = z_k - diff
+        diff = beta * (cxcx + F.inner(cxax.T, lam) - z * v) * r
+
+        if diff < epsilon:
+            # print('Converged in', k, 'iterations. diff =', diff)
+            break
+        if F.isnan(v):
+            raise SDPNumericalError('NaN encountered. This is probably due to numerical instability '
+                                    'or a infeasible system.')
+
+        if callback is not None:
+            params = dict(k = k, X = Xk, diff = diff, z = z - diff, M = M, lam = lam,
+                          eig_mean = eig_mean, eig_std = eig_std, beta = beta, v = v, r = r)
+            if callback(params) is True:
+                break
+
+    else:
+        raise SDPConvergenceError(f'Maximum number of {max_iter} iterations reached. '
+                                    f'Final diff = {diff}')
+
+    return Xk, lam
+
+
+def sdp_ipm_feasible(
+        A: List[Union[np.ndarray, sp.Matrix, mp.matrix]],
+        b: Union[np.ndarray, sp.Matrix, mp.matrix],
+        X0: Optional[Union[np.ndarray, sp.Matrix, mp.matrix]] = None,
+        dtype: Optional[str] = None,
+        rho: float = .5,
+        epsilon: float = 1e-8,
+        max_iter: int = 100,
+        blocks: Optional[List[int]] = None,
+        callback: Optional[Callable[[Dict[str, Any]], Any]] = None
+    ) -> Union[np.ndarray, sp.Matrix, mp.matrix]:
+    """
+    Find a feasible point for the semidefinite program
+            s.t. <A[i], X> = b[i], i = 1, ..., m
+                X >= 0
+                
+    using the interior point method. The method supports numpy, sympy and mpmath matrices,
+    which indicates arbitrary precision. All three libraries support @ for matrix multiplication.
+
+    The algorithm is based on [1]. We first introduce a relaxation variable and then solve
+    a semidefinite program with known feasible point.
+
+    Parameters
+    ----------
+    A : List[matrix]
+        The constraint matrices A[i].
+    b : matrix
+        The constraint vector b.
+    X0 : Optional[matrix]
+        Any positive definite n*n matrix. When None, defaults to an identity matrix.
+    dtype : Optional[str]
+        The type of the matrices. It can be 'np' for numpy, 'sp' for sympy, or 'mp' for mpmath.
+        If None, the type will be inferred from the type of the matrices in X0, A[0].
+    rho : float
+        The parameter rho for step size. It must lie in (0, 1). The default is .5.
+        Larger step size might lead to numerical instability, or stops too early.
+        Small step size might lead to slow convergence.
+    epsilon : float
+        The tolerance for convergence. When the difference of the objective function
+        between two iterations is less than epsilon, the algorithm stops. The default is 1e-8.
+    max_iter : int
+        The maximum number of iterations. The default is 100. SDPConvergenceError will be
+        raised if the algorithm does not converge within max_iter iterations.
+    blocks : List[int]
+        The block sizes of the matrices. For example, if all A and X0 are block diagonal matrices,
+        then computation can be sped up by specifying blocks = [n1, n2, ...], where n1, n2, ...
+        are the sizes of the blocks. It should satisfy sum(blocks) = n, where n is the size of X0.
+        The default is None, which means all matrices are treated as dense matrices.
+    callback : Optional[Callable[[Dict[str, Any], Any]]]
+        A callback function that will be called after each iteration. It takes a dictionary
+        as argument, containing k, X, diff, z, where k is the iteration number, X is the current
+        point, diff is the difference of the objective function between two iterations,
+        z is the current objective function value. If the callback function returns True,
+        the algorithm will stop. The default is None.
+
+    Returns
+    ----------
+    Xk : matrix
+        The feasible point.
+
+    References
+    ----------
+    [1] D. Benterki, J.-P. Crouzeix, and B. Merikhi, "A numerical feasible interior point method
+      for linear semidefinite programs" RAIRO - Operations Research, vol. 41, no. 1, pp. 49-59, 2007.
+    """
+    if len(A) == 0:
+        raise ValueError('Argument A must be non-empty.')
+
+    F = _functional(dtype, X0, A[0])
+    A = [F.as_array(Ai) for Ai in A]
+    b = F.as_array(b)
+    n = F.shape(A[0])[0]
+
+    C = F.zeros(n + 1, n + 1)
+    C[n, n] = 1
+
+    def _pad(X, v = 0):
+        X2 = F.zeros(n + 1, n + 1)
+        X2[:n, :n] = X
+        X2[n, n] = v
+        return X2
+
+    if X0 is None:
+        X0 = F.eye(n + 1)
+        A = [_pad(Ai, bi - F.trace(Ai)) for Ai, bi in zip(A, b)]
+    else:
+        X0 = F.as_array(X0)
+        A = [_pad(Ai, bi - F.inner(Ai, X0)) for Ai, bi in zip(A, b)]
+        X0 = _pad(X0, 1)
+
+
+    if blocks is None:
+        blocks = [n, 1]
+    else:
+        blocks = blocks + [1]
+
+
+    Xk, lam = sdp_ipm(A, b, C, X0, dtype=dtype, 
+                rho=rho, epsilon=epsilon, max_iter=max_iter, blocks=blocks, callback=callback)
+    return Xk[:n, :n]
+
+
+def sdp_dual_feasible(
+        C: Union[np.ndarray, sp.Matrix, mp.matrix],
+        A: List[Union[np.ndarray, sp.Matrix, mp.matrix]],
+        dtype: Optional[str] = None,
+        rho = .5,
+        epsilon = 1e-8,
+        max_iter = 100,
+        blocks = None,
+        callback = None
+    ) -> Tuple[Union[np.ndarray, sp.Matrix, mp.matrix], Union[np.ndarray, sp.Matrix, mp.matrix]]:
+    """
+    Solve the dual problem of the SDP feasibility problem
+    C + A[0]*x[0] + ... + A[n]*x[n] >= 0.
+
+    Parameters
+    ----------
+    C : matrix
+        The objective matrix C.
+    A : List[matrix]
+        The constraint matrices A[i].
+    dtype : Optional[str]
+        The type of the matrices. It can be 'np' for numpy, 'sp' for sympy, or 'mp' for mpmath.
+        If None, the type will be inferred from the type of the matrices in X0, A[0].
+    rho : float
+        The parameter rho for step size. It must lie in (0, 1). The default is .5.
+        Larger step size might lead to numerical instability, or stops too early.
+        Small step size might lead to slow convergence.
+    epsilon : float
+        The tolerance for convergence. When the difference of the objective function
+        between two iterations is less than epsilon, the algorithm stops. The default is 1e-8.
+    max_iter : int
+        The maximum number of iterations. The default is 100. SDPConvergenceError will be
+        raised if the algorithm does not converge within max_iter iterations.
+    blocks : List[int]
+        The block sizes of the matrices. For example, if all A and X0 are block diagonal matrices,
+        then computation can be sped up by specifying blocks = [n1, n2, ...], where n1, n2, ...
+        are the sizes of the blocks. It should satisfy sum(blocks) = n, where n is the size of X0.
+        The default is None, which means all matrices are treated as dense matrices.
+    callback : Optional[Callable[[Dict[str, Any], Any]]]
+        A callback function that will be called after each iteration. It takes a dictionary
+        as argument, containing k, X, diff, z, where k is the iteration number, X is the current
+        point, diff is the difference of the objective function between two iterations,
+        z is the current objective function value. If the callback function returns True,
+        the algorithm will stop. The default is None.
+
+    Returns
+    ----------
+    Xk : matrix
+        The optimal solution.
+    lam : matrix
+        The dual solution.
+    """
+    if len(A) == 0:
+        raise ValueError('Argument A must be non-empty.')
+
+    F = _functional(dtype, C, A[0])
+    A = [F.as_array(Ai) for Ai in A]
+    C = F.as_array(C)
+
+    b = F.as_array([F.trace(Ai) for Ai in A])
+    X, lam = sdp_ipm(A, b, C, F.eye(F.shape(C)[0]), dtype=dtype,
+                rho=rho, epsilon=epsilon, max_iter=max_iter, blocks=blocks, callback=callback)
+    return X, lam

--- a/src/core/sdpsos/rationalize.py
+++ b/src/core/sdpsos/rationalize.py
@@ -1,10 +1,12 @@
 from itertools import chain
-from typing import List, Union, Optional, Callable
+from typing import Tuple, List, Union, Optional, Callable
 
 import numpy as np
 import sympy as sp
 
 from .utils import congruence_with_perturbation, S_from_y
+
+Decomp = List[Tuple[sp.Matrix, sp.Matrix, List[sp.Rational]]]
 
 
 def rationalize(x, rounding = 1e-2, **kwargs):
@@ -126,7 +128,7 @@ def rationalize_and_decompose(
         reg: float = 0,
         perturb: bool = False,
         check_pretty: bool = True,
-    ):
+    ) -> Optional[Tuple[sp.Matrix, Decomp]]:
     """
     Recover symmetric matrices from `x0 + space * y` and check whether they are
     positive semidefinite.

--- a/src/core/sdpsos/sdpsos.py
+++ b/src/core/sdpsos/sdpsos.py
@@ -4,10 +4,10 @@ from typing import List, Optional, Union, Tuple, Dict, Callable
 import sympy as sp
 
 from .utils import (
-    upper_vec_of_symmetric_matrix, solve_undetermined_linear, split_vector, S_from_y, 
+    solve_undetermined_linear, split_vector,
     indented_print
 )
-from .solver import sdp_solver, SDPResult
+from .solver import SDPProblem, SDPProblemEmpty
 from .manifold import RootSubspace, _REDUCE_KWARGS, coefficient_matrix, add_cyclic_constraints
 from .solution import create_solution_from_M, SolutionSDP
 from ...utils.basis_generator import arraylize, arraylize_sp
@@ -38,58 +38,48 @@ class SOSProblem():
         self.deg = deepcopy(info)
         self.M = deepcopy(info)
 
-        self.S = deepcopy(info)
-        self.decompositions = deepcopy(info)
-
-        self.masked_rows = deepcopy(info)
-
         self.eq = deepcopy(info)
         self.vecP = None
 
-        # unmasked S, x0, space, splits
         self.S_ = deepcopy(info)
-        self.x0_ = None
-        self.space_ = None
-        self.splits_ = None
+        self.sdp = SDPProblemEmpty()
 
-        # masked x0, space, splits
-        self.x0 = None
-        self.space = None
-        self.splits = None
-
-        self.sos = None
-        self.y = None
-
-        self.success = False
 
         if manifold is None:
             manifold = RootSubspace(poly)
         self.manifold = manifold
+
         if verbose_manifold:
             print(manifold)
 
 
     def _masked_dims(self, filter_zero = False):
-        dims = {}
-        for key, Q in self.Q.items():
-            if Q is None:
-                v = 0
-            else:
-                mask = self.masked_rows.get(key, [])
-                v = Q.shape[1] - len(mask)
-            if filter_zero and v == 0:
-                continue
-            dims[key] = v
-        return dims
+        return self.sdp._masked_dims(filter_zero=filter_zero)
 
     def _not_none_keys(self):
-        return list(self._masked_dims(filter_zero = True))
+        return self.sdp._not_none_keys()
 
-    def update(self, collection):
-        if isinstance(collection, SDPResult):
-            collection = collection.as_dict()
-        for k, v in collection.items():
-            setattr(self, k, v)
+    @property
+    def masked_rows(self):
+        return self.sdp.masked_rows
+
+    @property
+    def S(self):
+        return self.sdp.S
+
+    @property
+    def y(self):
+        return self.sdp.y
+
+    def S_from_y(self, *args, **kwargs):
+        return self.sdp.S_from_y(*args, **kwargs)
+
+    def set_masked_rows(self, *args, **kwargs):
+        return self.sdp.set_masked_rows(*args, **kwargs)
+
+    def pad_masked_rows(self, *args, **kwargs):
+        return self.sdp.pad_masked_rows(*args, **kwargs)
+
 
     def __getitem__(self, key):
         return getattr(self, key)
@@ -138,7 +128,7 @@ class SOSProblem():
         return eq, self.vecP
 
 
-    def _compute_subspace(self, eq, vecM) -> Tuple[sp.Matrix, sp.Matrix, List[slice]]:
+    def _compute_subspace(self, eq, vecM) -> SDPProblem:
         """
         Given eq @ vec(S) = vec(M), if we want to solve S, then we can
         see that S = x0 + space * y where x0 is a particular solution and y is arbitrary.
@@ -146,105 +136,21 @@ class SOSProblem():
         # we have eq @ vecS = vecM
         # so that vecS = x0 + space * y where x0 is a particular solution and y is arbitrary
         x0, space = solve_undetermined_linear(eq, vecM)
-        splits = split_vector(list(self._masked_dims().values()))
+        keys = [k for k, v in self.Q.items() if v is not None]
+        splits = split_vector([self.Q[k].shape[1] for k in keys])
 
-        self.x0_ = x0
-        self.x0 = x0
-        self.space_ = space
-        self.space = space
-        self.splits_ = splits
-        self.splits = splits
-        return x0, space, splits
+        self.sdp = SDPProblem(x0, space, splits, keys=keys)
+        return self.sdp
 
  
     def construct_problem(self, minor = 0, cyclic_constraint = True, verbose = True) -> Tuple[sp.Matrix, sp.Matrix, List[slice]]:
         """
         Construct the symbolic representation of the problem.
         """
-        self.masked_rows = {}
         Q = self._compute_perp_space(minor = minor)
         eq, vecP = self._compute_equation(cyclic_constraint = cyclic_constraint)
-        subspace = self._compute_subspace(eq, vecP)
-        return subspace
-
-
-    def set_masked_rows(self, masks: Dict[str, List[int]] = {}) -> Dict[str, sp.Matrix]:
-        """
-        Sometimes the diagonal entries of S are zero. Or we set them to zero to
-        reduce the degree of freedom. This function masks the corresponding rows.
-
-        Parameters
-        ----------
-        masks : List[int]
-            Indicates the indices of the rows to be masked.
-        """
-        # restore masked values to unmaksed values
-        self.x0, self.space, self.splits = self.x0_, self.space_, self.splits_
-        self.masked_rows = {}
-
-        if len(masks) == 0 or not any(_ for _ in masks.values()):
-            return True
-
-        # first compute y = x1 + space1 @ y1
-        # => S = x0 + space @ x1 + space @ space1 @ y1
-        perp_space = []
-        tar_space = []
-        lines = []
-
-        for key, split in zip(self._not_none_keys(), self.splits):
-            mask = masks.get(key, [])
-            if not mask:
-                continue
-            n = self.Q[key].shape[1]
-            for v, (i,j) in enumerate(upper_vec_of_symmetric_matrix(n, return_inds = True)):
-                if i in mask or j in mask:
-                    lines.append(v + split.start)
-
-        tar_space = - self.x0[lines, :]
-        perp_space = self.space[lines, :]
-
-        # this might not have solution and raise an Error
-        x1, space1 = solve_undetermined_linear(perp_space, tar_space)
-
-        self.x0 += self.space @ x1
-        self.space = self.space @ space1
-
-        # remove masked rows
-        not_lines = list(set(range(self.space.shape[0])) - set(lines))
-        self.x0 = self.x0[not_lines, :]
-        self.space = self.space[not_lines, :]
-        self.masked_rows = deepcopy(masks)
-        self.splits = split_vector(list(self._masked_dims().values()))
-
-        return masks
-
-
-    def pad_masked_rows(self, S: Union[Dict, sp.Matrix], key: str) -> sp.Matrix:
-        """
-        Pad the masked rows of S[key] with zeros.
-
-        Returns
-        ----------
-        S : sp.Matrix
-            The padded S.
-        """
-        if isinstance(S, dict):
-            S = S[key]
-
-        mask = self.masked_rows.get(key, [])
-        if not mask:
-            return S
-
-        n = S.shape[0]
-        m = n + len(mask)
-        Z = sp.Matrix.zeros(m)
-        # Z[:n, :n] = S
-        not_masked = list(set(range(m)) - set(mask))
-
-        for v1, r1 in enumerate(not_masked):
-            for v2, r2 in enumerate(not_masked):
-                Z[r1, r2] = S[v1, v2]
-        return Z
+        sdp = self._compute_subspace(eq, vecP)
+        return sdp
 
 
     def solve(self,
@@ -252,9 +158,6 @@ class SOSProblem():
             cyclic_constraint: bool = True,
             skip_construct_subspace: bool = False,
             method: str = 'trivial',
-            reg: float = 0,
-            constraints: Optional[List[Callable]] = None,
-            objectives: Optional[List[Tuple[str, Callable]]] = None,
             allow_numer: bool = False,
             verbose: bool = False
         ) -> bool:
@@ -271,44 +174,13 @@ class SOSProblem():
             add the minor term, please set `minor = True`.
         cyclic_constraint : bool
             Whether to add cyclic constraint the problem. This reduces the degree of freedom.
+        method : str
+            The method to solve the SDP problem. Currently supports:
+            'partial deflation' and 'relax' and 'trivial'.
         skip_construct_subspace : bool
             Whether to skip the computation of the subspace. This is useful when we have
             already computed the subspace and want to solve the problem with different
             sdp configurations.
-        method: str
-            The method to solve the SDP problem. Currently supports:
-            'partial deflation' and 'trivial'.
-        reg : float
-            We require `S[i]` to be positive semidefinite, but in practice
-            we might want to add a small regularization term to make it
-            positive definite >> reg * I.
-        constraints : Optional[List[Callable]]
-            Extra constraints of the SDP problem. This is not called when the problem is degenerated
-            (when the degree of freedom is zero).
-
-            Example:
-            ```
-            constraints = [
-                lambda sos: sos.variables['y'][0] == 0,
-            ]
-            ```
-        objectives : Optional[List[Tuple[str, Callable]]]
-            Although it suffices to find one feasible solution, we might 
-            use objective to find particular feasible solution that has 
-            good rational approximant. This parameter takes in multiple objectives, 
-            and the solver will try each of the objective. If still no 
-            approximant is found, the final solution will average this 
-            SOS solution and perform rationalization. Note that SDP problem is 
-            convex so the convex combination is always feasible and not on the
-            boundary.
-
-            Example: 
-            ```
-            objectives = [
-                ('max', lambda sos: sos.variables['S_major'].tr),
-                ('max', lambda sos: sos.variables['S_major']|1)
-            ]
-            ```
         allow_numer : bool
             Whether to allow numerical solution. If True, then the function will return numerical solution
             if the rational solution does not exist.
@@ -320,19 +192,15 @@ class SOSProblem():
         bool
             Whether the problem is solved successfully. It can also be accessed by `sdp_problem.success`.
         """
-        self.success = False
-
         if not skip_construct_subspace:
             try:
-                subspace = self.construct_problem(minor = minor, cyclic_constraint = cyclic_constraint, verbose = verbose)
+                self.construct_problem(minor = minor, cyclic_constraint = cyclic_constraint, verbose = verbose)
             except:
                 if verbose:
                     print('Linear system no solution. Please higher the degree by multiplying something %s.'%(
                         'or use the minor term' if not minor else ''
                     ))
                 return False
-        else:
-            subspace = (self.x0, self.space, self.splits)
 
 
         if verbose:
@@ -342,45 +210,17 @@ class SOSProblem():
                 ).replace("'", '')))
 
         # Main SOS solver
-        sos_result = sdp_solver(
-            *subspace,
-            self._not_none_keys(),
+        sos_result = self.sdp.solve(
             method = method,
-            reg = reg,
-            constraints = constraints,
-            objectives = objectives,
             allow_numer = allow_numer,
             verbose = verbose
         )
-        self.update(sos_result)
 
         if not sos_result.success:
             return False
-
         self.M = self.compute_M(self.S)
 
         return True
-
-
-    def S_from_y(self, y: Optional[sp.Matrix] = None) -> Dict[str, sp.Matrix]:
-        """
-        Given y, compute the symmetric matrices. This is useful when we want to see the
-        symbolic representation of the SDP problem.
-
-        This function does not register the result to self.S.
-        """
-        if y is None:
-            m = self.space.shape[1]
-            y = sp.Matrix([sp.symbols('y_{%d}'%_) for _ in range(m)]).reshape(m, 1)
-        elif not isinstance(y, sp.MatrixBase) or y.shape != (self.space.shape[1], 1):
-            raise ValueError('y must be a sympy Matrix of shape (%d, 1).'%self.space.shape[1])
-
-        Ss = S_from_y(y, self.x0, self.space, self.splits)
-
-        ret = {}
-        for key, S in zip(self._not_none_keys(), Ss):
-            ret[key] = S
-        return ret
 
 
     def compute_M(self, S: Dict[str, sp.Matrix]) -> Dict[str, sp.Matrix]:

--- a/src/core/sdpsos/sdpsos.py
+++ b/src/core/sdpsos/sdpsos.py
@@ -14,9 +14,9 @@ from ...utils.basis_generator import arraylize, arraylize_sp
 from ...utils.polytools import deg
 
 
-class SDPProblem():
+class SOSProblem():
     """
-    Helper class for SDPSOS. See details at SDPProblem.solve.
+    Helper class for SDPSOS. See details at SOSProblem.solve.
 
     Assume that a polynomial can be written in the form v^T @ M @ v.
     Sometimes there are implicit constraints that M = Q @ S @ Q.T where Q is a rational matrix.
@@ -81,7 +81,6 @@ class SDPProblem():
                 continue
             dims[key] = v
         return dims
-
 
     def _not_none_keys(self):
         return list(self._masked_dims(filter_zero = True))
@@ -478,7 +477,7 @@ def SDPSOS(
 
     For more flexible usage, please use
     ```
-        sdp_problem = SDPProblem(poly)
+        sdp_problem = SOSProblem(poly)
         sdp_problem.solve(**kwargs)
         solution = sdp_problem.as_solution()
     ```
@@ -519,7 +518,7 @@ def SDPSOS(
     if not (poly.domain in (sp.polys.ZZ, sp.polys.QQ)):
         return None
 
-    sdp_problem = SDPProblem(poly, verbose_manifold=verbose)
+    sdp_problem = SOSProblem(poly, verbose_manifold=verbose)
 
     if isinstance(minor, (bool, int)):
         minor = [minor]

--- a/src/core/sdpsos/sdpsos.py
+++ b/src/core/sdpsos/sdpsos.py
@@ -208,6 +208,7 @@ class SOSProblem():
                     {k: '{}/{}'.format(v, self.Q[k].shape[0])
                         for k, v in self._masked_dims(filter_zero = True).items()}
                 ).replace("'", '')))
+            print('Degree of freedom: %d'%(self.sdp.dof))
 
         # Main SOS solver
         sos_result = self.sdp.solve(

--- a/src/core/sdpsos/sdpsos.py
+++ b/src/core/sdpsos/sdpsos.py
@@ -374,14 +374,14 @@ def SDPSOS(
 
         with indented_print(verbose = verbose):
             try:
-                sdp_problem.solve(
+                success = sdp_problem.solve(
                     minor = minor_,
                     cyclic_constraint = cyclic_constraint,
                     method = method,
                     allow_numer = allow_numer,
                     verbose = verbose
                 )
-                if sdp_problem.success:
+                if success:
                     # We can also pass in **M
                     return sdp_problem.as_solution(
                         decompose_method = decompose_method, 

--- a/src/core/sdpsos/sdpsos.py
+++ b/src/core/sdpsos/sdpsos.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import List, Optional, Union, Tuple, Dict, Callable
+from typing import List, Optional, Union, Tuple, Dict
 
 import sympy as sp
 
@@ -240,7 +240,7 @@ class SOSProblem():
             decompose_method: str = 'raw',
             cyc: bool = True,
             factor_result: bool = True
-        ):
+        ) -> SolutionSDP:
         """
         Wrap the matrix form solution to a SolutionSDP object.
         Note that the decomposition of a quadratic form is not unique.
@@ -255,6 +255,11 @@ class SOSProblem():
             Whether to convert the solution to a cyclic sum.
         factor_result : bool
             Whether to factorize the result. The default is True.
+
+        Returns
+        ----------
+        solution : SolutionSDP
+            SDP solution.
         """
 
         if y is None:

--- a/src/core/sdpsos/solver.py
+++ b/src/core/sdpsos/solver.py
@@ -1,11 +1,31 @@
-from typing import List, Optional, Tuple, Callable, Dict
-from contextlib import contextmanager
+from typing import List, Optional, Tuple, Callable, Dict, Any, Union
+from contextlib import contextmanager, nullcontext, AbstractContextManager
+from copy import deepcopy
 
 import numpy as np
 import sympy as sp
 
 from .rationalize import rationalize, rationalize_and_decompose
-from .utils import symmetric_matrix_from_upper_vec, S_from_y
+from .ipm import (
+    SDPConvergenceError, SDPNumericalError, SDPInfeasibleError, SDPRationalizeError
+)
+from .utils import (
+    symmetric_matrix_from_upper_vec, upper_vec_of_symmetric_matrix,
+    split_vector, solve_undetermined_linear, S_from_y
+)
+
+
+def _check_picos(verbose = False):
+    """
+    Check whether PICOS is installed.
+    """
+    try:
+        import picos
+    except ImportError:
+        if verbose:
+            print('Cannot import picos, please use command "pip install picos" to install it.')
+        return False
+    return True
 
 
 class SDPResult():
@@ -34,651 +54,540 @@ class SDPResult():
         }
 
 
-def _check_picos(verbose = False):
+class SDPProblem():
     """
-    Check whether PICOS is installed.
+    Main class to solve rational SDP problems.
     """
-    try:
+    _has_picos = _check_picos()
+    def __init__(self, x0, space, splits, keys = []):
+        # unmasked x0, space, splits
+        self._x0 = x0
+        self._space = space
+        self._splits = splits
+        self.masked_rows = {}
+
+        # masked x0, space, splits
+        self.x0 = x0
+        self.space = space
+        self.splits = splits
+
+        self.y = None
+        self.S = None
+
+        if keys is not None:
+            if len(keys) != len(splits):
+                raise ValueError("Length of keys and splits should be the same. But got %d and %d."%(len(keys), len(splits)))
+            self.keys = keys
+        else:
+            self.keys = ['S_%d'%i for i in range(len(splits))]
+
+        self.sos = self._construct_sos() if self._has_picos else None
+
+        # record the numerical solutions
+        self._ys = []
+
+    @property
+    def args(self):
+        return self.x0, self.space, self.splits
+
+    @property
+    def dof(self):
+        return self.space.shape[1]
+
+    def _masked_dims(self, filter_zero = False):
+        dims = {}
+        for i in range(len(self.keys)):
+            key = self.keys[i]
+            split = self.splits[i]
+            mask = self.masked_rows.get(key, [])
+            k = round(np.sqrt(2 * (split.end - split.start) + .25) - .5)
+            v = k - len(mask)
+            if filter_zero and v == 0:
+                continue
+            dims[key] = v
+        return dims
+
+    def _not_none_keys(self):
+        return list(self._masked_dims(filter_zero = True))
+
+
+    def set_masked_rows(self, masks: Dict[str, List[int]] = {}) -> Dict[str, sp.Matrix]:
+        """
+        Sometimes the diagonal entries of S are zero. Or we set them to zero to
+        reduce the degree of freedom. This function masks the corresponding rows.
+
+        Parameters
+        ----------
+        masks : List[int]
+            Indicates the indices of the rows to be masked.
+        """
+        # restore masked values to unmaksed values
+        self.x0, self.space, self.splits = self._x0, self._space, self._splits
+        self.masked_rows = {}
+
+        if len(masks) == 0 or not any(_ for _ in masks.values()):
+            return True
+
+        # first compute y = x1 + space1 @ y1
+        # => S = x0 + space @ x1 + space @ space1 @ y1
+        perp_space = []
+        tar_space = []
+        lines = []
+
+        for key, split in zip(self._not_none_keys(), self.splits):
+            mask = masks.get(key, [])
+            if not mask:
+                continue
+            n = self.Q[key].shape[1]
+            for v, (i,j) in enumerate(upper_vec_of_symmetric_matrix(n, return_inds = True)):
+                if i in mask or j in mask:
+                    lines.append(v + split.start)
+
+        tar_space = - self.x0[lines, :]
+        perp_space = self.space[lines, :]
+
+        # this might not have solution and raise an Error
+        x1, space1 = solve_undetermined_linear(perp_space, tar_space)
+
+        self.x0 += self.space @ x1
+        self.space = self.space @ space1
+
+        # remove masked rows
+        not_lines = list(set(range(self.space.shape[0])) - set(lines))
+        self.x0 = self.x0[not_lines, :]
+        self.space = self.space[not_lines, :]
+        self.masked_rows = deepcopy(masks)
+        self.splits = split_vector(list(self._masked_dims().values()))
+
+        return masks
+
+
+    def pad_masked_rows(self, S: Union[Dict, sp.Matrix], key: str) -> sp.Matrix:
+        """
+        Pad the masked rows of S[key] with zeros.
+
+        Returns
+        ----------
+        S : sp.Matrix
+            The padded S.
+        """
+        if isinstance(S, dict):
+            S = S[key]
+
+        mask = self.masked_rows.get(key, [])
+        if not mask:
+            return S
+
+        n = S.shape[0]
+        m = n + len(mask)
+        Z = sp.Matrix.zeros(m)
+        # Z[:n, :n] = S
+        not_masked = list(set(range(m)) - set(mask))
+
+        for v1, r1 in enumerate(not_masked):
+            for v2, r2 in enumerate(not_masked):
+                Z[r1, r2] = S[v1, v2]
+        return Z
+
+
+    def S_from_y(self, y: Optional[sp.Matrix] = None) -> Dict[str, sp.Matrix]:
+        """
+        Given y, compute the symmetric matrices. This is useful when we want to see the
+        symbolic representation of the SDP problem.
+
+        This function does not register the result to self.S.
+        """
+        m = self.dof
+        if y is None:
+            y = sp.Matrix([sp.symbols('y_{%d}'%_) for _ in range(m)]).reshape(m, 1)
+        elif not isinstance(y, sp.MatrixBase) or y.shape != (m, 1):
+            raise ValueError('y must be a sympy Matrix of shape (%d, 1).'%m)
+
+        Ss = S_from_y(y, *self.args)
+
+        ret = {}
+        for key, S in zip(self._not_none_keys(), Ss):
+            ret[key] = S
+        return ret
+
+
+
+    def _construct_sos(self, reg = 0, constraints = None):        
         import picos
-    except ImportError:
-        if verbose:
-            print('Cannot import picos, please use command "pip install picos" to install it.')
-        return False
-    return True
 
+        # SDP should use numerical algorithm
+        x0, space, splits = self.args
+        x0_numer = np.array(x0).astype(np.float64).flatten()
+        space_numer = np.array(space).astype(np.float64)
 
-def _sdp_solve_with_early_stop(sos, max_iters = 50, min_iters = 10, verbose = False):
-    """
-    Python package PICOS solving SDP problem with CVXOPT will oftentimes
-    faces ZeroDivisionError. This is due to the iterations is large while
-    working precision is not enough.
+        sos = picos.Problem()
+        y = picos.RealVariable('y', self.dof)
+        for key, split in zip(self.keys, splits):
+            x0_ = x0_numer[split]
+            k = round(np.sqrt(2 * len(x0_) + .25) - .5)
+            S = picos.SymmetricVariable(key, (k,k))
+            sos.add_constraint(S >> reg)
 
-    This function is a workaround to solve this. It flexibly reduces the
-    number of iterations and tries to solve the problem again until
-    the problem is solved or the number of iterations is less than min_iters.
+            self._add_sdp_eq(sos, S, x0_, space_numer[split], y)
 
-    Parameters
-    ----------
-    sos : picos.Problem
-        The SDP problem.
-    max_iters : int
-        Maximum number of iterations. It cuts down to half if ZeroDivisionError is raised. Defaults to 50. 
-    min_iters : int
-        Minimum number of iterations. Return None if max_iters < min_iters. Defaults to 10.
-    verbose : bool
-        If True, print the number of iterations.
+        for constraint in constraints or []:
+            sos.add_constraint(constraint(sos))
 
-    Returns
-    -------
-    solution : Optional[picos.Problem]
-        The solution of the SDP problem. If the problem is not solved,
-        return None.
-    """
-    sos.options.max_iterations = max_iters
-    if verbose:
-        print('Retry Early Stop SOS Max Iters = %d' % sos.options.max_iterations)
+        return sos, y
 
-    try:
-        solution = sos._strategy.execute()
-        return solution # .primals[sos.variables['y']]
-    except Exception as e:
-        if isinstance(e, ZeroDivisionError):
-            if max_iters // 2 >= min_iters and max_iters > 1:
-                return _sdp_solve_with_early_stop(
-                            sos, 
-                            max_iters = max_iters // 2, 
-                            min_iters = min_iters, 
-                            verbose = verbose
-                        )
-        return None
-    return None
-
-
-def _add_sdp_eq(
-        sos, 
-        x0: np.ndarray,
-        space: np.ndarray,
-        y: np.ndarray,
-        reg: float = 0,
-        suffix: str = '_0',
-        method: str = 'lmi'
-    ):
-    """
-    Add a new variable S to a PICOS.Problem such that S is a symmetric positive
-    semidefinite matrix and the upper triangular part of S = x0 + space * y.
-
-    Parameters
-    ----------
-    sos : picos.Problem
-        The SDP problem.
-    x0 : np.ndarray
-        The constant part of the equation. Stands for a particular solution
-        of the space of S.
-    space : np.ndarray
-        The space of S. Stands for the space constraint of S.
-    y : picos.RealVariable
-        The underlying generator of S.
-    reg : float
-        The regularization term of S. We require S >> reg * I.
-    suffix : str
-        A string suffix to the name of the variable.
-    method : str
-        The method to construct S. Currently supports 'lmi', 'intermediate' and 'direct'.
-
-    Returns
-    -------
-    S : picos.SymmetricVariable
-        The variable S.
-    """
-    import picos
-
-    # k(k+1)/2 = len(x0)
-    k = round(np.sqrt(2 * len(x0) + .25) - .5)
-    S = picos.SymmetricVariable('S%s'%suffix, (k,k))
-    sos.add_constraint(S >> reg)
-
-    if method == 'lmi':
+    def _add_sdp_eq(self, sos, S, x0, space, y):
+        k = round(np.sqrt(2 * len(x0) + .25) - .5)
         x0_sym = symmetric_matrix_from_upper_vec(x0)
         space_sym = symmetric_matrix_from_upper_vec(space).reshape(k**2, -1)
         sos.add_constraint(S.vec == x0_sym + space_sym * y)
 
-    elif method == 'intermediate':
-        z = picos.RealVariable('z%s'%suffix, len(x0))
-        sos.add_constraint(z == x0 + space * y)
-        target = z
-    elif method == 'direct':
-        target = space * y + x0.reshape((-1,1))
-    else:
-        raise ValueError('Method %s is not supported.'%method)
 
-    if method in ['direct', 'intermediate']:
-        pointer = 0
-        for i in range(k):
-            for j in range(i, k):
-                sos.add_constraint(S[i,j] == target[pointer])
-                pointer += 1
-    return S
+    def _nsolve_with_early_stop(
+            self,
+            max_iters: int = 50,
+            min_iters: int = 10,
+            verbose: bool = False
+        ) -> Any:
+        """
+        Numerically solve the sdp with PICOS.
 
+        Python package PICOS solving SDP problem with CVXOPT will oftentimes
+        faces ZeroDivisionError. This is due to the iterations is large while
+        working precision is not enough.
 
-def _sdp_constructor(
-        x0: sp.Matrix, 
-        space: sp.Matrix, 
-        splits: List[slice], 
-        keys: List[str],
-        reg: float = 0,
-        constraints: Optional[List[Callable]] = None
-    ):
-    """
-    Construct SDP problem: find feasible y such that
-    `x0[splits[i]] + space[splits[i],:] * y = uppervec(S[i])`
-    with constraint that each `S[i]` is symmetric positive semidefinite.
+        This function is a workaround to solve this. It flexibly reduces the
+        number of iterations and tries to solve the problem again until
+        the problem is solved or the number of iterations is less than min_iters.
 
-    Parameters
-    ----------
-    x0 : sp.Matrix
-        The constant part of the equation. Stands for a particular solution
-        of the space of S.
-    space : sp.Matrix
-        The space of S. Stands for the space constraint of S.
-    splits : List[slice]
-        The splits of the space. Each split is a slice object.
-    keys : List[str]
-        The keys of the variables.
-    reg : float
-        The regularization term of S. We require S >> reg * I.
-    constraints : Optional[List[Callable]]
-        Extra constraints of the SDP problem.
+        Parameters
+        ----------
+        max_iters : int
+            Maximum number of iterations. It cuts down to half if ZeroDivisionError is raised. Defaults to 50. 
+        min_iters : int
+            Minimum number of iterations. Return None if max_iters < min_iters. Defaults to 10.
+        verbose : bool
+            If True, print the number of iterations.
 
-        Example:
-        ```
-        constraints = [
-            lambda sos: sos.variables['y'][0] == 0,
-        ]
-        ```
+        Returns
+        -------
+        solution : Optional[picos.Problem]
+            The solution of the SDP problem. If the problem is not solved,
+            return None.
+        """
+        sos = self.sos
+        # verbose = self.verbose
 
-    Returns
-    -------
-    sos : picos.Problem
-        The SDP problem.
-    y : picos.RealVariable
-        The underlying generator of S.
-    """
-    import picos
-
-    # SDP should use numerical algorithm
-    x0_numer = np.array(x0).astype(np.float64).flatten()
-    space_numer = np.array(space).astype(np.float64)
-
-    sos = picos.Problem()
-    y = picos.RealVariable('y', space.shape[1])
-    for key, split in zip(keys, splits):
-        S = _add_sdp_eq(sos, x0_numer[split], space_numer[split], y, reg = reg, suffix = '_%s'%key)
-
-    for constraint in constraints or []:
-        sos.add_constraint(constraint(sos))
-
-    return sos, y
-
-
-def _sdp_solver(
-        sos,
-        x0: sp.Matrix,
-        space: sp.Matrix,
-        splits: List[slice],
-        objectives: Optional[List[Tuple[str, Callable]]] = None,
-        allow_numer: bool = False,
-        verbose: bool = False,
-        return_ys: bool = False
-    ):
-    """
-    Solve the SDP problem. See details at `sdp_solver` function.
-
-    Parameters
-    ----------
-    sos : picos.Problem
-        The SDP problem.
-    x0 : sp.Matrix
-        The constant part of the equation. Stands for a particular solution
-        of the space of S.
-    space : sp.Matrix
-        The space of S. Stands for the space constraint of S.
-    splits : List[slice]
-        The splits of the symmetric matrices. Each split is a slice object.
-    objectives : List[Tuple[str, Callable]]
-        The objectives of the SDP problem.
-    allow_numer : bool
-        Whether to allow numerical solution. If True, then the function will return numerical solution
-        if the rational solution does not exist.
-    verbose : bool
-        If True, print the details.
-    return_ys : bool
-        This is used for debugging. If True, return all numerical solutions of y without
-        performing rationalization or decompositions.
-
-    Returns
-    -------
-    y_rational: sp.Matrix
-        The rational solution of y.
-    decompositions: List[Tuple[sp.Matrix, sp.Matrix, List]]
-        The congruence decomposition of each symmetric matrix S. Each item is a tuple
-        of `(S, U, diag)` where `S = U.T * diag(diag) * U` where `U` is upper triangular
-        and `diag` is a diagonal matrix.
-    """
-
-    if objectives is None:
-        obj_key = 'S_minor' if 'S_minor' in sos.variables else 'S_major'
-        objectives = [
-            ('max', lambda sos: sos.variables[obj_key].tr),
-            ('min', lambda sos: sos.variables[obj_key].tr),
-            ('max', lambda sos: sos.variables[obj_key]|1)
-        ]
-        x = np.random.randn(*sos.variables[obj_key].shape)
-        objectives.append(('max', lambda sos: sos.variables[obj_key]|x))
-
-    # record all numerical solution of y
-    # so that we can take the convex combination in the final step
-    ys = []
-
-    for objective in objectives:
-        # try each of the objectives
-
-        sos.set_objective(objective[0], objective[1](sos))
-        y = None
-
-        from picos.modeling.strategy import Strategy
-        sos._strategy = Strategy.from_problem(sos)
-        solution = _sdp_solve_with_early_stop(sos, max_iters = 50)
-
-        if solution is not None:
-            # try:
-            y = solution.primals[sos.variables['y']]
-            # except KeyError:
-
-            # NOTE: PICOS uses a different vectorization of symmetric matrices
-            #       (off-diagonal elements are divided by sqrt(2))
-            #       so if we need to convert it back, we had better use its API.
-            # S0 = (SymmetricVectorization((6,6)).devectorize(cvxopt.matrix(list(solution.primals.values())[0])))
-            # print(np.linalg.eigvalsh(np.array(S0)))
-            # print(S0)
-        
-        if y is None:
-            continue
-
-        # perform rationalization
-        y = np.array(y)
-        ys.append(y)
-        
-        decomp = rationalize_and_decompose(y, x0, space, splits, 
-            try_rationalize_with_mask = True, times = 0, check_pretty = True
-        )
-
-    # Final try: convex combination
-    # Although SDP often presents low-rank solution and perturbation of low-rank solution
-    # is not guaranteed to be positive semidefinite. 
-    # We can take the convex combination of multiple solutions, which yields an interior point
-    # in the feasible set.
-    # An interior point must have rational approximant.
-
-    if not allow_numer:
-        y = np.array(ys).mean(axis = 0)
-
-
-        S_numer = S_from_y(y, x0, space, splits)
-        if all(_.is_positive_definite for _ in S_numer):
-            lcm, times = 1260, 5
-        else:
-            lcm = max(1260, sp.prod(set.union(*[set(sp.primefactors(_.q)) for _ in space])))
-            times = int(10 / sp.log(lcm, 10).n(15) + 3)
-
+        sos.options.max_iterations = max_iters
         if verbose:
-            print('Minimum Eigenvals = %s'%[min(map(lambda x:sp.re(x), _.eigenvals())) for _ in S_numer])
+            print('Retry Early Stop SOS Max Iters = %d' % sos.options.max_iterations)
 
-        decomp = rationalize_and_decompose(y, x0, space, splits,
-            try_rationalize_with_mask = False, lcm = 1260, times = times
-        )
-        if decomp is not None:
-            return decomp
+        try:
+            solution = sos._strategy.execute()
+            return solution # .primals[sos.variables['y']]
+        except Exception as e:
+            if isinstance(e, ZeroDivisionError):
+                if max_iters // 2 >= min_iters and max_iters > 1:
+                    return self._nsolve_with_early_stop(
+                                sos, 
+                                max_iters = max_iters // 2, 
+                                min_iters = min_iters, 
+                                verbose = verbose
+                            )
+            return None
+        return None
 
-    if return_ys:
-        return ys
 
-    if len(ys) > 0 and allow_numer:
-        y = sp.Matrix(ys[0])
-        decomp = rationalize_and_decompose(y, x0, space, splits,
-            try_rationalize_with_mask = False, times = 0, perturb = True, check_pretty = False
+    def _get_defaulted_objectives(self):
+        """Get the default objectives of the SDP problem."""
+        obj_key = 'S_minor' if 'S_minor' in self.sos.variables else 'S_major'
+        objectives = [
+            ('max', self.sos.variables[obj_key].tr),
+            ('min', self.sos.variables[obj_key].tr),
+            ('max', self.sos.variables[obj_key]|1)
+        ]
+        # x = np.random.randn(*sos.variables[obj_key].shape)
+        # objectives.append(('max', lambda sos: sos.variables[obj_key]|x))
+        return objectives
+
+
+    def _nsolve_with_obj(
+            self,
+            objectives: List[Tuple[str, Union[Any, Callable]]],
+            context: Optional[AbstractContextManager] = None
+        ) -> Optional[np.ndarray]:
+        """
+        Numerically solve a SDP problem with multiple objectives.
+        This returns a generator of ndarray.
+
+        Parameters
+        ---------- 
+        objectives : Optional[List[Tuple[str, Union[Any, Callable]]]]
+            Although it suffices to find one feasible solution, we might 
+            use objective to find particular feasible solution that has 
+            good rational approximant. This parameter takes in multiple objectives, 
+            and the solver will try each of the objective. If still no 
+            approximant is found, the final solution will average this 
+            SOS solution and perform rationalization. Note that SDP problem is 
+            convex so the convex combination is always feasible and not on the
+            boundary.
+
+            Example: 
+            ```
+            objectives = [
+                ('max', lambda sos: sos.variables['S_major'].tr),
+                ('max', lambda sos: sos.variables['S_major']|1)
+            ]
+            ```
+
+        Yields
+        ---------
+        y: Optional[np.ndarray]
+            Numerical solution y. Return None if y unfounded.
+        """
+        from picos.modeling.strategy import Strategy
+        sos = self.sos
+
+        if context is None:
+            context = nullcontext()
+        if objectives is None:
+            objectives = self._get_defaulted_objectives()
+
+        with context:
+            for objective in objectives:
+                # try each of the objectives
+                max_or_min, obj = objective
+                if isinstance(obj, Callable):
+                    obj = obj(sos)
+                sos.set_objective(max_or_min, obj)
+
+                sos._strategy = Strategy.from_problem(sos)
+                solution = self._nsolve_with_early_stop(max_iters = 50)
+
+                if solution is not None:
+                    try:
+                        y = np.array(solution.primals[sos.variables['y']])
+                    except KeyError:
+                        raise SDPInfeasibleError("SDP problem numerically infeasible.")
+
+                    self._ys.append(y)
+                    yield y
+
+                # NOTE: PICOS uses an isometric vectorization of symmetric matrices
+                #       (off-diagonal elements are divided by sqrt(2))
+                #       so if we need to convert it back, we had better use its API.
+                # S0 = (SymmetricVectorization((6,6)).devectorize(cvxopt.matrix(list(solution.primals.values())[0])))
+
+                yield None
+
+    def _nsolve_with_rationalization(
+            self,
+            objectives: List[Tuple[str, Union[Any, Callable]]],
+            context: Optional[AbstractContextManager] = None,
+            **kwargs
+        ):
+        for y in self._nsolve_with_obj(objectives, context):
+            if y is not None:
+                ra = self.rationalize(y, **kwargs)
+                if ra is not None:
+                    return ra
+
+    def rationalize(
+            self,
+            y: np.ndarray,
+            try_rationalize_with_mask: bool = True,
+            times: int = 0,
+            check_pretty: bool = True
+        ) ->  Optional[Tuple[sp.Matrix, List[Tuple[sp.Matrix, sp.Matrix, List[sp.Rational]]]]]:
+        decomp = rationalize_and_decompose(y, *self.args,
+            try_rationalize_with_mask=try_rationalize_with_mask, times=times, check_pretty=check_pretty
         )
         return decomp
 
-    if len(ys) > 0 and (not allow_numer) and verbose:
-        print('Failed to find a rational solution despite having a numerical solution. '
-            'Try other multipliers might be useful.')
+    def rationalize_combine(
+            self,
+            ys: List[np.ndarray] = None,
+            verbose: bool = False,
+        ) ->  Optional[Tuple[sp.Matrix, List[Tuple[sp.Matrix, sp.Matrix, List[sp.Rational]]]]]:
+            if ys is None:
+                ys = self._ys
 
-    return None
-
-
-def _sdp_solver_partial_deflation(
-        sos,
-        x0: sp.Matrix,
-        space: sp.Matrix,
-        splits: List[slice],
-        objectives: Optional[List[Tuple[str, Callable]]] = None,
-        deflation_sequence: Optional[List[int]] = None,
-        allow_numer: bool = False,
-        verbose: bool = False,     
-    ):
-    """
-    Solve the SDP problem. See details at `sdp_solver` function.
-    We use the following idea to generate a rational solution:
-    1. Solve SDP with objectives = max(y[-1]) and min(y[-1]).
-    2. Set y[-1] = (max + min) / 2 as a new constraint and solve SDP again.
-    3. Repeat step 2 until the solution is rational.
-
-    Parameters
-    ----------
-    sos : picos.Problem
-        The SDP problem.
-    x0 : sp.Matrix
-        The constant part of the equation. Stands for a particular solution
-        of the space of S.
-    space : sp.Matrix
-        The space of S. Stands for the space constraint of S.
-    splits : List[slice]
-        The splits of the symmetric matrices. Each split is a slice object.
-    objectives : List[Tuple[str, Callable]]
-        IT DOES NOT SUPPORT OBJECTIVES.
-    deflation_sequence : Optional[List[int]]
-        The deflation sequence. If None, we use range(n) where n is the
-        number of variables.
-    allow_numer : bool
-        Whether to allow numerical solution. If True, then the function will return numerical solution
-        if the rational solution does not exist.
-    verbose : bool
-        If True, print the details.
-
-    Returns
-    -------
-    y_rational: sp.Matrix
-        The rational solution of y.
-    decompositions: List[Tuple[sp.Matrix, sp.Matrix, List]]
-        The congruence decomposition of each symmetric matrix S. Each item is a tuple
-        of `(S, U, diag)` where `S = U.T * diag(diag) * U` where `U` is upper triangular
-        and `diag` is a diagonal matrix.
-    """
-    assert not objectives, 'Method "partial deflation" does not support objectives.'
-
-    @contextmanager
-    def restore_constraints(sos):
-        constraints_num = len(sos.constraints)
-        yield
-        for i in range(len(sos.constraints) - 1, constraints_num - 1, -1):
-            sos.remove_constraint(i)
-
-    n = space.shape[1]
-    deflation_sequence = deflation_sequence or range(n)
-
-    with restore_constraints(sos):
-        for i in deflation_sequence:
-            bounds = []
-            objectives = [
-                ('max', lambda sos: sos.variables['y'][i]),
-                ('min', lambda sos: sos.variables['y'][i])
-            ]
-            solution = _sdp_solver(sos, x0, space, splits, objectives = objectives, allow_numer = False, return_ys = True, verbose = verbose)
-
-            if solution is None or isinstance(solution, tuple):
-                return solution
-            elif len(solution) < 2:
-                # not enough solutions
+            if len(ys) == 0:
                 return None
 
-            bounds = [solution[0][i], solution[1][i]]
+            y = np.array(ys).mean(axis = 0)
 
-            # fix == (max + min) / 2
-            fix = (bounds[0] + bounds[1]) / 2
-            eps = (bounds[0] - bounds[1]) / 2
-            if eps <= 1e-7:
-                # this implies bounds[0] == bounds[1]
-                fix = rationalize(fix, reliable = True) if abs(fix) > 1e-7 else 0
-            elif bounds[0] > round(fix) > bounds[1]:
-                fix = round(fix)
+            S_numer = S_from_y(y, *self.args)
+            if all(_.is_positive_definite for _ in S_numer):
+                lcm, times = 1260, 5
             else:
-                fix = rationalize(fix, rounding = eps * .8, reliable = False)
+                lcm = max(1260, sp.prod(set.union(*[set(sp.primefactors(_.q)) for _ in space])))
+                times = int(10 / sp.log(lcm, 10).n(15) + 3)
 
             if verbose:
-                print('Deflate y[%d] = %s Bounds = %s'%(i, fix, bounds))
+                print('Minimum Eigenvals = %s'%[min(map(lambda x:sp.re(x), _.eigenvals())) for _ in S_numer])
 
-            sos.add_constraint(sos.variables['y'][i] == float(fix))
-
-    if allow_numer and len(solution) == 1:
-        y = sp.Matrix(solution[0])
-        decomp = rationalize_and_decompose(y, x0, space, splits,
-            try_rationalize_with_mask = False, times = 0, perturb = True, check_pretty = False
-        )
-        return decomp
-
-    return None
+            decomp = rationalize_and_decompose(y, *self.args,
+                try_rationalize_with_mask = False, lcm = 1260, times = times
+            )
+            return decomp
 
 
-def _sdp_solver_relax(
-        sos,
-        x0: sp.Matrix,
-        space: sp.Matrix,
-        splits: List[slice],
-        objectives: Optional[List[Tuple[str, Callable]]] = None,
-        allow_numer: bool = False,
-        verbose: bool = False,     
-    ):
-    """
-    Solve the SDP problem. See details at `sdp_solver` function.
-    We modify the problem to be a relaxation of the original problem:
-    S - a * I >> 0
-    and optimize max(a).
+    def _solve_trivial(
+            self,
+            objectives: Optional[List[Tuple[str, Callable]]] = None
+        ):
+        return self._nsolve_with_rationalization(objectives)
 
-    Parameters
-    ----------
-    sos : picos.Problem
-        The SDP problem.
-    x0 : sp.Matrix
-        The constant part of the equation. Stands for a particular solution
-        of the space of S.
-    space : sp.Matrix
-        The space of S. Stands for the space constraint of S.
-    splits : List[slice]
-        The splits of the symmetric matrices. Each split is a slice object.
-    objectives : List[Tuple[str, Callable]]
-        IT DOES NOT SUPPORT OBJECTIVES.
-    allow_numer : bool
-        Whether to allow numerical solution. If True, then the function will return numerical solution
-        if the rational solution does not exist.
-    verbose : bool
-        If True, print the details.
 
-    Returns
-    -------
-    y_rational: sp.Matrix
-        The rational solution of y.
-    decompositions: List[Tuple[sp.Matrix, sp.Matrix, List]]
-        The congruence decomposition of each symmetric matrix S. Each item is a tuple
-        of `(S, U, diag)` where `S = U.T * diag(diag) * U` where `U` is upper triangular
-        and `diag` is a diagonal matrix.
-    """
-    assert not objectives, 'Method "relax" does not support objectives.'
+    def _solve_relax(self):
+        import picos
+        from picos.constraints.con_lmi import LMIConstraint
 
-    import picos
-    from picos.constraints.con_lmi import LMIConstraint
+        sos = self.sos
+        obj_key = 'S_minor' if not 'S_major' in sos.variables else 'S_major'
+        lamb = picos.RealVariable('lamb', 1)
+        obj = sos.variables[obj_key]
 
-    obj_key = 'S_minor' if not 'S_major' in sos.variables else 'S_major'
-    lamb = picos.RealVariable('lamb', 1)
-    obj = sos.variables[obj_key]
+        @contextmanager
+        def restore_constraints(sos, obj, lamb):    
+            for i, constraint in enumerate(sos.constraints):
+                if isinstance(constraint, LMIConstraint) and obj in constraint.variables:
+                    # remove obj >> 0
+                    sos.remove_constraint(i)
+                    break
+            sos.add_constraint((obj - lamb * picos.I(obj.shape[0])) >> 0)
+            sos.add_constraint(lamb >= 0)
 
-    @contextmanager
-    def restore_constraints(sos, obj, lamb):    
-        for i, constraint in enumerate(sos.constraints):
-            if isinstance(constraint, LMIConstraint) and obj in constraint.variables:
-                # remove obj >> 0
-                sos.remove_constraint(i)
-                break
-        sos.add_constraint((obj - lamb * picos.I(obj.shape[0])) >> 0)
-        sos.add_constraint(lamb >= 0)
+            yield
+            sos.remove_constraint(-1)
+            sos.remove_constraint(-1)
+            sos.set_objective('max', obj.tr)
 
-        yield
-        sos.remove_constraint(-1)
-        sos.remove_constraint(-1)
-        sos.set_objective('max', obj.tr)
-
-    with restore_constraints(sos, obj, lamb):
         objectives = [('max', lambda sos: sos.variables['lamb'])]
-        solution = _sdp_solver(sos, x0, space, splits, objectives = objectives, allow_numer = allow_numer, verbose = verbose)
-
-    return solution
-
+        context = restore_constraints(sos, obj, lamb)
+        return self._nsolve_with_rationalization(objectives, context)
 
 
-def _check_method(method):
-    """
-    Return the corresponding function of the method.
-    """
-    method = method.lower()
-    METHODS = {
-        'partial deflation': _sdp_solver_partial_deflation,
-        'trivial': _sdp_solver,
-        'relax': _sdp_solver_relax
-    }
-    assert method in METHODS, 'Method %s is not supported. Currently supports %s'%(method, METHODS.keys())
+    def _solve_partial_deflation(
+            self,
+            deflation_sequence: Optional[List[int]] = None,
+            verbose: bool = False
+        ):
+        @contextmanager
+        def restore_constraints(sos):
+            constraints_num = len(sos.constraints)
+            yield
+            for i in range(len(sos.constraints) - 1, constraints_num - 1, -1):
+                sos.remove_constraint(i)
 
-    return METHODS[method]
+        n = self.dof
+        sos = self.sos
+        if deflation_sequence is None:
+            deflation_sequence = range(n)
 
-def sdp_solver(
-        x0: sp.Matrix, 
-        space: sp.Matrix, 
-        splits: List[slice],
-        keys: List[str],
-        method: str = 'partial deflation',
-        reg: float = 0,
-        constraints: Optional[List[Callable]] = None,
-        objectives: Optional[List[Tuple[str, Callable]]] = None,
-        allow_numer: bool = False,
-        verbose: bool = False
-    ):
-    """
-    Solve SDP problem: find feasible y such that
-    `x0[splits[i]] + space[splits[i],:] * y = uppervec(S[i])`
-    with constraint that each `S[i]` is symmetric positive semidefinite.
+        with restore_constraints(sos):
+            for i in deflation_sequence:
+                bounds = []
+                objectives = [
+                    ('max', lambda sos: sos.variables['y'][i]),
+                    ('min', lambda sos: sos.variables['y'][i])
+                ]
+                cnt_ys = len(self._ys)
+                ra = self._nsolve_with_rationalization(objectives, verbose = verbose)
+                cnt_sol = len(self._ys) - cnt_ys
 
-    Parameters
-    ----------
-    x0 : sp.Matrix
-        The constant part of the equation. Stands for a particular solution
-        of the space of S.
-    space : sp.Matrix
-        The space of S. Stands for the space constraint of S.
-    splits : List[slice]
-        Vector `x0 + space * y` is the concatenation of multiple
-        vectors `uppervec(S[i])`. Each `S[i]` is a symmetric matrix.
-        This parameter indicates how to split the vector `x0 + space * y`
-        into multiple vectors.
-    method: str
-        The method to solve the SDP problem. Currently supports:
-        'partial deflation' and 'relax' and 'trivial'
-    keys: List[str]
-        Represent the name of each symmetric matrix `S[i]`. Should match
-        the length of splits.
-    reg : float
-        We require `S[i]` to be positive semidefinite, but in practice
-        we might want to add a small regularization term to make it
-        positive definite >> reg * I.
-    constraints : Optional[List[Callable]]
-        Extra constraints of the SDP problem. This is not called when the problem is degenerated
-        (when the degree of freedom is zero).
+                if cnt_sol == 0 or isinstance(ra, tuple):
+                    return ra
+                elif cnt_sol < 2:
+                    # not enough solutions
+                    return None
 
-        Example:
-        ```
-        constraints = [
-            lambda sos: sos.variables['y'][0] == 0,
-        ]
-        ```
-    objectives : Optional[List[Tuple[str, Callable]]]
-        Although it suffices to find one feasible solution, we might 
-        use objective to find particular feasible solution that has 
-        good rational approximant. This parameter takes in multiple objectives, 
-        and the solver will try each of the objective. If still no 
-        approximant is found, the final solution will average this 
-        SOS solution and perform rationalization. Note that SDP problem is 
-        convex so the convex combination is always feasible and not on the
-        boundary.
+                bounds = [self._ys[-2][i], self._ys[-1][i]]
 
-        Example: 
-        ```
-        objectives = [
-            ('max', lambda sos: sos.variables['S_major'].tr),
-            ('max', lambda sos: sos.variables['S_major']|1)
-        ]
-        ```
-    allow_numer : bool
-        Whether to allow numerical solution. If True, then the function will return numerical solution
-        if the rational solution does not exist.
+                # fix == (max + min) / 2
+                fix = (bounds[0] + bounds[1]) / 2
+                eps = (bounds[0] - bounds[1]) / 2
+                if eps <= 1e-7:
+                    # this implies bounds[0] == bounds[1]
+                    fix = rationalize(fix, reliable = True) if abs(fix) > 1e-7 else 0
+                elif bounds[0] > round(fix) > bounds[1]:
+                    fix = round(fix)
+                else:
+                    fix = rationalize(fix, rounding = eps * .8, reliable = False)
 
-    Returns
-    -------
-    Returns a dict if the problem is solved, otherwise return None.
-    The dict contains the following keys:
-        sos : picos.Problem
-            The SDP problem.
-        y : sp.Matrix
-            The rational solution of y.
-        S : Dict[str, sp.Matrix]
-            The solution of each symmetric matrix S.
-        decompositions : Dict[str, Tuple[sp.Matrix, List[sp.Rational]]]
-            The congruence decomposition of each symmetric matrix S. Each item is a tuple.
-    """
-    if not isinstance(keys, list):
-        keys = list(keys) # avoid troubles of iterator
-
-    if verbose:
-        print('Degree of freedom: %d'%space.shape[1])
-
-    if space.shape[1] > 0:
-        sos, y = _sdp_constructor(x0, space, splits, keys, reg = reg, constraints = constraints)
-
-        func = _check_method(method)
-        if _check_picos(verbose = verbose):
-            try:
-                solution = func(sos, x0, space, splits, objectives = objectives, allow_numer = allow_numer, verbose = verbose)
-            except KeyError:
-                # This implies that the SDP problem is infeasible (even solved numerically).
                 if verbose:
-                    print('Cannot find numerical solution for y.')
-                solution = None
-    else:
-        sos = None
-        solution = _degenerated_solver(x0, space, splits, verbose = verbose)
+                    print('Deflate y[%d] = %s Bounds = %s'%(i, fix, bounds))
 
-    if solution is not None:
-        solution = {
-            'y': solution[0],
-            'S': dict((key, S[0]) for key, S in zip(keys, solution[1])),
-            'decompositions': dict((key, S[1:]) for key, S in zip(keys, solution[1]))
-        }
-
-    return SDPResult(sos, solution)
+                sos.add_constraint(sos.variables['y'][i] == float(fix))
 
 
-def _degenerated_solver(
-        x0: sp.Matrix,
-        space: sp.Matrix,
-        splits: List[slice],
-        verbose: bool = True
+    def _solve_degenerated(self):
+        if self.dof == 0:
+            decomp = rationalize_and_decompose(
+                sp.Matrix([]).reshape(0,1), *self.args,
+                check_pretty = False
+            )
+            return decomp
+
+
+    def _solve_wrapped(
+        self,
+        method: str = 'partial deflation',
+        allow_numer: bool = False,
+        verbose: bool = False,
+        **kwargs
     ):
-    """
-    When there is zero degree of freedom, the space degenerates to matrix with shape[1] == 0.
-    Then the unique solution is presented by x0.
+        method = method.lower()
+        if method == 'trivial':
+            ra = self._solve_trivial(**kwargs)
+        elif method == 'relax':
+            ra = self._solve_relax(**kwargs)
+        elif method == 'partial deflation':
+            ra = self._solve_partial_deflation(verbose=verbose, **kwargs)
+        else:
+            raise ValueError("Method %s is not supported."%method)
 
-    The function will construct S from x0.
-    """
-    y = x0
+        if ra is not None:
+            return ra
 
-    decomp = rationalize_and_decompose(
-        sp.Matrix([]).reshape(0,1), x0, space, splits,
-        check_pretty = False
-    )
-    return decomp
+
+        ra = self.rationalize_combine(verbose = verbose)
+        if ra is not None:
+            return ra
+
+        if len(self._ys) > 0:
+            if allow_numer:
+                y = sp.Matrix(self._ys[-1])
+                decomp = rationalize_and_decompose(y, *self.args,
+                    try_rationalize_with_mask = False, times = 0, perturb = True, check_pretty = False
+                )
+                return decomp
+            else:
+                raise SDPRationalizeError(
+                    "Failed to find a rational solution despite having a numerical solution."
+                )
+
+        return None
+
+    def solve(
+            self,
+            method: str = 'partial deflation',
+            allow_numer: bool = False,
+            verbose: bool = False,
+            **kwargs
+        ) -> SDPResult:
+
+        if self.dof == 0:
+            solution = self._solve_degenerated()
+        elif self._has_picos:
+            solution = self._solve_wrapped(method = method, allow_numer = allow_numer, verbose = verbose, **kwargs)
+
+        if solution is not None:
+            solution = {
+                'y': solution[0],
+                'S': dict((key, S[0]) for key, S in zip(self.keys, solution[1])),
+                'decompositions': dict((key, S[1:]) for key, S in zip(self.keys, solution[1]))
+            }
+            self.y = solution['y']
+            self.S = solution['S']
+        return SDPResult(self.sos, solution)

--- a/src/core/sdpsos/solver.py
+++ b/src/core/sdpsos/solver.py
@@ -524,7 +524,7 @@ class SDPProblem():
             self,
             y: np.ndarray,
             try_rationalize_with_mask: bool = True,
-            times: int = 0,
+            times: int = 1,
             check_pretty: bool = True
         ) -> Optional[Tuple[sp.Matrix, Decomp]]:
         """

--- a/src/core/sdpsos/solver.py
+++ b/src/core/sdpsos/solver.py
@@ -705,8 +705,10 @@ class SDPProblem():
             verbose: bool = False
         ) -> Optional[Tuple[sp.Matrix, Decomp]]:
         """
-        Solve SDP by fixing some of the entry of the variable
-        until a rational solution is found.
+        We use the following idea to generate a rational solution:
+        1. Solve SDP with objectives = max(y[-1]) and min(y[-1]).
+        2. Set y[-1] = (max + min) / 2 as a new constraint and solve SDP again.
+        3. Repeat step 2 until the solution is rational.
         """
         @contextmanager
         def restore_constraints(sos):

--- a/src/core/sdpsos/solver.py
+++ b/src/core/sdpsos/solver.py
@@ -875,6 +875,8 @@ class SDPProblem():
         elif self._has_picos:
             self._construct_sos()
             solution = self._solve_wrapped(method = method, allow_numer = allow_numer, verbose = verbose, **kwargs)
+        else:
+            solution = None
 
         if solution is not None:
             solution = {

--- a/src/core/sdpsos/utils.py
+++ b/src/core/sdpsos/utils.py
@@ -7,7 +7,10 @@ import sympy as sp
 from ...utils import congruence
 
 
-def congruence_with_perturbation(M: sp.Matrix, perturb: bool = False):
+def congruence_with_perturbation(
+        M: sp.Matrix,
+        perturb: bool = False
+    ) -> Optional[Tuple[sp.Matrix, sp.Matrix]]:
     """
     Perform congruence decomposition on M. This is a wrapper of congruence.
     Write it as M = U.T @ S @ U where U is upper triangular and S is a diagonal matrix.

--- a/src/core/symsos/univariate.py
+++ b/src/core/symsos/univariate.py
@@ -399,7 +399,7 @@ def _reduce_sos(
     ret = _create_sos_from_US(*congruence(M), x = x, return_raw = True)
 
     def _remove_zeros(p):
-        if not any(_ != 0 for _ in p[0]):
+        if not any(_ == 0 for _ in p[0]):
             return p
         coeffs, polys = p
         new_coeffs = []


### PR DESCRIPTION
* SDPProblem renamed to SOSProblem.
* Add a new SDPProblem class to handle rational sum of square. It accepts symbolic matrices as input.
Example:
```
  sdp = SDPProblem.from_matrix(
      {'S_0': sp.Matrix([[-1+a,2-a],[2-a,1]])}
  )
  sdp.solve()
  sdp.as_params()
```
And it returns `{a: 3}`.
* Remove previous sdp_solver, _sdp_solver, ... functions. (Please use SDPProblem instead now).
* Now cases of infeasiblity, rationalization error, .... are raised as errors.
* Add an experimental ipm.py for further use. It supports SDP with arbitrary precision using mpmath.