### PR TITLE
Optim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ __pycache__/
 *.ipynb
 *.csv
 *.zip
+.vscode/
 test_cyclic.py

--- a/static/js/visualization.js
+++ b/static/js/visualization.js
@@ -38,13 +38,21 @@ function renderVisualization(data){
 
     if (_3d_vis.in3d){
         // VIEW2DPARENT.hidden = true;
-        _3d_vis.tetrahedron.visible = true;
-        _3d_vis.pointCloud.visible = true;
+        if (_3d_vis.tetrav.length){
+            _3d_vis.tetrahedron.visible = true;
+            _3d_vis.pointCloud.visible = true;
+        }else{
+            _3d_vis.tetrahedron.style.display = 'block';
+        }
         renderHeatmap3D(data.heatmap);
     }else{
         // VIEW2DPARENT.hidden = false;
-        _3d_vis.tetrahedron.visible = false;
-        _3d_vis.pointCloud.visible = false;
+        if (_3d_vis.tetrav.length){
+            _3d_vis.tetrahedron.visible = false;
+            _3d_vis.pointCloud.visible = false;
+        }else{
+            _3d_vis.tetrahedron.style.display = 'none';
+        }
         renderHeatmap(data.heatmap);
     }
     // _3d_vis.controls.enableDamping = _3d_vis.in3d;
@@ -315,7 +323,7 @@ function init3DVisualization(){// Get the div element
         renderer.render(scene, camera);
     }
     animate();
-    
+
 }
 
 function _initDashlinesPlugin(){
@@ -424,11 +432,6 @@ function _init3DHeatmap(){
         pointCloud.material.needsUpdate = true;
     }
 }
-
-init3DVisualization();
-
-
-
 
 
 function updateTextPositions() {
@@ -546,4 +549,52 @@ function renderHeatmap3D(heatmap){
         color.setXYZ(i, heatValue[0]/255, heatValue[1]/255, heatValue[2]/255);
     });
     color.needsUpdate = true;
+}
+
+
+
+function _init3DWebGLCheck(){
+    const canvas = document.createElement('canvas');
+    const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl') || canvas.getContext('webgl2');
+    if (!gl) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
+function _init3DVisualizationFallback(){
+    // When WebGL is not supported
+    const coeffs_view = VIEW3DPARENT;
+    _3d_vis.scene = {};
+    _3d_vis.camera = {};
+    _3d_vis.renderer = {};
+    _3d_vis.controls = {};
+    _3d_vis.raycaster = {};
+    _3d_vis.tetrahedron = coeffs_view.appendChild(document.createElement('div'));
+    _3d_vis.tetrahedron.innerHTML = 
+        'WebGL is not supported in your browser.<br>' +
+        'Please visit <a href="https://get.webgl.org/" target="_blank">https://get.webgl.org/</a> for more information.';
+    _3d_vis.tetrahedron.style.color = 'black';
+    _3d_vis.tetrahedron.style.position = 'absolute';
+    _3d_vis.tetrahedron.style.top = '15px';
+    _3d_vis.tetrahedron.style.left = '15px';
+    _3d_vis.tetrahedron.style.display = 'none';
+    _3d_vis.positions = [];
+    // _3d_vis.frustum = frustum;
+    _3d_vis.pointCloud = {};
+    _3d_vis.dashlines = null;
+    _3d_vis.cameraViewProjectionMatrix = {};
+    _3d_vis.tetrav = [];
+}
+
+if (_init3DWebGLCheck()){
+    init3DVisualization();
+}else{
+    _init3DVisualizationFallback();
+    updateTextPositions = () => {};
+    renderCoeffs3D = () => {_3d_vis.in3d = true;};
+    renderHeatmap3D = () => {renderHeatmap(null);};
+    console.warn('WebGL is not supported in your browser.\nPlease visit https://get.webgl.org/ for more information.');
+    console.log('WebGL is not supported in your browser.\nPlease visit https://get.webgl.org/ for more information.');
 }

--- a/triples/core/linsos/linsos.py
+++ b/triples/core/linsos/linsos.py
@@ -9,7 +9,7 @@ from sympy import Poly, Expr, Symbol
 from sympy.core.singleton import S
 from sympy.combinatorics import PermutationGroup
 from scipy.optimize import linprog
-from scipy import __version__ as SCIPY_VERSION
+from scipy import __version__ as _SCIPY_VERSION
 
 from .basis import LinearBasis, LinearBasisTangent, LinearBasisTangentEven
 from .tangents import root_tangents
@@ -20,8 +20,26 @@ from ..shared import homogenize_expr_list, clear_polys_by_symmetry, sanitize_inp
 from ...utils import findroot, RootsInfo, RootTangent
 from ...utils.monomials import MonomialManager
 
+
+def _is_version_greater_than(v1, v2) -> bool:
+    """Version comparison. No dependencies on distutils
+    (which has been deprecated since Python 3.10)."""
+    def _version(s):
+        from re import findall
+        parts = []
+        for comp in s.split('.'):
+            for elem in findall(r'\d+|\D+', comp):
+                parts.append(int(elem) if elem.isdigit() else elem)
+        return tuple(parts)
+    for i, j in zip(_version(v1), _version(v2)):
+        if isinstance(i, str) or isinstance(j, str): i, j = str(i), str(j)
+        if i > j: return True
+        if i < j: return False
+    return bool(len(_version(v1)) >= len(_version(v2)))
+
+
 LINPROG_OPTIONS = {
-    'method': 'highs-ds' if SCIPY_VERSION >= '1.6.0' else 'simplex',
+    'method': 'highs-ds' if _is_version_greater_than(_SCIPY_VERSION, '1.6') else 'simplex',
     'options': {
         'presolve': False,
     }

--- a/triples/sdp/arithmetic.py
+++ b/triples/sdp/arithmetic.py
@@ -652,7 +652,8 @@ def matmul(A: sp.Matrix, B: sp.Matrix, return_shape = None) -> sp.Matrix:
         Shape of the result. If not specified, it will be inferred.
     """
     if A.shape[0] == 0 or B.shape[0] == 0 or B.shape[1] == 0:
-        return sp.zeros(A.shape[0], B.shape[1])
+        return_shape = return_shape or (A.shape[0], B.shape[1])
+        return sp.zeros(*return_shape)
     A0, B0 = A, B
 
     def default(A0, B0):

--- a/triples/sdp/arithmetic.py
+++ b/triples/sdp/arithmetic.py
@@ -14,18 +14,34 @@ from math import gcd
 from time import time
 from typing import List, Tuple, Union, Optional
 
-from numpy import array as np_array
-from numpy import around as np_round
-from numpy import iinfo as np_iinfo
+from numpy import array as np_array, around as np_round, zeros as np_zeros, iinfo as np_iinfo
 from numpy import isnan, inf, unique
 import sympy as sp
+from sympy import __version__ as _SYMPY_VERSION
 from sympy import Rational
-from sympy.external.gmpy import MPQ
+from sympy.external.gmpy import MPQ # >= 1.9
+from sympy.matrices.repmatrix import RepMatrix
+from sympy.polys.domains import ZZ, QQ, EX, EXRAW # EXRAW >= 1.9
+from sympy.polys.matrices.domainmatrix import DomainMatrix # polys.matrices >= 1.8
+from sympy.polys.matrices.ddm import DDM
+from sympy.polys.matrices.sdm import SDM
+
+if _SYMPY_VERSION >= '1.13':
+    from sympy.polys.matrices.dfm import DFM
+else:
+    class _DFM_dummy: ...
+    DFM = _DFM_dummy
 
 from .utils import Mat2Vec, is_empty_matrix
 
 _INT32_MAX = np_iinfo('int32').max # 2147483647
 _INT64_MAX = np_iinfo('int64').max # 9223372036854775807
+
+# for dev purpose only
+_VERBOSE_MATMUL_MULTIPLE = False
+_VERBOSE_SOLVE_UNDETERMINED_LINEAR = False
+_VERBOSE_SOLVE_CSR_LINEAR = False
+
 
 def _lcm(x, y):
     """
@@ -33,6 +49,12 @@ def _lcm(x, y):
     WHEN CONVERTING TO SYMPY INTEGERS.
     """
     return x * y // gcd(x, y)
+
+def is_zz_qq_mat(mat):
+    """
+    Judge whether a matrix is a ZZ/QQ RepMatrix.
+    """
+    return isinstance(mat, RepMatrix) and mat._rep.domain in (ZZ, QQ)
 
 def _find_reasonable_pivot_naive(col):
     """
@@ -121,33 +143,282 @@ def _row_reduce_list(mat, rows, cols, normalize_last=True, normalize=True, zero_
 
     return mat, tuple(pivot_cols), tuple(swaps)
 
+
+def sdm_rref_den(A, K):
+    """
+    Return the reduced row echelon form (RREF) of A with denominator.
+    The RREF is computed using fraction-free Gauss-Jordan elimination.
+
+    The algorithm used is the fraction-free version of Gauss-Jordan elimination
+    described as FFGJ. Here it is modified to handle zero or missing
+    pivots and to avoid redundant arithmetic. This implementation is also
+    optimized for sparse matrices. See also sympy.polys.matrices.sdm (version >= 1.13).
+    """
+    if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
+        time0 = time()
+    if not A:
+        return ({}, K.one, [])
+    elif len(A) == 1:
+        Ai, = A.values()
+        j = min(Ai)
+        Aij = Ai[j]
+        return ({0: Ai.copy()}, Aij, [j])
+
+    # For inexact domains like RR[x] we use quo and discard the remainder.
+    # Maybe it would be better for K.exquo to do this automatically.
+    if K.is_Exact:
+        exquo = K.exquo
+    else:
+        exquo = K.quo
+
+    # Make sure we have the rows in order to make this deterministic from the
+    # outset.
+    _, rows_in_order = zip(*sorted(A.items()))
+
+    col_to_row_reduced = {}
+    col_to_row_unreduced = {}
+    reduced = col_to_row_reduced.keys()
+    unreduced = col_to_row_unreduced.keys()
+
+    # Our representation of the RREF so far.
+    A_rref_rows = []
+    denom = None
+    divisor = None
+
+    # The rows that remain to be added to the RREF. These are sorted by the
+    # column index of their leading entry. Note that sorted() is stable so the
+    # previous sort by unique row index is still needed to make this
+    # deterministic (there may be multiple rows with the same leading column).
+    A_rows = sorted(rows_in_order, key=min)
+
+    for Ai in A_rows:
+
+        # All fully reduced columns can be immediately discarded.
+        Ai = {j: Aij for j, Aij in Ai.items() if j not in reduced}
+        Ai_cancel = {}
+
+        for j in unreduced & Ai.keys():
+            # Remove the pivot column from the new row since it would become
+            # zero anyway.
+            Aij = Ai.pop(j)
+
+            Aj = A_rref_rows[col_to_row_unreduced[j]]
+
+            for k, Ajk in Aj.items():
+                Aik_cancel = Ai_cancel.get(k)
+                if Aik_cancel is None:
+                    Ai_cancel[k] = Aij * Ajk
+                else:
+                    Aik_cancel = Aik_cancel + Aij * Ajk
+                    if Aik_cancel:
+                        Ai_cancel[k] = Aik_cancel
+                    else:
+                        Ai_cancel.pop(k)
+
+        # Multiply the new row by the current denominator and subtract.
+        Ai_nz = set(Ai)
+        Ai_cancel_nz = set(Ai_cancel)
+
+        d = denom or K.one
+
+        for k in Ai_cancel_nz - Ai_nz:
+            Ai[k] = -Ai_cancel[k]
+
+        for k in Ai_nz - Ai_cancel_nz:
+            Ai[k] = Ai[k] * d
+
+        for k in Ai_cancel_nz & Ai_nz:
+            Aik = Ai[k] * d - Ai_cancel[k]
+            if Aik:
+                Ai[k] = Aik
+            else:
+                Ai.pop(k)
+
+        # Now Ai has the same scale as the other rows and is reduced wrt the
+        # unreduced rows.
+
+        # If the row is reduced to zero then discard it.
+        if not Ai:
+            continue
+
+        # Choose a pivot for this row.
+        j = min(Ai)
+        Aij = Ai.pop(j)
+
+        # Cross cancel the unreduced rows by the new row.
+        #     a[k][l] = (a[i][j]*a[k][l] - a[k][j]*a[i][l]) / divisor
+        for pk, k in list(col_to_row_unreduced.items()):
+
+            Ak = A_rref_rows[k]
+
+            if j not in Ak:
+                # This row is already reduced wrt the new row but we need to
+                # bring it to the same scale as the new denominator. This step
+                # is not needed in sdm_irref.
+                for l, Akl in Ak.items():
+                    Akl = Akl * Aij
+                    if divisor is not None:
+                        Akl = exquo(Akl, divisor)
+                    Ak[l] = Akl
+                continue
+
+            Akj = Ak.pop(j)
+            Ai_nz = set(Ai)
+            Ak_nz = set(Ak)
+
+            for l in Ai_nz - Ak_nz:
+                Ak[l] = - Akj * Ai[l]
+                if divisor is not None:
+                    Ak[l] = exquo(Ak[l], divisor)
+
+            # This loop also not needed in sdm_irref.
+            for l in Ak_nz - Ai_nz:
+                Ak[l] = Aij * Ak[l]
+                if divisor is not None:
+                    Ak[l] = exquo(Ak[l], divisor)
+
+            for l in Ai_nz & Ak_nz:
+                Akl = Aij * Ak[l] - Akj * Ai[l]
+                if Akl:
+                    if divisor is not None:
+                        Akl = exquo(Akl, divisor)
+                    Ak[l] = Akl
+                else:
+                    Ak.pop(l)
+
+            if not Ak:
+                col_to_row_unreduced.pop(pk)
+                col_to_row_reduced[pk] = k
+
+        i = len(A_rref_rows)
+        A_rref_rows.append(Ai)
+        if Ai:
+            col_to_row_unreduced[j] = i
+        else:
+            col_to_row_reduced[j] = i
+
+        # Update the denominator.
+        if not K.is_one(Aij):
+            if denom is None:
+                denom = Aij
+            else:
+                denom *= Aij
+
+        if divisor is not None:
+            denom = exquo(denom, divisor)
+
+        # Update the divisor.
+        divisor = denom
+
+    if denom is None:
+        denom = K.one
+
+    # Sort the rows by their leading column index.
+    col_to_row = {**col_to_row_reduced, **col_to_row_unreduced}
+    row_to_col = {i: j for j, i in col_to_row.items()}
+    A_rref_rows_col = [(row_to_col[i], Ai) for i, Ai in enumerate(A_rref_rows)]
+    pivots, A_rref = zip(*sorted(A_rref_rows_col))
+    pivots = list(pivots)
+
+    # Insert the pivot values
+    for i, Ai in enumerate(A_rref):
+        Ai[pivots[i]] = denom
+
+    A_rref_sdm = dict(enumerate(A_rref))
+
+    if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
+        print(">> Time for sdm_rref_den:", time() - time0)
+    return A_rref_sdm, denom, pivots
+
+
 def _row_reduce(M, normalize_last=True,
                 normalize=True, zero_above=True):
     """
     See also in sympy.matrices.reductions._row_reduce
     It converts sympy Rational matrix to MPQ without checking.
+
+    M should be a RepMatrix with domain ZZ or QQ.
     """
+    if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
+        time0 = time()
+
     M_frac_list = [MPQ.__new__(MPQ, x.p, x.q) for x in M]
+
+    if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
+        print(">> Time for converting to MPQ:", time() - time0)
+        time0 = time()
 
     mat, pivot_cols, swaps = _row_reduce_list(M_frac_list, M.rows, M.cols,
             normalize_last=normalize_last, normalize=normalize, zero_above=zero_above)
+
+    if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
+        print(">> Time for row reduce list:", time() - time0)
+        time0 = time()
 
     mat = [Rational(x.numerator, x.denominator, gcd = 1) for x in mat]
 
     return sp.Matrix(M.rows, M.cols, mat), pivot_cols, swaps
 
+
 def _rref(M, pivots=True, normalize_last=True):
     """
     See also in sympy.matrices.reductions.rref
     """
-    if not all(_.is_Rational for _ in M):
+    if not is_zz_qq_mat(M):
         return M.rref(pivots=pivots, normalize_last=normalize_last)
 
-    mat, pivot_cols, _ = _row_reduce(M, normalize_last=normalize_last, normalize=True, zero_above=True)
+    sdm = M._rep.to_sdm()
+    K = sdm.domain
+
+    sdm_rref_dict, den, pivots = sdm_rref_den(sdm, K)
+    sdm_rref = sdm.new(sdm_rref_dict, sdm.shape, sdm.domain)
+    dM = DomainMatrix.from_rep(sdm_rref)
+    if den != K.one:
+        dM = dM.to_field()
+        dM = dM / den
+
+    mat = M.__class__._fromrep(dM)
+    # dM_rref = M.new(dM_rref, M.shape, M.domain)
+    # mat = 
+    # if pivots:
+    #     return dM_rref, pivots
+    # return dM_rref
+    # mat, pivot_cols, _ = _row_reduce(M, normalize_last=normalize_last, normalize=True, zero_above=True)
 
     if pivots:
-        mat = (mat, pivot_cols)
+        mat = (mat, pivots)
     return mat
+
+def _permute_matrix_rows(matrix, permutation):
+    rep = matrix._rep.rep if isinstance(matrix, RepMatrix) else None
+
+    if isinstance(rep, SDM):
+        new_rep = {}
+        for orig_row, cols_dict in rep.items():
+            new_rep[permutation[orig_row]] = cols_dict #.copy()
+        new_rep = SDM(new_rep, rep.shape, rep.domain)
+        return matrix.__class__._fromrep(DomainMatrix.from_rep(new_rep))
+
+    elif isinstance(rep, DDM):
+        new_rep = [None for _ in range(rep.shape[0])]
+        for orig_row in range(rep.shape[0]):
+            new_rep[permutation[orig_row]] = rep[orig_row]#[:]
+        new_rep = DDM(new_rep, rep.shape, rep.domain)
+        return matrix.__class__._fromrep(DomainMatrix.from_rep(new_rep))
+
+    elif isinstance(rep, DFM):
+        new_rep = [None for _ in range(rep.shape[0])]
+        rep2 = rep.rep.tolist()
+        for orig_row in range(rep.shape[0]):
+            new_rep[permutation[orig_row]] = rep2[orig_row]
+        new_rep = DFM(new_rep, rep.shape, rep.domain)
+        return matrix.__class__._fromrep(DomainMatrix.from_rep(new_rep))
+
+    # else:
+    new_mat = matrix.copy()
+    for orig_row in range(matrix.shape[0]):
+        new_mat[permutation[orig_row], :] = matrix[orig_row, :]
+    return new_mat
 
 
 def solve_undetermined_linear(M: sp.Matrix, B: sp.Matrix) -> Tuple[sp.Matrix, sp.Matrix]:
@@ -166,13 +437,19 @@ def solve_undetermined_linear(M: sp.Matrix, B: sp.Matrix) -> Tuple[sp.Matrix, sp
     B_cols   = B.cols
     row, col = aug[:, :-B_cols].shape
 
-    # time0 = time()
+    if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
+        sparsity = lambda x: len(list(x.iter_values())) / (x.shape[0] * x.shape[1])
+        print('SolveUndeterminedLinear', M.shape)
+        print('>> Sparsity M =', sparsity(M))
+        time0 = time()
 
     # solve by reduced row echelon form
     A, pivots = _rref(aug, normalize_last = False)
 
-    # print("Time for rref: ", time() - time0, 'Shape =', M.shape)
-    # time0 = time()
+    
+    if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
+        print(">> Time for rref:", time() - time0) # main bottleneck
+        time0 = time()
 
     A, v      = A[:, :-B_cols], A[:, -B_cols:]
     pivots    = list(filter(lambda p: p < col, pivots))
@@ -183,7 +460,7 @@ def solve_undetermined_linear(M: sp.Matrix, B: sp.Matrix) -> Tuple[sp.Matrix, sp
     free_var_index = [c for c in range(A.cols) if c not in pivots]
 
     # Bring to block form
-    permutation = sp.Matrix(pivots + free_var_index).T
+    permutation = pivots + free_var_index
 
     # check for existence of solutions
     # rank of aug Matrix should be equal to rank of coefficient matrix
@@ -197,13 +474,17 @@ def solve_undetermined_linear(M: sp.Matrix, B: sp.Matrix) -> Tuple[sp.Matrix, sp
     vt       = vt.col_join(sp.zeros(V.cols, vt.cols))
 
     # Undo permutation
-    V2       = sp.zeros(*V.shape)
-    vt2      = sp.zeros(*vt.shape)
-    for k in range(col):
-        V2[permutation[k], :] = V[k, :]
-        vt2[permutation[k]] = vt[k]
+    V2 = _permute_matrix_rows(V, permutation)
+    vt2 = _permute_matrix_rows(vt, permutation)
+    # V2       = sp.zeros(V.shape[0], V.shape[1])
+    # vt2      = sp.zeros(vt.shape[0], vt.shape[1])
+    # for k in range(col):
+    #     V2[permutation[k], :] = V[k, :]
+    #     vt2[permutation[k]] = vt[k]
 
-    # print("Time for solving: ", time() - time0)
+    if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
+        print(">> Time for undo permutation:", time() - time0,
+              'V2, vt2 shape =', V2.shape, vt2.shape)
 
     return vt2, V2
 
@@ -224,7 +505,8 @@ def solve_nullspace(A: sp.Matrix) -> sp.Matrix:
 
 
 
-def solve_column_separated_linear(A: List[List[Tuple[int, Rational]]], b: sp.Matrix, x0_equal_indices: List[List[int]] = [], _cols: int = -1):
+def solve_column_separated_linear(A: List[List[Tuple[int, Rational]]], b: sp.Matrix, x0_equal_indices: List[List[int]] = [],
+                                  _cols: int = -1, domain = None):
     """
     This is a function that solves a special linear system Ax = b => x = x_0 + C * y
     where each column of A has at most 1 nonzero element. For more general cases, use solve_csr_linear.
@@ -253,6 +535,16 @@ def solve_column_separated_linear(A: List[List[Tuple[int, Rational]]], b: sp.Mat
     # count the number of columns of A
     cols = _cols if _cols != -1 else (max(max(k[0] for k in row) for row in A) + 1)
 
+    if not isinstance(b, RepMatrix):
+        domain = EXRAW
+    elif domain is None:
+        domain = QQ # EXRAW
+    else:
+        domain = domain.unify(b._rep.domain).get_field()
+
+    if _VERBOSE_SOLVE_CSR_LINEAR:
+        time0 = time()
+
     # form the equal indices as a UFS
     ufs = list(range(cols))
     groups = {}
@@ -266,17 +558,28 @@ def solve_column_separated_linear(A: List[List[Tuple[int, Rational]]], b: sp.Mat
             if group is None:
                 groups[i] = [i]
 
-    x0 = [0] * cols
+    if _VERBOSE_SOLVE_CSR_LINEAR:
+        print('>> UFS construction time', time() - time0) # 0 sec, can be ignored
+        time0 = time()
+
+    toK = domain.from_sympy
+    one, zero = domain.one, domain.zero
+    b = b._rep.convert_to(domain).to_sdm() # DomainMatrix
+
+    x0 = []
     spaces = []
     for i, row in enumerate(A):
         if len(row):
             pivot = row[0]
             head = ufs[pivot[0]]
             group = groups[head]
-            w = len(group) * pivot[1]
-            v = b[i] / w
-            for k in group:
-                x0[k] = v
+            w = len(group) * toK(pivot[1])
+            bi = b.get(i, 0)
+            if bi:
+                bi = bi.get(0, zero)
+                v = bi / w
+                for k in group:
+                    x0.append((k, {0: v}))
 
             for j in range(1, len(row)):
                 pivot2 = row[j]
@@ -285,29 +588,47 @@ def solve_column_separated_linear(A: List[List[Tuple[int, Rational]]], b: sp.Mat
                     continue
                 # only handle the case that pivot is the head of the group
                 group2 = groups[head2]
-                w2 = len(group2) * pivot2[1]
+                w2 = len(group2) * toK(pivot2[1])
 
-                space = [0] * cols
-                for k in group:
-                    space[k] = w2
-                for k in group2:
-                    space[k] = -w
+                space = {}
+                if w2:
+                    for k in group:
+                        space[k] = w2
+                if w:
+                    for k in group2:
+                        space[k] = -w
                 spaces.append(space)
 
         else:
-            if b[i] != 0:
+            bi = b.get(i, 0)
+            print('bi', bi, bi.get(0, zero), zero)
+            if bi != 0 and bi.get(0, zero) != zero:
                 raise ValueError("Linear system has no solution")
 
             for j in range(len(row)):
                 if ufs[row[j][0]] == row[j][0]:
                     group = groups[row[j][0]]
 
-                    space = [0] * cols
+                    space = {}
                     for k in group:
-                        space[k] = 1
+                        space[k] = one
                     spaces.append(space)
 
-    return sp.Matrix(x0), sp.Matrix(spaces).T
+    x0 = dict(x0)
+    spaces = dict(enumerate(spaces))
+    if _VERBOSE_SOLVE_CSR_LINEAR:
+        print('>> Solve separated system time:', time() - time0) # fast, < 1 sec over (100 x 10000)
+        time0 = time()
+
+    to_mat = lambda x, shape: sp.Matrix._fromrep(DomainMatrix.from_rep(SDM(x, shape, domain)))
+    # x0, space = sp.Matrix(x0), sp.Matrix(spaces).T
+    x0 = to_mat(x0, (cols, 1))
+    spaces = to_mat(spaces, (len(spaces), cols)).T
+
+    if _VERBOSE_SOLVE_CSR_LINEAR:
+        print('>> Matrix restoration time:', time() - time0, 'space shape =', spaces.shape)
+
+    return x0, spaces
 
 
 def solve_csr_linear(A: List[List[Tuple[int, Rational]]], b: sp.Matrix, x0_equal_indices: List[List[int]] = [], _cols: int = -1):
@@ -336,6 +657,9 @@ def solve_csr_linear(A: List[List[Tuple[int, Rational]]], b: sp.Matrix, x0_equal
         All solution x is in the form of x0 + space @ y.
     """
     cols = _cols if _cols != -1 else (max(max(k[0] for k in row) for row in A) + 1)
+    if _VERBOSE_SOLVE_CSR_LINEAR:
+        print('SolveCsrLinear A shape', (len(A), cols))
+        time0 = time()
 
     # check whether there is at most one nonzero element in each column
     _column_separated = True
@@ -350,6 +674,8 @@ def solve_csr_linear(A: List[List[Tuple[int, Rational]]], b: sp.Matrix, x0_equal
             break
 
     if _column_separated:
+        if _VERBOSE_SOLVE_CSR_LINEAR:
+            print('>> Column Separated System recognized', time() - time0)
         return solve_column_separated_linear(A, b, x0_equal_indices, _cols=cols)
 
     # convert to dense matrix
@@ -394,6 +720,16 @@ def _common_denoms(A: Union[List, sp.Matrix], bound: int = 4096) -> Optional[int
     Compute the common denominator of a list of rational numbers.
     This might be slow when the list is large. (e.g. 30000 entries -> 0.2 sec)
     """
+    if isinstance(A, RepMatrix):
+        rep = A._rep
+        if rep.domain is ZZ:
+            return 1
+        elif rep.domain is QQ:
+            return int(rep.content().denominator)
+        elif rep.domain in (EX, EXRAW):
+            return None
+
+    # fallback
     q = 1
     for v in A:
         if not v.is_Rational:
@@ -416,6 +752,27 @@ def _common_denoms(A: Union[List, sp.Matrix], bound: int = 4096) -> Optional[int
     # except:
     #     return None # not all elements are Rational
 
+def _cast_sympy_matrix_to_numpy(sympy_mat_rep, dtype: str = 'int64'):
+    rows, cols = sympy_mat_rep.shape
+    items = list(sympy_mat_rep.iter_items())
+    n = len(items)
+
+    row_indices = [0] * n
+    col_indices = [0] * n
+    data_list = [0] * n
+
+    for k in range(n):
+        (i, j), v = items[k]
+        row_indices[k] = i
+        col_indices[k] = j
+        data_list[k] = v.__int__()
+
+    arr = np_zeros((rows, cols), dtype=dtype)
+    if data_list:
+        arr[row_indices, col_indices] = data_list
+    return arr
+
+
 
 def matmul(A: sp.Matrix, B: sp.Matrix, q1: Optional[int] = None, q2: Optional[int] = None) -> sp.Matrix:
     """
@@ -437,29 +794,38 @@ def matmul(A: sp.Matrix, B: sp.Matrix, q1: Optional[int] = None, q2: Optional[in
     if A.shape[0] == 0 or B.shape[0] == 0 or B.shape[1] == 0:
         return sp.zeros(A.shape[0], B.shape[1])
     A0, B0 = A, B
-    if q1 is None:
-        q1 = _common_denoms(A)
-    if q1 is not None and q2 is None:
-        q2 = _common_denoms(B)
-    if q1 is None or q2 is None:
-        return A * B
 
-    A = np_array(A).astype('float') * q1
+    
+    if not (is_zz_qq_mat(A) and is_zz_qq_mat(B)):
+        return A0 * B0
+
+    q1, A = A._rep.primitive()
+    try:
+        A = _cast_sympy_matrix_to_numpy(A, dtype = 'int64')
+    except OverflowError:
+        return A0 * B0
     _MAXA = abs(A).max()
     if isnan(_MAXA) or _MAXA == inf or _MAXA > _INT64_MAX:
         return A0 * B0
 
-    B = np_array(B).astype('float') * q2
+    q2, B = B._rep.primitive()
+    try:
+        B = _cast_sympy_matrix_to_numpy(B, dtype = 'int64')
+    except OverflowError:
+        return A0 * B0
     _MAXB = abs(B).max()
     if isnan(_MAXB) or _MAXB == inf or _MAXB > _INT64_MAX or int(_MAXA) * int(_MAXB) * B.shape[0] > _INT64_MAX:
         return A0 * B0
 
-    CAST_TYPE = 'int' if int(_MAXA) * int(_MAXB) * B.shape[0] <= _INT32_MAX else 'int64'
-    A = np_round(A).astype(CAST_TYPE)
-    B = np_round(B).astype(CAST_TYPE)
+    # CAST_TYPE = 'int' if int(_MAXA) * int(_MAXB) * n**2 <= _INT32_MAX else 'int64'
+    # CAST_TYPE = 'int64'
+    # A = np_round(A).astype(CAST_TYPE)
+    # B = np_round(B).astype(CAST_TYPE)
 
-    C = A @ B
-    C = sp.Matrix(C.tolist()) / (q1 * q2)
+    C = (A @ B).flatten().tolist()
+    q1q2 = q1 * q2
+    C = [i*q1q2 for i in C]
+    C = sp.Matrix(A0.shape[0], B0.shape[1], [Rational(i.numerator, i.denominator, gcd = 1) for i in C])
     return C
 
 def matmul_multiple(A: sp.Matrix, B: sp.Matrix, q1: Optional[int] = None, q2: Optional[int] = None) -> sp.Matrix:
@@ -491,36 +857,62 @@ def matmul_multiple(A: sp.Matrix, B: sp.Matrix, q1: Optional[int] = None, q2: Op
         eq_mat = sp.Matrix(eq_mat)
         return eq_mat
 
-    if q1 is None:
-        q1 = _common_denoms(A)
-    if q1 is not None and q2 is None:
-        q2 = _common_denoms(B)
+    if _VERBOSE_MATMUL_MULTIPLE:
+        print('MatmulMultiple A B shape =', A.shape, B.shape)
+        sparsity = lambda x: len(list(x.iter_values())) / (x.shape[0] * x.shape[1])
+        print('>> Sparsity A B =', sparsity(A), sparsity(B))
+        time0 = time()
 
-    if q1 is None or q2 is None:
+
+    if not (is_zz_qq_mat(A) and is_zz_qq_mat(B)):
         # fallback to defaulted method
         return default(A0, B0)
 
     N = A.shape[0]
     n, m = B.shape
 
-    A = np_array(A).astype('float') * q1
+    q1, A = A._rep.primitive()
+    try:
+        A = _cast_sympy_matrix_to_numpy(A, dtype = 'int64')
+    except OverflowError:
+        return default(A0, B0)
     _MAXA = abs(A).max()
     if isnan(_MAXA) or _MAXA == inf or _MAXA > _INT64_MAX:
         return default(A0, B0)
 
-    B = np_array(B).astype('float') * q2
+    q2, B = B._rep.primitive()
+    try:
+        B = _cast_sympy_matrix_to_numpy(B, dtype = 'int64')
+    except OverflowError:
+        return default(A0, B0)
     _MAXB = abs(B).max()
     if isnan(_MAXB) or _MAXB == inf or _MAXB > _INT64_MAX or int(_MAXA) * int(_MAXB) * n > _INT64_MAX:
         return default(A0, B0)
 
-    CAST_TYPE = 'int' if int(_MAXA) * int(_MAXB) * n**2 <= _INT32_MAX else 'int64'
-    A = np_round(A).astype(CAST_TYPE).reshape((N, n, n))
-    B = np_round(B).astype(CAST_TYPE)
+    # CAST_TYPE = 'int' if int(_MAXA) * int(_MAXB) * n**2 <= _INT32_MAX else 'int64'
+    # CAST_TYPE = 'int64'
+    # A = np_round(A).astype(CAST_TYPE)
+    # B = np_round(B).astype(CAST_TYPE)
+    A = A.reshape((N, n, n))
+
+    if _VERBOSE_MATMUL_MULTIPLE:
+        print('>> Time for casting to numpy:', time() - time0)
+        time0 = time()
 
     C = (A @ B).flatten().tolist()
+
+    if _VERBOSE_MATMUL_MULTIPLE:
+        print('>> Time for numpy matmul:', time() - time0) # very fast (can be ignored)
+        time0 = time()
+
     q1q2 = q1 * q2
-    C = [MPQ(i, q1q2) for i in C]
+    C = [i*q1q2 for i in C]
     C = sp.Matrix(N, n*m, [Rational(i.numerator, i.denominator, gcd = 1) for i in C])
+
+    if _VERBOSE_MATMUL_MULTIPLE:
+        print('>> Time for casting to sympy:', time() - time0) # < 1 sec over (800*8000)
+        time0 = time()
+
     return C
 
 
@@ -602,35 +994,40 @@ def symmetric_bilinear_multiple(U: sp.Matrix, A: sp.Matrix) -> sp.Matrix:
     N = A.shape[0]
     if N == 0:
         return sp.Matrix.zeros(0, U.shape[1]**2)
-    q1, q2 = None, None
-    if q1 is None:
-        q1 = _common_denoms(A)
-    if q1 is not None and q2 is None:
-        q2 = _common_denoms(U)
-    # print('q1 q2 =', q1, q2, 'A U shape =', A.shape, U.shape)
-    if q1 is None or q2 is None:
-        # fallback to defaulted method
+
+    if not (is_zz_qq_mat(A) and is_zz_qq_mat(U)):
         return default(A0, U0)
 
     n, m = U.shape
 
-    A = np_array(A).astype('float') * q1
+
+    q1, A = A._rep.primitive()
+    try:
+        A = _cast_sympy_matrix_to_numpy(A, dtype = 'int64')
+    except OverflowError:
+        return default(A0, U0)
     _MAXA = abs(A).max()
     if isnan(_MAXA) or _MAXA == inf or _MAXA > _INT64_MAX:
         return default(A0, U0)
 
-    U = np_array(U).astype('float') * q2
+    q2, U = U._rep.primitive()
+    try:
+        U = _cast_sympy_matrix_to_numpy(U, dtype = 'int64')
+    except OverflowError:
+        return default(A0, U0)
     _MAXU = abs(U).max()
     if isnan(_MAXU) or _MAXU == inf or _MAXU > _INT64_MAX or int(_MAXA) * int(_MAXU) * n**2 > _INT64_MAX:
         return default(A0, U0)
 
-    CAST_TYPE = 'int' if int(_MAXA) * int(_MAXU) * n**2 <= _INT32_MAX else 'int64'
-    A = np_round(A).astype(CAST_TYPE).reshape((N, n, n))
-    U = np_round(U).astype(CAST_TYPE)
+    # CAST_TYPE = 'int' if int(_MAXA) * int(_MAXU) * n**2 <= _INT32_MAX else 'int64'
+    # CAST_TYPE = 'int64'
+    # A = np_round(A).astype(CAST_TYPE)
+    # U = np_round(U).astype(CAST_TYPE)
+    A = A.reshape((N, n, n))
 
     C = (U.T @ A @ U).flatten().tolist()
     q1q22 = q1 * q2**2
-    C = [MPQ(i, q1q22) for i in C]
+    C = [i * q1q22 for i in C]
     C = sp.Matrix(N, m**2, [Rational(i.numerator, i.denominator, gcd = 1) for i in C])
     # C = sp.Matrix(C.reshape((-1, m*m)).tolist()) / (q1 * q2**2)
     return C

--- a/triples/sdp/arithmetic.py
+++ b/triples/sdp/arithmetic.py
@@ -11,7 +11,6 @@
 
 # from fractions import Fraction
 from collections import defaultdict
-from distutils.version import LooseVersion
 from math import gcd
 from time import time
 from typing import List, Tuple, Union, Optional
@@ -21,14 +20,30 @@ from numpy import isnan, inf, unique
 import sympy as sp
 from sympy import __version__ as _SYMPY_VERSION
 from sympy import Rational
-from sympy.external.gmpy import MPQ # >= 1.9
+from sympy.external.gmpy import MPQ, MPZ # >= 1.9
 from sympy.matrices.repmatrix import RepMatrix
 from sympy.polys.domains import ZZ, QQ, EX, EXRAW # EXRAW >= 1.9
 from sympy.polys.matrices.domainmatrix import DomainMatrix # polys.matrices >= 1.8
 from sympy.polys.matrices.ddm import DDM
 from sympy.polys.matrices.sdm import SDM
 
-if LooseVersion(_SYMPY_VERSION) >= LooseVersion('1.13'):
+def _is_version_greater_than(v1, v2) -> bool:
+    """Version comparison. No dependencies on distutils
+    (which has been deprecated since Python 3.10)."""
+    def _version(s):
+        from re import findall
+        parts = []
+        for comp in s.split('.'):
+            for elem in findall(r'\d+|\D+', comp):
+                parts.append(int(elem) if elem.isdigit() else elem)
+        return tuple(parts)
+    for i, j in zip(_version(v1), _version(v2)):
+        if isinstance(i, str) or isinstance(j, str): i, j = str(i), str(j)
+        if i > j: return True
+        if i < j: return False
+    return bool(len(_version(v1)) >= len(_version(v2)))
+
+if _is_version_greater_than(_SYMPY_VERSION, '1.13'):
     from sympy.polys.matrices.dfm import DFM
 
     primitive = lambda x: x.primitive()
@@ -58,6 +73,7 @@ _INT64_MAX = np_iinfo('int64').max # 9223372036854775807
 _VERBOSE_MATMUL_MULTIPLE = False
 _VERBOSE_SOLVE_UNDETERMINED_LINEAR = False
 _VERBOSE_SOLVE_CSR_LINEAR = False
+_USE_SDM_RREF_DEN = False # has bug in low sympy versions due to behaviour of quo
 
 
 def _lcm(x, y):
@@ -71,38 +87,56 @@ def is_zz_qq_mat(mat):
     """Judge whether a matrix is a ZZ/QQ RepMatrix."""
     return isinstance(mat, RepMatrix) and mat._rep.domain in (ZZ, QQ)
 
-def _find_reasonable_pivot_naive(col):
-    """
-    Find a reasonable pivot candidate in a column.
-    See also in sympy.matrices.determinant._find_reasonable_pivot_naive
-    """
-    for i, col_val in enumerate(col):
-        if col_val != 0:
-            # This pivot candidate is non-zero.
-            return i, col_val
-
-    return None, None
-
-def _row_reduce_list(mat, rows, cols, normalize_last=True, normalize=True, zero_above=True):
+def _row_reduce_dict(mat, rows, cols, normalize_last=True, normalize=True, zero_above=True):
     """
     See also in sympy.matrices.reductions._row_reduce_list
     """
-    one = MPQ.__new__(MPQ, 1, 1)
-
-    def get_col(i):
-        return mat[i::cols]
+    one, zero = QQ.one, QQ.zero
 
     def row_swap(i, j):
-        mat[i*cols:(i + 1)*cols], mat[j*cols:(j + 1)*cols] = \
-            mat[j*cols:(j + 1)*cols], mat[i*cols:(i + 1)*cols]
+        # mat[i*cols:(i + 1)*cols], mat[j*cols:(j + 1)*cols] = \
+        #     mat[j*cols:(j + 1)*cols], mat[i*cols:(i + 1)*cols]
+        mati = mat.get(i, None)
+        matj = mat.get(j, None)
+        if mati is not None and matj is not None:
+            mat[i], mat[j] = matj, mati
+        elif mati is not None:
+            mat[j] = mat.pop(i)
+        elif matj is not None:
+            mat[i] = mat.pop(j)
 
     def cross_cancel(a, i, b, j):
         """Does the row op row[i] = a*row[i] - b*row[j]"""
-        q = (j - i)*cols
+        # q = (j - i)*cols
         gcdab = MPQ(gcd(a.numerator, b.numerator), gcd(a.denominator, b.denominator))
         a, b = a / gcdab, b / gcdab
-        for p in range(i*cols, (i + 1)*cols):
-            mat[p] = (a*mat[p] - b*mat[p + q])
+        mati = mat.get(i, {})
+        if mati:
+            if a:
+                mati = {k: a*v for k, v in mati.items()}
+            else:
+                mati = {}
+
+        if b:
+            matj = mat.get(j, {})
+            for k, v in matj.items():
+                new_val = mati.get(k, zero) - b*v
+                if new_val:
+                    mati[k] = new_val
+                elif v: # mati[k] == b*v != 0
+                    del mati[k]
+        if mati:
+            mat[i] = mati
+        elif i in mat:
+            del mat[i]
+
+    def _find_reasonable_pivot_naive(piv_row, piv_col):
+        """Find mat[piv_row + piv_offset, piv_col] != 0."""
+        for row in range(piv_row, rows):
+            val = mat.get(row, {}).get(piv_col, zero)
+            if val != zero:
+                return row - piv_row, val
+        return None, None
 
     piv_row, piv_col = 0, 0
     pivot_cols = []
@@ -110,8 +144,7 @@ def _row_reduce_list(mat, rows, cols, normalize_last=True, normalize=True, zero_
 
     # use a fraction free method to zero above and below each pivot
     while piv_col < cols and piv_row < rows:
-        pivot_offset, pivot_val = _find_reasonable_pivot_naive(
-                get_col(piv_col)[piv_row:])
+        pivot_offset, pivot_val = _find_reasonable_pivot_naive(piv_row, piv_col)
 
         if pivot_offset is None:
             piv_col += 1
@@ -126,9 +159,16 @@ def _row_reduce_list(mat, rows, cols, normalize_last=True, normalize=True, zero_
         # before we zero the other rows
         if normalize_last is False:
             i, j = piv_row, piv_col
-            mat[i*cols + j] = one
-            for p in range(i*cols + j + 1, (i + 1)*cols):
-                mat[p] = (mat[p] / pivot_val)
+            if mat.get(i, None) is None:
+                mat[i] = {j: one}
+            else:
+                mat[i][j] = one
+            # for p in range(i*cols + j + 1, (i + 1)*cols):
+            #     mat[p] = (mat[p] / pivot_val)
+            mati = mat[i]
+            for k, v in mati.items():
+                if k > j:
+                    mati[k] = v / pivot_val
             # after normalizing, the pivot value is 1
             pivot_val = one
 
@@ -141,8 +181,12 @@ def _row_reduce_list(mat, rows, cols, normalize_last=True, normalize=True, zero_
             if zero_above is False and row < piv_row:
                 continue
             # if we're already a zero, don't do anything
-            val = mat[row*cols + piv_col]
-            if val == 0:
+            mat_row = mat.get(row, None)
+            if not mat_row:
+                continue
+
+            val = mat_row.get(piv_col, zero)
+            if val == zero:
                 continue
 
             cross_cancel(pivot_val, row, val, piv_row)
@@ -151,199 +195,20 @@ def _row_reduce_list(mat, rows, cols, normalize_last=True, normalize=True, zero_
     # normalize each row
     if normalize_last is True and normalize is True:
         for piv_i, piv_j in enumerate(pivot_cols):
-            pivot_val = mat[piv_i*cols + piv_j]
-            mat[piv_i*cols + piv_j] = one
-            for p in range(piv_i*cols + piv_j + 1, (piv_i + 1)*cols):
-                mat[p] = (mat[p] / pivot_val)
+            # pivot_val = mat[piv_i*cols + piv_j]
+            mat_piv_i = mat.get(piv_i, None)
+            if mat_piv_i is None:
+                mat_piv_i = {}
+                mat[piv_i] = mat_piv_i
+            pivot_val = mat_piv_i.get(piv_j, zero)
+            mat_piv_i[piv_j] = one
+            # for p in range(piv_i*cols + piv_j + 1, (piv_i + 1)*cols):
+            #     mat[p] = (mat[p] / pivot_val)
+            for k, v in mat_piv_i.items():
+                if k > piv_j:
+                    mat_piv_i[k] = v / pivot_val
 
     return mat, tuple(pivot_cols), tuple(swaps)
-
-
-def sdm_rref_den(A, K):
-    """
-    Return the reduced row echelon form (RREF) of A with denominator.
-    The RREF is computed using fraction-free Gauss-Jordan elimination.
-
-    The algorithm used is the fraction-free version of Gauss-Jordan elimination
-    described as FFGJ. Here it is modified to handle zero or missing
-    pivots and to avoid redundant arithmetic. This implementation is also
-    optimized for sparse matrices. See also sympy.polys.matrices.sdm (version >= 1.13).
-    """
-    if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
-        time0 = time()
-    if not A:
-        return ({}, K.one, [])
-    elif len(A) == 1:
-        Ai, = A.values()
-        j = min(Ai)
-        Aij = Ai[j]
-        return ({0: Ai.copy()}, Aij, [j])
-
-    # For inexact domains like RR[x] we use quo and discard the remainder.
-    # Maybe it would be better for K.exquo to do this automatically.
-    if K.is_Exact:
-        exquo = K.exquo
-    else:
-        exquo = K.quo
-
-    # Make sure we have the rows in order to make this deterministic from the
-    # outset.
-    _, rows_in_order = zip(*sorted(A.items()))
-
-    col_to_row_reduced = {}
-    col_to_row_unreduced = {}
-    reduced = col_to_row_reduced.keys()
-    unreduced = col_to_row_unreduced.keys()
-
-    # Our representation of the RREF so far.
-    A_rref_rows = []
-    denom = None
-    divisor = None
-
-    # The rows that remain to be added to the RREF. These are sorted by the
-    # column index of their leading entry. Note that sorted() is stable so the
-    # previous sort by unique row index is still needed to make this
-    # deterministic (there may be multiple rows with the same leading column).
-    A_rows = sorted(rows_in_order, key=min)
-
-    for Ai in A_rows:
-
-        # All fully reduced columns can be immediately discarded.
-        Ai = {j: Aij for j, Aij in Ai.items() if j not in reduced}
-        Ai_cancel = {}
-
-        for j in unreduced & Ai.keys():
-            # Remove the pivot column from the new row since it would become
-            # zero anyway.
-            Aij = Ai.pop(j)
-
-            Aj = A_rref_rows[col_to_row_unreduced[j]]
-
-            for k, Ajk in Aj.items():
-                Aik_cancel = Ai_cancel.get(k)
-                if Aik_cancel is None:
-                    Ai_cancel[k] = Aij * Ajk
-                else:
-                    Aik_cancel = Aik_cancel + Aij * Ajk
-                    if Aik_cancel:
-                        Ai_cancel[k] = Aik_cancel
-                    else:
-                        Ai_cancel.pop(k)
-
-        # Multiply the new row by the current denominator and subtract.
-        Ai_nz = set(Ai)
-        Ai_cancel_nz = set(Ai_cancel)
-
-        d = denom or K.one
-
-        for k in Ai_cancel_nz - Ai_nz:
-            Ai[k] = -Ai_cancel[k]
-
-        for k in Ai_nz - Ai_cancel_nz:
-            Ai[k] = Ai[k] * d
-
-        for k in Ai_cancel_nz & Ai_nz:
-            Aik = Ai[k] * d - Ai_cancel[k]
-            if Aik:
-                Ai[k] = Aik
-            else:
-                Ai.pop(k)
-
-        # Now Ai has the same scale as the other rows and is reduced wrt the
-        # unreduced rows.
-
-        # If the row is reduced to zero then discard it.
-        if not Ai:
-            continue
-
-        # Choose a pivot for this row.
-        j = min(Ai)
-        Aij = Ai.pop(j)
-
-        # Cross cancel the unreduced rows by the new row.
-        #     a[k][l] = (a[i][j]*a[k][l] - a[k][j]*a[i][l]) / divisor
-        for pk, k in list(col_to_row_unreduced.items()):
-
-            Ak = A_rref_rows[k]
-
-            if j not in Ak:
-                # This row is already reduced wrt the new row but we need to
-                # bring it to the same scale as the new denominator. This step
-                # is not needed in sdm_irref.
-                for l, Akl in Ak.items():
-                    Akl = Akl * Aij
-                    if divisor is not None:
-                        Akl = exquo(Akl, divisor)
-                    Ak[l] = Akl
-                continue
-
-            Akj = Ak.pop(j)
-            Ai_nz = set(Ai)
-            Ak_nz = set(Ak)
-
-            for l in Ai_nz - Ak_nz:
-                Ak[l] = - Akj * Ai[l]
-                if divisor is not None:
-                    Ak[l] = exquo(Ak[l], divisor)
-
-            # This loop also not needed in sdm_irref.
-            for l in Ak_nz - Ai_nz:
-                Ak[l] = Aij * Ak[l]
-                if divisor is not None:
-                    Ak[l] = exquo(Ak[l], divisor)
-
-            for l in Ai_nz & Ak_nz:
-                Akl = Aij * Ak[l] - Akj * Ai[l]
-                if Akl:
-                    if divisor is not None:
-                        Akl = exquo(Akl, divisor)
-                    Ak[l] = Akl
-                else:
-                    Ak.pop(l)
-
-            if not Ak:
-                col_to_row_unreduced.pop(pk)
-                col_to_row_reduced[pk] = k
-
-        i = len(A_rref_rows)
-        A_rref_rows.append(Ai)
-        if Ai:
-            col_to_row_unreduced[j] = i
-        else:
-            col_to_row_reduced[j] = i
-
-        # Update the denominator.
-        if not K.is_one(Aij):
-            if denom is None:
-                denom = Aij
-            else:
-                denom *= Aij
-
-        if divisor is not None:
-            denom = exquo(denom, divisor)
-
-        # Update the divisor.
-        divisor = denom
-
-    if denom is None:
-        denom = K.one
-
-    # Sort the rows by their leading column index.
-    col_to_row = {**col_to_row_reduced, **col_to_row_unreduced}
-    row_to_col = {i: j for j, i in col_to_row.items()}
-    A_rref_rows_col = [(row_to_col[i], Ai) for i, Ai in enumerate(A_rref_rows)]
-    pivots, A_rref = zip(*sorted(A_rref_rows_col))
-    pivots = list(pivots)
-
-    # Insert the pivot values
-    for i, Ai in enumerate(A_rref):
-        Ai[pivots[i]] = denom
-
-    A_rref_sdm = dict(enumerate(A_rref))
-
-    if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
-        print(">> Time for sdm_rref_den:", time() - time0)
-    return A_rref_sdm, denom, pivots
 
 
 def _row_reduce(M, normalize_last=True,
@@ -357,22 +222,23 @@ def _row_reduce(M, normalize_last=True,
     if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
         time0 = time()
 
-    M_frac_list = [MPQ.__new__(MPQ, x.p, x.q) for x in M]
+    sdm = M._rep.to_field().rep.to_sdm()
+    sdm = {k: {k2: i for k2, i in v.items()} for k, v in sdm.items()}
 
     if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
         print(">> Time for converting to MPQ:", time() - time0)
         time0 = time()
 
-    mat, pivot_cols, swaps = _row_reduce_list(M_frac_list, M.rows, M.cols,
+    mat, pivot_cols, swaps = _row_reduce_dict(sdm, M.shape[0], M.shape[1],
             normalize_last=normalize_last, normalize=normalize, zero_above=zero_above)
 
     if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
         print(">> Time for row reduce list:", time() - time0)
         time0 = time()
 
-    mat = [Rational(x.numerator, x.denominator, gcd = 1) for x in mat]
+    mat = M._fromrep(DomainMatrix.from_rep(SDM(mat, M.shape, M._rep.domain.get_field())))
 
-    return sp.Matrix(M.rows, M.cols, mat), pivot_cols, swaps
+    return mat, pivot_cols, swaps
 
 
 def _rref(M, pivots=True, normalize_last=True):
@@ -382,23 +248,25 @@ def _rref(M, pivots=True, normalize_last=True):
     if not is_zz_qq_mat(M):
         return M.rref(pivots=pivots, normalize_last=normalize_last)
 
-    sdm = M._rep.rep.to_sdm()
-    K = sdm.domain
+    if _USE_SDM_RREF_DEN:
+        # sdm_rref_den is implemented in sympy since 1.13
+        # even if we copy the code of sdm_rref_den,
+        # it still has bugs on low sympy versions
+        # due to the behaviour of domain.quo on Rings (e.g. ZZ)
+        from sympy.polys.matrices.sdm import sdm_rref_den
+        sdm = M._rep.rep.to_sdm()
+        K = sdm.domain
 
-    sdm_rref_dict, den, pivots = sdm_rref_den(sdm, K)
-    sdm_rref = sdm.new(sdm_rref_dict, sdm.shape, sdm.domain)
-    dM = DomainMatrix.from_rep(sdm_rref)
-    if den != 1:
-        dM = dM.to_field()
-        dM = dM * K.get_field().quo(K.one, den)
+        sdm_rref_dict, den, pivots = sdm_rref_den(sdm, K)
+        sdm_rref = sdm.new(sdm_rref_dict, sdm.shape, sdm.domain)
+        dM = DomainMatrix.from_rep(sdm_rref)
+        if den != 1:
+            dM = dM.to_field()
+            dM = dM * K.get_field().quo(K.one, den)
 
-    mat = M.__class__._fromrep(dM)
-    # dM_rref = M.new(dM_rref, M.shape, M.domain)
-    # mat = 
-    # if pivots:
-    #     return dM_rref, pivots
-    # return dM_rref
-    # mat, pivot_cols, _ = _row_reduce(M, normalize_last=normalize_last, normalize=True, zero_above=True)
+        mat = M.__class__._fromrep(dM)
+    else:
+        mat, pivots, _ = _row_reduce(M, normalize_last=normalize_last, normalize=True, zero_above=True)
 
     if pivots:
         mat = (mat, pivots)
@@ -460,7 +328,7 @@ def solve_undetermined_linear(M: sp.Matrix, B: sp.Matrix) -> Tuple[sp.Matrix, sp
         time0 = time()
 
     # solve by reduced row echelon form
-    A, pivots = _rref(aug, normalize_last = False)
+    A, pivots = _rref(aug, normalize_last=False)
 
     
     if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
@@ -492,8 +360,6 @@ def solve_undetermined_linear(M: sp.Matrix, B: sp.Matrix) -> Tuple[sp.Matrix, sp
     # Undo permutation
     V2 = _permute_matrix_rows(V, permutation)
     vt2 = _permute_matrix_rows(vt, permutation)
-    # V2       = sp.zeros(V.shape[0], V.shape[1])
-    # vt2      = sp.zeros(vt.shape[0], vt.shape[1])
     # for k in range(col):
     #     V2[permutation[k], :] = V[k, :]
     #     vt2[permutation[k]] = vt[k]
@@ -529,10 +395,8 @@ def solve_column_separated_linear(A: sp.Matrix, b: sp.Matrix, x0_equal_indices: 
 
     Parameters
     ----------
-    A: List[List[Tuple[int, Rational]]]
-        Sparse row representation of A. If A[i][..] = (j, v), then A[i, j] = v.
-        Also, it must guarantee that A[i', j] == 0 for all i' != i.
-        Also, be sure that v != 0.
+    A: sp.Matrix
+        Sympy matrix that satisfies the condition.
     b: sp.Matrix
         Right-hand side
     x0_equal_indices: List[List[int]]
@@ -611,7 +475,6 @@ def solve_column_separated_linear(A: sp.Matrix, b: sp.Matrix, x0_equal_indices: 
 
         else:
             bi = b.get(i, 0)
-            print('bi', bi, bi.get(0, zero), zero)
             if bi != 0 and bi.get(0, zero) != zero:
                 raise ValueError("Linear system has no solution")
 
@@ -643,15 +506,13 @@ def solve_column_separated_linear(A: sp.Matrix, b: sp.Matrix, x0_equal_indices: 
 
 def solve_csr_linear(A: sp.Matrix, b: sp.Matrix, x0_equal_indices: List[List[int]] = []):
     """
-    Solve a linear system Ax = b where A is stored in CSR format.
+    Solve a linear system Ax = b where A is stored in SDM (CSR) format.
     Further, we could require some of entries of x to be equal.
 
     Parameters
     ----------
-    A: List[List[Tuple[int, Rational]]]
-        Sparse row representation of A. If A[i][..] = (j, v), then A[i, j] = v.
-        Also, it must guarantee that A[i', j] == 0 for all i' != i.
-        Also, be sure that v != 0.
+    A: sp.Matrix
+        Sympy matrix (with preferably SDM format).
     b: sp.Matrix
         Right-hand side
     x0_equal_indices: List[List[int]]
@@ -740,31 +601,6 @@ def solve_csr_linear(A: sp.Matrix, b: sp.Matrix, x0_equal_indices: List[List[int
     space = _restore_from_compressed(space_compressed, mapping)
     return x0, space
 
-
-def _common_denoms(A: Union[List, sp.Matrix], bound: int = 4096) -> Optional[int]:
-    """
-    Compute the common denominator of a list of rational numbers.
-    This might be slow when the list is large. (e.g. 30000 entries -> 0.2 sec)
-    """
-    if isinstance(A, RepMatrix):
-        rep = A._rep
-        if rep.domain is ZZ:
-            return 1
-        elif rep.domain is QQ:
-            return int(rep.content().denominator)
-        elif rep.domain in (EX, EXRAW):
-            return None
-
-    # fallback
-    q = 1
-    for v in A:
-        if not v.is_Rational:
-            return None
-        q = _lcm(q, v.q)
-        if q > bound:
-            return None
-    return int(q)
-
 def _cast_sympy_matrix_to_numpy(sympy_mat_rep, dtype: str = 'int64'):
     """Cast a sympy RepMatrix on ZZ to numpy int64 matrix."""
     rows, cols = sympy_mat_rep.shape
@@ -786,9 +622,21 @@ def _cast_sympy_matrix_to_numpy(sympy_mat_rep, dtype: str = 'int64'):
         arr[row_indices, col_indices] = data_list
     return arr
 
+def _cast_list_to_sympy_matrix(rows: int, cols: int, lst: List[int]) -> sp.Matrix:
+    """Convert a list of INTEGER values to a sympy matrix efficiently."""
+    sdm = {}
+    for i in range(rows):
+        row = {}
+        for j, v in enumerate(lst[i*cols:(i+1)*cols]):
+            if v:
+                row[j] = MPZ(v)
+        if row:
+            sdm[i] = row
+    return sp.Matrix._fromrep(DomainMatrix.from_rep(SDM(sdm, (rows, cols), ZZ)))
 
 
-def matmul(A: sp.Matrix, B: sp.Matrix, q1: Optional[int] = None, q2: Optional[int] = None) -> sp.Matrix:
+
+def matmul(A: sp.Matrix, B: sp.Matrix, return_shape = None) -> sp.Matrix:
     """
     Fast, low-level implementation of symbolic matrix multiplication.
     When A and B are both rational matrices, it calls NumPy to compute the result.
@@ -800,49 +648,47 @@ def matmul(A: sp.Matrix, B: sp.Matrix, q1: Optional[int] = None, q2: Optional[in
         Matrix A
     B: Matrix
         Matrix B
-    q1: int
-        Common denominator of A. If not specified, it will be inferred.
-    q2: int
-        Common denominator of B. If not specified, it will be inferred.
+    return_shape: Tuple[int, int]
+        Shape of the result. If not specified, it will be inferred.
     """
     if A.shape[0] == 0 or B.shape[0] == 0 or B.shape[1] == 0:
         return sp.zeros(A.shape[0], B.shape[1])
     A0, B0 = A, B
 
+    def default(A0, B0):
+        AB = A0 * B0
+        if return_shape: AB = AB.reshape(*return_shape)
+        return AB
     
     if not (is_zz_qq_mat(A) and is_zz_qq_mat(B)):
-        return A0 * B0
+        return default(A0, B0)
 
     q1, A = primitive(A._rep)
     try:
         A = _cast_sympy_matrix_to_numpy(A, dtype = 'int64')
     except OverflowError:
-        return A0 * B0
+        return default(A0, B0)
     _MAXA = abs(A).max()
     if isnan(_MAXA) or _MAXA == inf or _MAXA > _INT64_MAX:
-        return A0 * B0
+        return default(A0, B0)
 
     q2, B = primitive(B._rep)
     try:
         B = _cast_sympy_matrix_to_numpy(B, dtype = 'int64')
     except OverflowError:
-        return A0 * B0
+        return default(A0, B0)
     _MAXB = abs(B).max()
     if isnan(_MAXB) or _MAXB == inf or _MAXB > _INT64_MAX or int(_MAXA) * int(_MAXB) * B.shape[0] > _INT64_MAX:
-        return A0 * B0
-
-    # CAST_TYPE = 'int' if int(_MAXA) * int(_MAXB) * n**2 <= _INT32_MAX else 'int64'
-    # CAST_TYPE = 'int64'
-    # A = np_round(A).astype(CAST_TYPE)
-    # B = np_round(B).astype(CAST_TYPE)
+        return default(A0, B0)
 
     C = (A @ B).flatten().tolist()
     q1q2 = q1 * q2
-    C = [i*q1q2 for i in C]
-    C = sp.Matrix(A0.shape[0], B0.shape[1], [Rational(i.numerator, i.denominator, gcd = 1) for i in C])
+    return_shape = return_shape or (A0.shape[0], B0.shape[1])
+    C = _cast_list_to_sympy_matrix(*return_shape, C) * q1q2
     return C
 
-def matmul_multiple(A: sp.Matrix, B: sp.Matrix, q1: Optional[int] = None, q2: Optional[int] = None) -> sp.Matrix:
+
+def matmul_multiple(A: sp.Matrix, B: sp.Matrix) -> sp.Matrix:
     """
     Perform multiple matrix multiplications. This can be regarded as a 3-dim tensor multiplication.
     Assume A has shape N x (n^2) and B has shape n x m, then the result has shape N x (n*m).
@@ -853,10 +699,6 @@ def matmul_multiple(A: sp.Matrix, B: sp.Matrix, q1: Optional[int] = None, q2: Op
         Matrix A
     B: Matrix
         Matrix B
-    q1: int
-        Common denominator of A. If not specified, it will be inferred.
-    q2: int
-        Common denominator of B. If not specified, it will be inferred.
     """
     if A.shape[0] == 0 or B.shape[0] == 0 or B.shape[1] == 0:
         return sp.zeros(A.shape[0], B.shape[0]*B.shape[1])
@@ -866,9 +708,9 @@ def matmul_multiple(A: sp.Matrix, B: sp.Matrix, q1: Optional[int] = None, q2: Op
         eq_mat = []
         for i in range(A.shape[0]):
             Aij = Mat2Vec.vec2mat(A[i,:])
-            eq = list(matmul(Aij, B))
+            eq = matmul(Aij, B, return_shape = (1, Aij.shape[0]*B.shape[1]))
             eq_mat.append(eq)
-        eq_mat = sp.Matrix(eq_mat)
+        eq_mat = sp.Matrix.vstack(*eq_mat)
         return eq_mat
 
     if _VERBOSE_MATMUL_MULTIPLE:
@@ -903,10 +745,6 @@ def matmul_multiple(A: sp.Matrix, B: sp.Matrix, q1: Optional[int] = None, q2: Op
     if isnan(_MAXB) or _MAXB == inf or _MAXB > _INT64_MAX or int(_MAXA) * int(_MAXB) * n > _INT64_MAX:
         return default(A0, B0)
 
-    # CAST_TYPE = 'int' if int(_MAXA) * int(_MAXB) * n**2 <= _INT32_MAX else 'int64'
-    # CAST_TYPE = 'int64'
-    # A = np_round(A).astype(CAST_TYPE)
-    # B = np_round(B).astype(CAST_TYPE)
     A = A.reshape((N, n, n))
 
     if _VERBOSE_MATMUL_MULTIPLE:
@@ -920,8 +758,7 @@ def matmul_multiple(A: sp.Matrix, B: sp.Matrix, q1: Optional[int] = None, q2: Op
         time0 = time()
 
     q1q2 = q1 * q2
-    C = [i*q1q2 for i in C]
-    C = sp.Matrix(N, n*m, [Rational(i.numerator, i.denominator, gcd = 1) for i in C])
+    C = _cast_list_to_sympy_matrix(N, n*m, C) * q1q2
 
     if _VERBOSE_MATMUL_MULTIPLE:
         print('>> Time for casting to sympy:', time() - time0) # < 1 sec over (800*8000)
@@ -930,12 +767,12 @@ def matmul_multiple(A: sp.Matrix, B: sp.Matrix, q1: Optional[int] = None, q2: Op
     return C
 
 
-def symmetric_bilinear(U: sp.Matrix, A: sp.Matrix, is_A_vec: bool = False, return_vec: bool = False):
+def symmetric_bilinear(U: sp.Matrix, A: sp.Matrix, is_A_vec: bool = False, return_shape = None):
     """
     Compute U.T * A * U efficiently.
-    Assume U.T is m x n and A is n x n. Then Kronecker product is O(m^2n^2),
-    and using direct matmul is O(mn(n+m)).
+    Assume U is n x m, U.T is m x n and A is n x n. The result is m x m.
 
+    Complexity: Kronecker product is O(m^2n^2), and using direct matmul is O(mn(n+m)).
     When A is sparse with k nonzeros, the complexity is O(2m^2k).
 
     Parameters
@@ -946,40 +783,19 @@ def symmetric_bilinear(U: sp.Matrix, A: sp.Matrix, is_A_vec: bool = False, retur
         Matrix A
     is_A_vec: bool
         Whether A is stored as a vector. If True, it first converts A to a matrix.
-    return_vec: bool
-        Whether to return the result as a vector list.
+    return_shape: Optional[Tuple[int, int]]
+        Shape of the returned matrix.
     """
-    nonzeros = []
-    for i, val in enumerate(A):
-        if val != 0:
-            nonzeros.append((i, val))
+    # n, m = U.shape
+    
+    if is_A_vec:
+        A = Mat2Vec.vec2mat(A)
+    M = matmul(U.T, matmul(A, U))
+    # M = U.T * A * U
 
-    n, m = U.shape
-    if len(nonzeros) * 2 >= n**2:
-    # if True:
-        if is_A_vec:
-            A = Mat2Vec.vec2mat(A)
-        M = matmul(U.T, matmul(A, U))
-        # M = U.T * A * U
-
-        if return_vec:
-            return list(M)
-        return M
-    else:
-        # A is sparse
-        M = [sp.S.Zero] * (m * m)
-        for l, val in nonzeros:
-            p = 0
-            l1, l2 = divmod(l, n)
-            for i in range(m):
-                for j in range(m):
-                    M[p] += U[l1, i] * U[l2, j] * val
-                    p += 1
-
-    if return_vec:
-        return M
-
-    return sp.Matrix(m, m, M)
+    if return_shape is not None:
+        return M.reshape(return_shape[0], return_shape[1])
+    return M
 
 
 def symmetric_bilinear_multiple(U: sp.Matrix, A: sp.Matrix) -> sp.Matrix:
@@ -1000,9 +816,9 @@ def symmetric_bilinear_multiple(U: sp.Matrix, A: sp.Matrix) -> sp.Matrix:
         for i in range(A.shape[0]):
             # Aij = Mat2Vec.vec2mat(space[i,:])
             # eq = U.T * Aij * U
-            eq = symmetric_bilinear(U, A[i,:], is_A_vec = True, return_vec = True)
+            eq = symmetric_bilinear(U, A[i,:], is_A_vec = True, return_shape = (1, U.shape[1]**2))
             eq_mat.append(eq)
-        eq_mat = sp.Matrix(eq_mat)
+        eq_mat = sp.Matrix.vstack(*eq_mat)
         return eq_mat
 
     N = A.shape[0]
@@ -1011,7 +827,7 @@ def symmetric_bilinear_multiple(U: sp.Matrix, A: sp.Matrix) -> sp.Matrix:
 
     if not (is_zz_qq_mat(A) and is_zz_qq_mat(U)):
         return default(A0, U0)
-
+    # return default(A0, U0)
     n, m = U.shape
 
 
@@ -1030,18 +846,19 @@ def symmetric_bilinear_multiple(U: sp.Matrix, A: sp.Matrix) -> sp.Matrix:
     except OverflowError:
         return default(A0, U0)
     _MAXU = abs(U).max()
-    if isnan(_MAXU) or _MAXU == inf or _MAXU > _INT64_MAX or int(_MAXA) * int(_MAXU) * n**2 > _INT64_MAX:
+    if isnan(_MAXU) or _MAXU == inf or _MAXU > _INT64_MAX or int(_MAXA) * int(_MAXU)**2 * n**2 > _INT64_MAX:
         return default(A0, U0)
-
-    # CAST_TYPE = 'int' if int(_MAXA) * int(_MAXU) * n**2 <= _INT32_MAX else 'int64'
-    # CAST_TYPE = 'int64'
-    # A = np_round(A).astype(CAST_TYPE)
-    # U = np_round(U).astype(CAST_TYPE)
     A = A.reshape((N, n, n))
 
     C = (U.T @ A @ U).flatten().tolist()
+
+    if _VERBOSE_MATMUL_MULTIPLE:
+        time0 = time()
+
     q1q22 = q1 * q2**2
-    C = [i * q1q22 for i in C]
-    C = sp.Matrix(N, m**2, [Rational(i.numerator, i.denominator, gcd = 1) for i in C])
-    # C = sp.Matrix(C.reshape((-1, m*m)).tolist()) / (q1 * q2**2)
+    C = _cast_list_to_sympy_matrix(N, m**2, C) * q1q22
+
+    if _VERBOSE_MATMUL_MULTIPLE:
+        print('>> Time for casting to sympy Bilinear:', time() - time0)
+
     return C

--- a/triples/sdp/dual.py
+++ b/triples/sdp/dual.py
@@ -253,7 +253,7 @@ class SDPProblem(DualTransformMixin):
         elif isinstance(y, np.ndarray):
             if y.size != m:
                 raise ValueError(f"Vector y must be an array of shape ({m},) or ({m}, 1), but got {y.shape}.")
-            y = Matrix(y.flatten())
+            y = Matrix(m, 1, y.flatten().tolist())
         elif isinstance(y, dict):
             y = Matrix([y.get(v, v) for v in self.free_symbols]).reshape(m, 1)
 

--- a/triples/sdp/rationalize.py
+++ b/triples/sdp/rationalize.py
@@ -58,7 +58,7 @@ class RationalizeWithMask(Rationalizer):
     def __call__(self, y: np.ndarray) -> Generator[sp.Matrix, None, None]:
         tol = max(1, np.abs(y).max()) * self.zero_tolerance
         y_rational_mask = np.abs(y) > tol
-        y_rational = np.where(y_rational_mask, y, 0)
+        y_rational = np.where(y_rational_mask, y, 0).flatten().tolist()
         y_rational = [rationalize(v, rounding = abs(v) * 1e-4) for v in y_rational]
         y_rational = sp.Matrix(y_rational)
         return (y_rational,)
@@ -171,6 +171,8 @@ def rationalize_and_decompose(
         rationalizers = [IdentityRationalizer()]
     if len(y) == 0:
         rationalizers = [EmptyRationalizer()]
+    if isinstance(y, np.ndarray):
+        y = y.flatten().tolist()
 
     for rationalizer in rationalizers:
         # print(rationalizer, rationalizer(y))

--- a/triples/sdp/transform.py
+++ b/triples/sdp/transform.py
@@ -213,7 +213,7 @@ class DualMatrixTransform(SDPMatrixTransform):
 
             # Ai0 = Mat2Vec.vec2mat(x0)
             # new_x0 = Mat2Vec.mat2vec(U.T * Ai0 * U) + eq_mat * trans_x0
-            new_x0 = sp.Matrix(symmetric_bilinear(U, x0, is_A_vec = True, return_vec = True))
+            new_x0 = symmetric_bilinear(U, x0, is_A_vec = True, return_shape=(U.shape[1]**2, 1))
             new_x0 += eq_mat * trans_x0
             # new_x0 += matmul(eq_mat, trans_x0)
 

--- a/triples/utils/expression/cyclic.py
+++ b/triples/utils/expression/cyclic.py
@@ -617,7 +617,24 @@ setattr(StrPrinter, '_print_CyclicSum', lambda self, expr: CyclicSum._str_str(se
 setattr(StrPrinter, '_print_CyclicProduct', lambda self, expr: CyclicProduct._str_str(self, expr))
 
 
-if sp.__version__ < '1.14':
+def _is_version_greater_than(v1, v2) -> bool:
+    """Version comparison. No dependencies on distutils
+    (which has been deprecated since Python 3.10)."""
+    def _version(s):
+        from re import findall
+        parts = []
+        for comp in s.split('.'):
+            for elem in findall(r'\d+|\D+', comp):
+                parts.append(int(elem) if elem.isdigit() else elem)
+        return tuple(parts)
+    for i, j in zip(_version(v1), _version(v2)):
+        if isinstance(i, str) or isinstance(j, str): i, j = str(i), str(j)
+        if i > j: return True
+        if i < j: return False
+    return bool(len(_version(v1)) >= len(_version(v2)))
+
+# if sp.__version__ < '1.14':
+if not _is_version_greater_than(sp.__version__, '1.14'):
     def radsimp(expr, symbolic=True, max_terms=4):
         r"""
         Rationalize the denominator by removing square roots.

--- a/triples/utils/expression/solution.py
+++ b/triples/utils/expression/solution.py
@@ -200,6 +200,7 @@ class Solution():
     def signsimp(self) -> 'Solution':
         """
         Make a copy of the solution and apply signsimp on it.
+        See also: sympy.signsimp.
         """
         self = self.copy()
         self.solution = sp.signsimp(self.solution)
@@ -208,16 +209,30 @@ class Solution():
     def xreplace(self, *args, **kwargs) -> 'Solution':
         """
         Make a copy of the solution and apply xreplace on it.
+        See also: sympy.xreplace.
         """
         self = self.copy()
         self.solution = self.solution.xreplace(*args, **kwargs)
         return self
 
-    def doit(self, *args, **kwargs) -> sp.Expr:
+    def doit(self, *args, **kwargs) -> 'Solution':
         """
-        Return the evaluated solution expression (by expanding CyclicSum, etc.).
+        Make a copy of the solution and apply doit on it.
+        This is useful to expand cyclic expressions.
+        See also: sympy.doit.
         """
-        return self.solution.doit(*args, **kwargs)
+        self = self.copy()
+        self.solution = self.solution.doit(*args, **kwargs)
+        return self
+
+    def collect(self, *args, **kwargs) -> 'Solution':
+        """
+        Make a copy of the solution and apply collect on it.
+        See also: sympy.collect.
+        """
+        self = self.copy()
+        self.solution = self.solution.collect(*args, **kwargs)
+        return self
 
     def as_expr(self, *args, **kwargs) -> sp.Expr:
         """

--- a/triples/utils/monomials.py
+++ b/triples/utils/monomials.py
@@ -55,6 +55,14 @@ class MonomialManager():
     def copy(self) -> 'MonomialManager':
         return MonomialManager(self.nvars, perm_group=self._perm_group, is_homogeneous=self._is_homogeneous)
 
+    def __hash__(self) -> int:
+        return hash((self.__class__, self.nvars, self._perm_group, self._is_homogeneous))
+
+    def __eq__(self, other: 'MonomialManager') -> bool:
+        if self is other:
+            return True
+        return self.nvars == other.nvars and self._perm_group == other._perm_group and self._is_homogeneous == other._is_homogeneous
+
     @property
     def is_homogeneous(self) -> bool:
         return self._is_homogeneous
@@ -287,8 +295,8 @@ def arraylize_np(poly: sp.Poly, expand_cyc: bool = False, **options) -> np.ndarr
         The sympy polynomial.
 
     expand_cyc: bool
-        Whether to accumulate the non-standard monomials given a
-        symmetry group.
+        Whether to compute the cyclic sum of the polynomial given
+        the symmetry group.
 
     Keyword Arguments
     -----------------
@@ -342,8 +350,8 @@ def arraylize_sp(poly: sp.Poly, expand_cyc: bool = False, **options) -> sp.Matri
         The sympy polynomial.
 
     expand_cyc: bool
-        Whether to accumulate the non-standard monomials given a
-        symmetry group.
+        Whether to compute the cyclic sum of the polynomial given
+        the symmetry group.
 
     Keyword Arguments
     -----------------

--- a/triples/utils/text_process.py
+++ b/triples/utils/text_process.py
@@ -225,11 +225,10 @@ def preprocess_text(
     if return_type == 'text':
         return poly
 
+    poly = sympify(poly)
     if return_type == 'expr':
-        return sympify(poly)
-    elif return_type == 'frac': 
-        poly = sympify(poly)
-
+        return poly
+    elif return_type == 'frac':
         try:
             frac = fraction(cancel(poly))
 


### PR DESCRIPTION
This pull request includes several bug fixes.

### Bug Fixes
* `utils/text_process.py`: Fixed a severe bug in `pl` for not sympifying texts before converting them to polynomials. E.g. `pl('(a^2)^2')` failed when calling `sp.Poly('(a^2)^2', (a,b,c))`.
* `static/js/visualization.js`: Added a check for WebGL support and a fallback for browsers that do not support WebGL. This ensures 2D display works normally on browsers without WebGL.
* `triples/sdp`: Fixed an int64 overflow detection bug in `symmetric_bilinear_multiple`. Also, sympy matrices are now built from low-level rep class, achieving a huge boost in rational arithmetic. For large scale problems, rational SDP formulation can be accelerated by x10 times. Changed the APIs of `solve_column_separated_linear` and `solve_csr_linear`. Tests carried out on Python 3.7-3.12, SymPy 1.10-1.14.dev.
* `triples/core/sdpsos`: Made numpy arrays converted to python data types before casted to sympy matrices. This makes NumPy 2 compatible with SymPy <= 1.12.0. See also in [https://github.com/sympy/sympy/wiki/Release-Notes-for-1.12.1](https://github.com/sympy/sympy/wiki/Release-Notes-for-1.12.1).
* `triples/core/linsos`: Introduced a low-level matrix building strategy to slightly accelerate basis formulation in `generate_quad_diff`.
* Fixed comparison of versions of packages (e.g. SymPy and SciPy), which used to compare versions improperly by strings.