### PR TITLE
Structsos groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,50 @@ include = ["triples*"]
 
 [tool.setuptools.package-data]
 triples = ["**/*.npz"]
+
+[tool.ruff]
+# from SymPy
+lint.select = [
+    "B015",  # Useless comparison: a == b rather than a = b.
+    "I002",  # `import` statement not at top of file
+    "C4",
+    "E",
+    "F",
+    "FURB",
+    "LOG",
+    "PIE810",
+    "PLE",
+    "PLR1736",
+    "PLW0602", # Global statement used but no assignment
+    "SIM101",
+    "SLOT",
+    "TC001",
+    "TC002",
+    "TC003",
+    "TC004",
+    "TC005",
+    "TRY002",
+    "BLE001", # except Exception or except BaseException
+    # "UP006", # pyupgrade - non-pep585-annotation
+    # "UP007", # pyupgrade - non-pep604-annotation-union
+    # "UP045", # pyupgrade - non-pep604-annotation-optional
+]
+
+# Ignore rules that currently fail on the SymPy codebase
+lint.ignore = [
+    "E401",  # Multiple imports on one line
+    "E402",  # Module level import not at top of file
+    "E501",  # Line too long (<LENGTH> > 88 characters)
+    "E701",  # Multiple statements on one line (colon)
+    "E702",  # Multiple statements on one line (semicolon)
+    "E712",  # Comparison to `<BOOL>` should be `cond is <BOOL>`
+    "E713",  # Test for membership should be `not in`
+    "E714",  # Test for object identity should be `is not`
+    "E721",  # Do not compare types, use `isinstance()`
+    "E731",  # Do not assign a `lambda` expression, use a `def`
+    "E741",  # Ambiguous variable name: `<VARIABLE>`
+    "E743",  # Ambiguous function name: `<FUNCTION>`
+    "F811",
+    "FURB110",  # Replace ternary `if` expression with `or` operator
+    "FURB187",  # Use of assignment of `reversed` on list `{name}`
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ lint.ignore = [
     # "E702",  # Multiple statements on one line (semicolon)
     "E712",  # Comparison to `<BOOL>` should be `cond is <BOOL>`
     # "E713",  # Test for membership should be `not in`
-    "E714",  # Test for object identity should be `is not`
+    # "E714",  # Test for object identity should be `is not`
     "E721",  # Do not compare types, use `isinstance()`
     "E731",  # Do not assign a `lambda` expression, use a `def`
     "E741",  # Ambiguous variable name: `<VARIABLE>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ lint.select = [
     "TC004",
     "TC005",
     "TRY002",
+    # "BLE001", # except Exception or except BaseException
     # "UP006", # pyupgrade - non-pep585-annotation
     # "UP007", # pyupgrade - non-pep604-annotation-union
     # "UP045", # pyupgrade - non-pep604-annotation-optional
@@ -79,9 +80,9 @@ lint.ignore = [
     "E402",  # Module level import not at top of file
     "E501",  # Line too long (<LENGTH> > 88 characters)
     "E701",  # Multiple statements on one line (colon)
-    "E702",  # Multiple statements on one line (semicolon)
+    # "E702",  # Multiple statements on one line (semicolon)
     "E712",  # Comparison to `<BOOL>` should be `cond is <BOOL>`
-    "E713",  # Test for membership should be `not in`
+    # "E713",  # Test for membership should be `not in`
     "E714",  # Test for object identity should be `is not`
     "E721",  # Do not compare types, use `isinstance()`
     "E731",  # Do not assign a `lambda` expression, use a `def`
@@ -90,7 +91,6 @@ lint.ignore = [
     "F811",
     "FURB110",  # Replace ternary `if` expression with `or` operator
     "FURB187",  # Use of assignment of `reversed` on list `{name}`
-    "BLE001", # except Exception or except BaseException
 ]
 
 exclude = ["triples/benchmarks/run_benchmark.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ lint.select = [
     "TC004",
     "TC005",
     "TRY002",
-    "BLE001", # except Exception or except BaseException
     # "UP006", # pyupgrade - non-pep585-annotation
     # "UP007", # pyupgrade - non-pep604-annotation-union
     # "UP045", # pyupgrade - non-pep604-annotation-optional
@@ -91,4 +90,7 @@ lint.ignore = [
     "F811",
     "FURB110",  # Replace ternary `if` expression with `or` operator
     "FURB187",  # Use of assignment of `reversed` on list `{name}`
+    "BLE001", # except Exception or except BaseException
 ]
+
+exclude = ["triples/benchmarks/run_benchmark.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,11 +84,11 @@ lint.ignore = [
     "E712",  # Comparison to `<BOOL>` should be `cond is <BOOL>`
     # "E713",  # Test for membership should be `not in`
     # "E714",  # Test for object identity should be `is not`
-    "E721",  # Do not compare types, use `isinstance()`
+    # "E721",  # Do not compare types, use `isinstance()`
     "E731",  # Do not assign a `lambda` expression, use a `def`
     "E741",  # Ambiguous variable name: `<VARIABLE>`
     "E743",  # Ambiguous function name: `<FUNCTION>`
-    "F811",
+    "F811",  # Redefinition of unused XXX
     "FURB110",  # Replace ternary `if` expression with `or` operator
     "FURB187",  # Use of assignment of `reversed` on list `{name}`
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ lint.ignore = [
     "F811",  # Redefinition of unused XXX
     "FURB110",  # Replace ternary `if` expression with `or` operator
     "FURB187",  # Use of assignment of `reversed` on list `{name}`
+    "FURB188",  # Prefer `str.removeprefix()` over conditionally replacing with slice
 ]
 
 exclude = ["triples/benchmarks/run_benchmark.py"]

--- a/triples/benchmarks/problems/books/nice_and_hard567.py
+++ b/triples/benchmarks/problems/books/nice_and_hard567.py
@@ -1,6 +1,6 @@
 from ..problem_set import ProblemSet, mark
-from sympy.abc import a,b,c,d,e,f,k,m,n,p,q,r,s,u,v,x,y,z,w
-from sympy import symbols, prod, Rational, Add, Mul, exp, sqrt, cbrt, sin, cos, pi, Abs, Min, Max
+from sympy.abc import a,b,c,d,e,p,q,x,y,z
+from sympy import symbols, Rational, Add, Mul, sqrt, cbrt, Abs
 
 CyclicSum = lambda x, y: Add(*[x.xreplace(
     dict(zip(y,[y[(i+j)%len(y)] for j in range(len(y))]))) for i in range(len(y))])

--- a/triples/benchmarks/problems/books/vasile.py
+++ b/triples/benchmarks/problems/books/vasile.py
@@ -1,6 +1,6 @@
 from ..problem_set import ProblemSet, mark
-from sympy.abc import a,b,c,d,e,f,k,m,n,p,q,r,s,u,v,x,y,z,w
-from sympy import symbols, prod, Rational, Add, Mul, exp, sqrt, cbrt, sin, cos, pi, Abs, Min, Max
+from sympy.abc import a,b,c,d,e,f,k,m,n,x,y,z
+from sympy import symbols, prod, Rational, Add, Mul, exp, sqrt, cbrt, Abs, Min, Max
 
 CyclicSum = lambda x, y: Add(*[x.xreplace(
     dict(zip(y,[y[(i+j)%len(y)] for j in range(len(y))]))) for i in range(len(y))])

--- a/triples/benchmarks/problems/books/vasile.py
+++ b/triples/benchmarks/problems/books/vasile.py
@@ -1889,7 +1889,7 @@ class MathematicalInequalitiesVol2(MathematicalInequalities):
     def problem_vasile_p22088_p3(self):
         p_ = c3s(a)
         q_ = c3s(a*b)
-        w_ = sqrt(p_**2-3*q_)
+        # w_ = sqrt(p_**2-3*q_)
         h_ = sqrt(p_)+sqrt(p_+sqrt(q_))
         return h_ - c3s(sqrt(a+b)), [a,b,c,p_**2-4*q_], []
 

--- a/triples/benchmarks/problems/contests/__init__.py
+++ b/triples/benchmarks/problems/contests/__init__.py
@@ -3,6 +3,6 @@ from .imo import IMOProblems, IMOSLProblems
 
 
 __all__ = [
-    'CMOProblems', 'ChinaHighSchoolMathLeague2', 'CTSTProblems'
+    'CMOProblems', 'ChinaHighSchoolMathLeague2', 'CTSTProblems',
     'IMOProblems', 'IMOSLProblems'
 ]

--- a/triples/benchmarks/problems/contests/chn.py
+++ b/triples/benchmarks/problems/contests/chn.py
@@ -199,7 +199,8 @@ class CMOProblems(ProblemSet):
 
     @mark(mark.skip)
     def problem_CMO_2007_p1(self):
-        A,B,C = (p,q), (u,v), (x,y)
+        A, B = (p, q), (u, v)
+        # C = (x, y)
         AC = (p*x-q*y, q*x+p*y)
         BC = (u*x-v*y, v*x+u*y)
         norm2 = lambda z: (z[0]**2+z[1]**2)
@@ -472,7 +473,6 @@ class ChinaHighSchoolMathLeague2(ProblemSet):
     def problem_CNHSML_2022A2_p3_lb(self):
         """LP"""
         ai = symbols('a1:10')
-        S = Add(*[Min(ai[i],ai[(i+1)%9])*(i+1) for i in range(9)])
         T = Add(*[Max(ai[i],ai[(i+1)%9])*(i+1) for i in range(9)])
         return T - Rational(36,5), ai, [Add(*ai) - 1]
 

--- a/triples/benchmarks/problems/contests/chn.py
+++ b/triples/benchmarks/problems/contests/chn.py
@@ -1,5 +1,5 @@
 from ..problem_set import ProblemSet, mark
-from sympy.abc import a,b,c,d,e,p,q,r,s,u,v,x,y,z,w
+from sympy.abc import a,b,c,d,e,p,q,r,u,v,x,y,z,w
 from sympy import symbols, Rational, Add, Mul, sqrt, cbrt, sin, cos, pi, Abs, Min, Max
 
 class CMOProblems(ProblemSet):

--- a/triples/benchmarks/problems/contests/imo.py
+++ b/triples/benchmarks/problems/contests/imo.py
@@ -1,5 +1,5 @@
 from ..problem_set import ProblemSet, mark
-from sympy.abc import a,b,c,d,e,p,q,r,s,x,y,z
+from sympy.abc import a,b,c,d,e,f,p,q,r,s,x,y,z
 from sympy import symbols, Rational, Add, sqrt, cbrt, sin, pi, Abs, Min, Max
 
 class IMOProblems(ProblemSet):

--- a/triples/benchmarks/problems/contests/imo.py
+++ b/triples/benchmarks/problems/contests/imo.py
@@ -1,6 +1,6 @@
 from ..problem_set import ProblemSet, mark
-from sympy.abc import a,b,c,d,e,p,q,r,s,x,y,z,w
-from sympy import symbols, Rational, Add, sqrt, cbrt, sin, cos, pi, Abs, Min, Max
+from sympy.abc import a,b,c,d,e,p,q,r,s,x,y,z
+from sympy import symbols, Rational, Add, sqrt, cbrt, sin, pi, Abs, Min, Max
 
 class IMOProblems(ProblemSet):
     @mark(mark.noimpl, mark.geom)

--- a/triples/benchmarks/problems/problem_set.py
+++ b/triples/benchmarks/problems/problem_set.py
@@ -1,4 +1,3 @@
-from functools import wraps
 
 class mark:
     """Mark a problem with hints."""
@@ -65,20 +64,20 @@ class ProblemSet:
         to (dense) polynomials and should be solved by operating on the symbolic tree only.
     """
     @classmethod
-    def collect(cls, include=tuple(), exclude=tuple()):
+    def collect(cls, include=(), exclude=()):
         cands = {k: getattr(cls, k) for k in dir(cls) if k.startswith('problem')}
         include = (include,) if isinstance(include, str) else include
         exclude = (exclude,) if isinstance(exclude, str) else exclude
         for m in include:
             dels = []
             for k, v in cands.items():
-                if m not in getattr(v, 'marks', tuple()):
+                if m not in getattr(v, 'marks', ()):
                     dels.append(k)
             [cands.pop(k) for k in dels]
         for m in exclude:
             dels = []
             for k, v in cands.items():
-                if m in getattr(v, 'marks', tuple()):
+                if m in getattr(v, 'marks', ()):
                     dels.append(k)
             [cands.pop(k) for k in dels]
         return cands

--- a/triples/benchmarks/run_benchmark.py
+++ b/triples/benchmarks/run_benchmark.py
@@ -82,6 +82,7 @@ def run_bench(benchmarks=BENCHMARKS, save_interval=0):
     platform_info = _get_platform_info()
 
     from triples import sum_of_squares
+    from triples.benchmarks.problems.problem_set import mark
     from datetime import datetime
     os.makedirs("./.benchmarks", exist_ok=True)
 

--- a/triples/benchmarks/run_benchmark.py
+++ b/triples/benchmarks/run_benchmark.py
@@ -117,7 +117,7 @@ def run_bench(benchmarks=BENCHMARKS, save_interval=0):
         max_problem_name_len = max([len(problem_name) for problem_name in problems.keys()], default=0)
         for i, (problem_name, problem) in enumerate(problems.items(), start=1):
             # (problem_name) (status) (start_time) --- (end_time) [(solved)/(processed)]
-            problem_marks = getattr(problem, 'marks', tuple())
+            problem_marks = getattr(problem, 'marks', ())
             print(problem_name.ljust(max_problem_name_len), end=' ')
             if mark.skip in problem_marks:
                 skipped += 1

--- a/triples/core/complexity.py
+++ b/triples/core/complexity.py
@@ -57,3 +57,5 @@ class ProblemComplexity:
     def __eq__(a, b) -> bool:
         # todo: is it well-defined?
         return a.time == b.time and a.prob == b.prob and a.length == b.length
+    def __hash__(self) -> int:
+        return hash((self.time, self.prob, self.length))

--- a/triples/core/dispatch.py
+++ b/triples/core/dispatch.py
@@ -187,7 +187,7 @@ def _domainelement_convert(x: DomainElement, y: Any) -> DomainElement:
 
 @_dtype_free_symbols.register(PolyElement)
 def _polyelement_free_symbols(x: PolyElement) -> Set[Symbol]:
-    symbols = set([g for g, d in zip(x.ring.gens, x.degrees()) if d > 0])
+    symbols = {g for g, d in zip(x.ring.gens, x.degrees()) if d > 0}
     domain = x.ring.domain
     if domain.is_Composite:
         for gen in domain.symbols:

--- a/triples/core/linsos/basis.py
+++ b/triples/core/linsos/basis.py
@@ -236,6 +236,7 @@ class LinearBasisTangent(LinearBasis):
         quad_diff_order = max(0, min(quad_diff_order, degree - tangent_p.total_degree()))
 
         # 2. get cross(quad_diff) * tangent_p
+        time0 = perf_counter()
         cross_exprs_mul_p, cross_polys_mul_p = _get_cross_exprs_and_polys_of_quad_diff(
             symbols, quad_diff_order, tangent, tangent_p
         )
@@ -380,7 +381,7 @@ def _get_cross_dmps_of_quad_diff(quad_diff_order: int, tangent_dmp: DMP) -> List
 
     # polys are the DMPs of (ai - aj)^2 for all i < j
     polys, lst = [None] * ndiff, [0] * nvars
-    cnt, lev, one, negtwo = 0, nvars - 1, domain.one, domain.one * -2
+    cnt, one, negtwo = 0, domain.one, domain.one * -2
     for i in range(nvars):
         for j in range(i+1, nvars):
             coeffs = {}

--- a/triples/core/linsos/basis.py
+++ b/triples/core/linsos/basis.py
@@ -315,7 +315,7 @@ def quadratic_difference(symbols: Tuple[Symbol, ...]) -> List[Expr]:
     [(a - b)**2, (a - c)**2, (b - c)**2]
     """
     exprs = []
-    symbols = sorted(list(symbols), key=lambda x: x.name)
+    symbols = sorted(symbols, key=lambda x: x.name)
     for i in range(len(symbols)):
         for j in range(i + 1, len(symbols)):
             exprs.append((symbols[i] - symbols[j])**2)
@@ -466,7 +466,7 @@ def _get_cross_exprs_and_polys_of_quad_diff(symbols: Tuple[Symbol, ...],
 
     # Faster implementation
     nvars = len(symbols)
-    # symbols = sorted(list(symbols), key=lambda x: x.name) # sorting makes rep reordered
+    # symbols = sorted(symbols, key=lambda x: x.name) # sorting makes rep reordered
     inds = [(i,j) for i in range(nvars) for j in range(nvars) if i < j]
     powers = generate_partitions([2] * (nvars*(nvars-1)//2), quad_diff_order, descending=False)
 

--- a/triples/core/linsos/correction.py
+++ b/triples/core/linsos/correction.py
@@ -127,7 +127,7 @@ def linear_correction(
                 if _is_Ax_equal_to_b(reduced_arrays, reduced_y, target):
                     is_equal = True
                     y, basis = reduced_y, reduced_basis
-        except Exception as e:
+        except Exception:
             # raise e
             is_equal = False
 
@@ -153,7 +153,7 @@ def LUsolve(A: Matrix, b: Matrix) -> Matrix:
         new_domain = A2.domain.unify(b2.domain).get_field()
         A2 = A2.convert_to(new_domain)
         b2 = b2.convert_to(new_domain)
-    except Exception as e:
+    except Exception:
         A2 = None
     if A2 is None: # fallback to default
         return A.LUsolve(b)
@@ -180,7 +180,7 @@ def _is_Ax_equal_to_b(A: Matrix, x: Matrix, b: Matrix) -> bool:
         A2 = A2.convert_to(new_domain)
         x2 = x2.convert_to(new_domain)
         b2 = b2.convert_to(new_domain)
-    except Exception as e:
+    except Exception:
         A2 = None
 
     if A2 is None: # fallback to default

--- a/triples/core/linsos/lift.py
+++ b/triples/core/linsos/lift.py
@@ -1,4 +1,4 @@
-from typing import Generator, Dict, Tuple, List, Optional
+from typing import Generator, Dict, Tuple, Optional
 
 from sympy import Poly, Expr, Symbol, Mul
 

--- a/triples/core/linsos/lift.py
+++ b/triples/core/linsos/lift.py
@@ -84,7 +84,6 @@ def lift_degree(
             The degree of h(a,b,c).
     """
     n = poly.total_degree()
-    nvars = len(poly.gens)
     symbols = poly.gens
     n_plus = 0
 

--- a/triples/core/linsos/linsos.py
+++ b/triples/core/linsos/linsos.py
@@ -464,7 +464,7 @@ class LinearSOSSolver(ProofNode):
                     print(f"Basis limit {configs['basis_limit']} exceeded. LinearSOS aborted.")
             elif isinstance(e, ArithmeticTimeout):
                 if verbose:
-                    print(f"Arithmetic timeout. LinearSOS aborted.")
+                    print("Arithmetic timeout. LinearSOS aborted.")
                 raise e
             elif isinstance(e, MemoryError):
                 if verbose:

--- a/triples/core/linsos/solution.py
+++ b/triples/core/linsos/solution.py
@@ -108,7 +108,7 @@ def _collect_constraints(
             tangent = base.tangent(symbols)
             has_eq_part = has_eq(tangent)
             if has_eq_part is not None:
-                if not (has_eq_part[0] in eq_part): # not expected to happen
+                if has_eq_part[0] not in eq_part: # not expected to happen
                     eq_part[has_eq_part[0]] = []
                 eq_part[has_eq_part[0]].append(v * has_eq_part[1] * Mul(*[s**p for s, p in zip(symbols, base.powers)]))
             else:

--- a/triples/core/linsos/solution.py
+++ b/triples/core/linsos/solution.py
@@ -359,7 +359,7 @@ def _collect_ineq_constraints(
         if r < 0:
             tangents_and_exprs[i] = (one, tangent * expr) # keep everything unchanged
             continue
-        elif not (r is one):
+        elif r is not one:
             tangents_and_exprs[i] = (Mul(*args), r * expr) # move the constant to expr
 
         factors.update(set(args))

--- a/triples/core/linsos/tangents.py
+++ b/triples/core/linsos/tangents.py
@@ -423,7 +423,7 @@ def prepare_inexact_tangents(
     roots = [r for r in problem.roots if not r.is_zero] if problem.roots is not None else []
     if nvars <= 1 or len(eq_constraints) or monomial_manager.is_symmetric \
             or any(r.is_nontrivial for r in roots):
-        return dict()
+        return {}
 
     # parameters for numerical optimization
     perms = [[1,0] + list(range(2, nvars))] # reflection
@@ -436,11 +436,11 @@ def prepare_inexact_tangents(
         new_roots = numeric_optimize_skew_symmetry(poly, poly.gens, perms, num=5)
         new_roots = [r for r in new_roots if all(ineq(*r) >= 0 for ineq in ineq_constraints)]
         new_roots = [Root(_, domain=RR) for _ in new_roots] # convert to RR
-    except Exception as e: # shall we handle this?
+    except Exception: # shall we handle this?
         pass
 
     if len(new_roots) == 0:
-        return dict()
+        return {}
 
     new_tangents = []
     monomial_base = monomial_manager.base()

--- a/triples/core/linsos/tangents.py
+++ b/triples/core/linsos/tangents.py
@@ -341,7 +341,7 @@ def get_qmodule_list(
         The preordering rule, one of 'none', 'linear', 'quadratic', 'full'.
     """
     _ACCEPTED_PREORDERINGS = ['none', 'linear', 'quadratic', 'full']
-    if not preordering in _ACCEPTED_PREORDERINGS:
+    if preordering not in _ACCEPTED_PREORDERINGS:
         raise ValueError("Invalid preordering method, expected one of %s, received %s." \
                          % (str(_ACCEPTED_PREORDERINGS), preordering))
 

--- a/triples/core/linsos/tangents.py
+++ b/triples/core/linsos/tangents.py
@@ -469,7 +469,7 @@ def prepare_inexact_tangents(
                                  .retract()) for p in vecs])
             break
 
-    new_tangents = dict([(t**2, t.as_expr()**2) for t in new_tangents if t is not None])
+    new_tangents = {t**2: t.as_expr()**2 for t in new_tangents if t is not None}
     # print('New tangents:\n', list(new_tangents.values()))
 
     return new_tangents

--- a/triples/core/node.py
+++ b/triples/core/node.py
@@ -227,7 +227,7 @@ class ProofTree:
     def get_configs(self, node: Union[ProofNode, 'ProofTree']) -> Dict[str, Any]:
         cfg = node.default_configs.copy()
 
-        if not (node is self):
+        if node is not self:
             # compute the time limit dynamically (the remaining time)
             cfg["time_limit"] = min(self._expected_end_time - perf_counter(),
                                     cfg.get("time_limit", float("inf")))

--- a/triples/core/pivoting/quadratic.py
+++ b/triples/core/pivoting/quadratic.py
@@ -78,7 +78,6 @@ class PivotQuadratic(ProofNode):
             return self._explore_state_2(configs)
 
     def _explore_state_0(self, configs):
-        problem = self.problem
         self.state = 1
 
         _info = self._info

--- a/triples/core/preprocess/algebraic.py
+++ b/triples/core/preprocess/algebraic.py
@@ -1,4 +1,3 @@
-from typing import List, Dict, Tuple, Union, Optional
 
 from sympy import Expr, Poly, Rational, Integer, Mul, fraction
 

--- a/triples/core/preprocess/elimination.py
+++ b/triples/core/preprocess/elimination.py
@@ -66,7 +66,7 @@ def _rowwise_primitive(A: Matrix) -> Matrix:
     dom = A._rep.domain
     for row, terms in rows.items():
         prim_terms = dup_primitive(list(terms.values()), dom)[1]
-        rows[row] = {i: v for i, v in zip(terms.keys(), prim_terms)}
+        rows[row] = dict(zip(terms.keys(), prim_terms))
     return Matrix._fromrep(A._rep.from_rep(SDM(rows, A.shape, dom)).convert_to(ZZ))
 
 

--- a/triples/core/preprocess/elimination.py
+++ b/triples/core/preprocess/elimination.py
@@ -54,7 +54,7 @@ def _identify_matrix_symmetry(S: Matrix) -> List[List[int]]:
             cluster_dict[root] = []
         cluster_dict[root].append(i)
 
-    clusters = sorted(list(cluster_dict.values()), key=lambda x: min(x))
+    clusters = sorted(cluster_dict.values(), key=lambda x: min(x))
     return clusters
 
 def _rowwise_primitive(A: Matrix) -> Matrix:

--- a/triples/core/preprocess/elimination.py
+++ b/triples/core/preprocess/elimination.py
@@ -269,7 +269,7 @@ def eliminate_power_constraints(
     }
     # print('transform =', transform, '\ninv_transform =', inv_transform)
 
-    new_eqs = {k: e for i, (k, e) in enumerate(eq_constraints.items()) if not i in eq_inds}
+    new_eqs = {k: e for i, (k, e) in enumerate(eq_constraints.items()) if i not in eq_inds}
     problem = problem.copy_new(problem.expr, ineq_constraints, new_eqs)
 
     problem, restore_transform = problem.transform(transform, inv_transform)

--- a/triples/core/preprocess/modeling.py
+++ b/triples/core/preprocess/modeling.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Tuple, Union, Set, Callable, Optional
+from typing import Dict, Tuple, Union, Set, Callable, Optional
 
 import sympy as sp
 from sympy import (Expr, Poly, Symbol, Rational, Integer,

--- a/triples/core/preprocess/polynomial.py
+++ b/triples/core/preprocess/polynomial.py
@@ -1,10 +1,10 @@
-from typing import List, Dict, Union, Tuple, Callable, Optional
+from typing import List, Dict, Tuple, Callable, Optional
 
-from sympy import Expr, Poly, Integer
+from sympy import Expr, Poly
 
 from .elimination import eliminate_power_constraints
 from ..problem import InequalityProblem
-from ..node import ProofNode, TransformNode
+from ..node import TransformNode
 from ...utils import (
     CyclicSum,
     identify_symmetry_from_lists, verify_symmetry, poly_reduce_by_symmetry
@@ -96,7 +96,7 @@ class SolvePolynomial(TransformNode):
                 return None
             return sqf**2 * power_restore(_restoration(x))
 
-        self.restorations = {c: composed_restoration for c in self.children}
+        self.restorations = dict.fromkeys(self.children, composed_restoration)
 
         if self.state != 0 and len(self.children) == 0:
             # check one more time if there are no children
@@ -194,7 +194,7 @@ def _align_degree(p: Poly, p1: Poly, p2: Poly, accept_odd_degree: bool = False) 
         else:
             terms[d].append((m, c))
     # p = sum(d * polys[d] for d in terms)
-    keys = sorted(list(terms.keys()))
+    keys = sorted(terms.keys())
     for i in range(len(keys)-1):
         if (keys[i+1]-keys[i])%ddiff != 0:
             return None

--- a/triples/core/preprocess/signs.py
+++ b/triples/core/preprocess/signs.py
@@ -1,7 +1,6 @@
 from typing import List, Dict, Tuple, Union, Set, Optional
 
-from sympy import Expr, Poly, Rational, Integer, Add, Mul, Symbol, true
-from sympy.polys.rings import PolyElement
+from sympy import Expr, Poly, Rational, Add, Mul, Symbol, true
 
 from ..problem import InequalityProblem
 from ...utils import CyclicExpr
@@ -552,7 +551,7 @@ def get_symbol_signs(problem: InequalityProblem) -> Dict[Symbol, Tuple[Optional[
                 key = Poly(key, *fs0)
             tar[key] = val
 
-    signs = {i: (None, None) for i in range(len(fs0))}
+    signs = dict.fromkeys(range(len(fs0)), (None, None))
 
     # infer signs from constraints
     signs = _get_signs_by_topological_order(ineqs, eqs, signs)

--- a/triples/core/preprocess/signs.py
+++ b/triples/core/preprocess/signs.py
@@ -129,7 +129,7 @@ def _prove_by_recur(expr: Expr, signs: SIGNS_TYPE) -> Optional[Tuple[Expr, bool]
             nonneg.append(_prove_by_recur(arg, signs))
             if nonneg[-1] is None:
                 return None
-        changed = any([_[1] for _ in nonneg])
+        changed = any(_[1] for _ in nonneg)
         if changed:
             return expr.func(*[_[0] for _ in nonneg]), True
         return expr, False
@@ -388,8 +388,8 @@ def _infer_separable_sign(poly: Poly, expr: Expr, s: int,
     if r_sign == 0: # division by zero
         return None
 
-    absq = Add(*[x for x in qr[0]])
-    absr = Add(*[x for x in qr[1]])
+    absq = Add(*qr[0])
+    absr = Add(*qr[1])
 
     if q_sign != 0:
         # note that we return the absolute value of gens[s]
@@ -461,7 +461,7 @@ def _get_signs_by_topological_order(ineq_constraints: Dict[Poly, Expr], eq_const
             if not _is_separable(p):
                 continue
             pd = p.degree_list()
-            pfs = set([i for i in range(nvars) if pd[i] > 0 and signs[i][0] is None])
+            pfs = {i for i in range(nvars) if pd[i] > 0 and signs[i][0] is None}
             for s in pfs:
                 neighbors[s].add(cons_cnt)
             cons.append((p, e, cmp))

--- a/triples/core/preprocess/tests/test_signs.py
+++ b/triples/core/preprocess/tests/test_signs.py
@@ -1,11 +1,11 @@
-from sympy.abc import a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z
+from sympy.abc import a,b,c,d,e,f,g,h,r,u,v,w,x,y,z
 from sympy import Poly, Function, Rational, fraction
 
 F, G = Function('F'), Function('G')
 
 import pytest
 
-from ..signs import _prove_poly, sign_sos
+from ..signs import _prove_poly
 from ...problem import InequalityProblem
 
 class InferSignProblems:
@@ -165,7 +165,7 @@ def test_prove_poly_by_signs():
         assert proof is not None, f"Case {ind}: failed to establish the nonnegativity of {poly} given {signs}."
 
         # extract nonnegative symbols from "signs"
-        new_signs = {g: (None, None) for g in poly.free_symbols}
+        new_signs = dict.fromkeys(poly.free_symbols, (None, None))
         new_signs.update({e: (1 if s else 0, e) for s, e in signs.values() if s is not None})
 
         valid_proof = _prove_poly(proof.as_poly(), new_signs, factor=need_factor)

--- a/triples/core/problem.py
+++ b/triples/core/problem.py
@@ -786,7 +786,7 @@ class InequalityProblem(Generic[T]):
         dst_dicts = [{}, {}, {}]
         if isinstance(self.expr, Poly):
             new_symbols = tuple(sorted(inv_transform.keys(), key=lambda x:x.name))
-            symbols = tuple([_ for _ in self.expr.gens if (not _ in transform)]) + new_symbols
+            symbols = tuple([_ for _ in self.expr.gens if (_ not in transform)]) + new_symbols
         for src, dst in zip(src_dicts, dst_dicts):
             for p, e in src.items():
                 if isinstance(p, Expr):
@@ -854,7 +854,7 @@ class InequalityProblem(Generic[T]):
 
         gens = self.gens
         changed_gens = [g for g in gens if (g in transform)]
-        other_gens = [g for g in gens if (not g in transform)]
+        other_gens = [g for g in gens if (g not in transform)]
         shift = {g: g + v for g, v in transform.items()}
 
         expr_mul = 1

--- a/triples/core/problem.py
+++ b/triples/core/problem.py
@@ -90,14 +90,14 @@ class InequalityProblem(Generic[T]):
     def __str__(self) -> str:
         ss = [f"[Problem] Prove that:\n    {self.expr} >= 0"]
         if len(self.ineq_constraints):
-            ss.append(f"given inequality constraints:")
+            ss.append("given inequality constraints:")
             for p, e in self.ineq_constraints.items():
                 ss.append(f"    {p} >= 0" + (f"    ({e})" if p.as_expr() != e else ""))
         else:
             ss.append("given no inequality constraints,")
 
         if len(self.eq_constraints):
-            ss.append(f"and equality constraints:")
+            ss.append("and equality constraints:")
             for p, e in self.eq_constraints.items():
                 ss.append(f"    {p} == 0" + (f"    ({e})" if e != 0 and p.as_expr() != e else ""))
         else:
@@ -124,7 +124,7 @@ class InequalityProblem(Generic[T]):
         ands = ["&" if self.REPR_LATEX_ALIGN_AT == i else "" for i in range(4)]
         ss = [f"**Problem** Prove that:\n\n{delim_l}{latex(self.expr)} \\geq 0{delim_r}"]
         if len(self.ineq_constraints):
-            ss.append(f"given inequality constraints:")
+            ss.append("given inequality constraints:")
             ss.append(delim_l + "\\begin{aligned}" + "\\\\\n ".join([
                 f"{ands[0]} {latex(p)} {ands[1]}\\geq 0" + \
                         (f"{ands[2]} \\qquad {ands[3]} ({latex(e)})" if p.as_expr() != e else "")
@@ -134,7 +134,7 @@ class InequalityProblem(Generic[T]):
             ss.append("given no inequality constraints,")
 
         if len(self.eq_constraints):
-            ss.append(f"and equality constraints:")
+            ss.append("and equality constraints:")
             ss.append(delim_l + "\\begin{aligned}" + "\\\\\n ".join([
                 f"{ands[0]} {latex(p)} {ands[1]}= 0" + \
                         (f"{ands[2]} \\qquad {ands[3]} ({latex(e)})" if p.as_expr() != e else "")
@@ -281,7 +281,7 @@ class InequalityProblem(Generic[T]):
         """
         poly_gens = self._dtype_gens(self.expr)
         other_syms = self.free_symbols - set(poly_gens)
-        other_syms = sorted(list(other_syms), key=lambda x: x.name)
+        other_syms = sorted(other_syms, key=lambda x: x.name)
         return poly_gens + tuple(other_syms)
 
     def extract_constraints(self, symbols: Union[Symbol, List[Symbol]]) \
@@ -785,7 +785,7 @@ class InequalityProblem(Generic[T]):
         src_dicts = [{self.expr: Integer(1)}, self.ineq_constraints, self.eq_constraints]
         dst_dicts = [{}, {}, {}]
         if isinstance(self.expr, Poly):
-            new_symbols = tuple(sorted(list(inv_transform.keys()), key=lambda x:x.name))
+            new_symbols = tuple(sorted(inv_transform.keys(), key=lambda x:x.name))
             symbols = tuple([_ for _ in self.expr.gens if (not _ in transform)]) + new_symbols
         for src, dst in zip(src_dicts, dst_dicts):
             for p, e in src.items():
@@ -936,8 +936,8 @@ def _get_constraints_wrapper(
         return max(digits, default=-1) + 1
 
     def _get_dicts(constraints, name='_G', counter=None):
-        dt = dict()
-        inv = dict()
+        dt = {}
+        inv = {}
         # rep_dict = dict((p, v) for p, v in constraints.items())
         rep_dict = constraints
         if counter is None:

--- a/triples/core/problem.py
+++ b/triples/core/problem.py
@@ -69,8 +69,8 @@ class InequalityProblem(Generic[T]):
             ineq_constraints = {e: e for e in ineq_constraints}
         if not isinstance(eq_constraints, dict):
             eq_constraints = {e: e for e in eq_constraints}
-        ineq_constraints = dict((_try_sympify(e), _try_sympify(e2).as_expr()) for e, e2 in ineq_constraints.items())
-        eq_constraints = dict((_try_sympify(e), _try_sympify(e2).as_expr()) for e, e2 in eq_constraints.items())
+        ineq_constraints = {_try_sympify(e): _try_sympify(e2).as_expr() for e, e2 in ineq_constraints.items()}
+        eq_constraints = {_try_sympify(e): _try_sympify(e2).as_expr() for e, e2 in eq_constraints.items()}
 
         return cls.new(expr, ineq_constraints, eq_constraints)
 
@@ -400,8 +400,8 @@ class InequalityProblem(Generic[T]):
             return Poly(expr.doit(), *gens, extension=extension)
 
         expr = as_poly(expr)
-        ineq_constraints = dict((as_poly(e), e2) for e, e2 in ineq_constraints.items())
-        eq_constraints = dict((as_poly(e), e2) for e, e2 in eq_constraints.items())
+        ineq_constraints = {as_poly(e): e2 for e, e2 in ineq_constraints.items()}
+        eq_constraints = {as_poly(e): e2 for e, e2 in eq_constraints.items()}
 
         problem = InequalityProblem(expr, ineq_constraints, eq_constraints)
         problem, _ = problem.sqr_free(problem_sqf=False,
@@ -547,13 +547,13 @@ class InequalityProblem(Generic[T]):
         if ineqs_sqf:
             ineq_constraints = dict(self._dtype_std_ineq_constraints(*item)
                 for item in ineq_constraints.items())
-        self.ineq_constraints = dict((e, e2) for e, e2 in ineq_constraints.items())
+        self.ineq_constraints = dict(ineq_constraints.items())
 
         eq_constraints = self.eq_constraints
         if eqs_sqf:
             eq_constraints = dict(self._dtype_std_eq_constraints(*item)
                 for item in eq_constraints.items())
-        self.eq_constraints = dict((e, e2) for e, e2 in eq_constraints.items())
+        self.eq_constraints = dict(eq_constraints.items())
         return self, sqr
 
     def recompute_constraints(
@@ -928,7 +928,7 @@ def _get_constraints_wrapper(
     def _get_counter(name='_G'):
         # avoid duplicate function counters
         k = len(name)
-        exprs = [e for e in ineq_constraints.values()] + [e for e in eq_constraints.values()]
+        exprs = list(ineq_constraints) + list(eq_constraints.values())
         names = [[f.name for f in e.find(AppliedUndef)] for e in exprs]
         names = [item for sublist in names for item in sublist]
         names = [n[k:] for n in names if n.startswith(name)]

--- a/triples/core/sdpsos/abstract.py
+++ b/triples/core/sdpsos/abstract.py
@@ -304,7 +304,7 @@ class AtomSOSElement(SOSElement):
             rhs = arraylize(self.poly)
             return rhs, Matrix.zeros(rhs.shape[0], 0)
 
-        domain, gens = self.poly.domain, self.poly.gens
+        gens = self.poly.gens
         poly = self.poly.as_poly(*parameters)
         if poly.total_degree() > 1:
             raise ValueError(f"Unable to handle nonlinear terms {poly.LM()} in the polynomial."

--- a/triples/core/sdpsos/abstract.py
+++ b/triples/core/sdpsos/abstract.py
@@ -9,7 +9,7 @@ from sympy.core.relational import Relational
 
 from .algebra import StateAlgebra, SOSBasis
 from ...sdp import SDPProblem
-from ...sdp.arithmetic import ArithmeticTimeout, sqrtsize_of_mat, matmul, matadd, solve_csr_linear, rep_matrix_from_dict
+from ...sdp.arithmetic import ArithmeticTimeout, sqrtsize_of_mat, matmul, matadd, rep_matrix_from_dict
 from ...sdp.utils import exprs_to_arrays, collect_constraints
 from ...sdp.wedderburn import symmetry_adapted_basis
 

--- a/triples/core/sdpsos/algebra/basis.py
+++ b/triples/core/sdpsos/algebra/basis.py
@@ -4,7 +4,6 @@ from typing import List, Tuple, Dict, Any, Callable, Optional
 from sympy import Expr, Poly, Domain
 from sympy.matrices import MutableDenseMatrix as Matrix
 from sympy.combinatorics import PermutationGroup, Permutation
-from scipy.sparse import csr_matrix
 
 from .state_algebra import StateAlgebra, MONOM, TERM
 from ....sdp.arithmetic import rep_matrix_from_dict

--- a/triples/core/sdpsos/algebra/basis.py
+++ b/triples/core/sdpsos/algebra/basis.py
@@ -104,7 +104,7 @@ class QmoduleBasis(SOSBasis):
         algebra = self.algebra
         qmodule = algebra.terms(self.qmodule.set_domain(domain))
         one, zero = domain.one, domain.zero
-        mul, state, adjoint, index = algebra.mul, algebra.s, algebra.adjoint, algebra.index
+        mul, state, _, index = algebra.mul, algebra.s, algebra.adjoint, algebra.index
         basis = self._basis
         def _mapping(i, j):
             vec = defaultdict(lambda : zero)
@@ -128,7 +128,7 @@ class QmoduleBasis(SOSBasis):
         N, n = len(self.algebra), len(self)
 
         if isinstance(domain, Domain):
-            rows = defaultdict(lambda : dict())
+            rows = defaultdict(lambda : {})
             if self.is_commutative:
                 for i in range(n):
                     for t, v in mapping(i, i).items():
@@ -165,7 +165,7 @@ class QmoduleBasis(SOSBasis):
                     continue
 
                 m2 = basis[j]
-                s = set((i*n+j, j*n+i))
+                s = {i*n+j, j*n+i}
                 for p in symmetry.elements:
                     m3, m4 = pm(m1, p), pm(m2, p)
                     i2, j2 = dict_basis.get(m3), dict_basis.get(m4)
@@ -211,7 +211,7 @@ class IdealBasis(SOSBasis):
         algebra = self.algebra
         ideal = algebra.terms(self.ideal.set_domain(domain))
         one, zero = domain.one, domain.zero
-        mul, state, adjoint, index = algebra.mul, algebra.s, algebra.adjoint, algebra.index
+        mul, state, _, index = algebra.mul, algebra.s, algebra.adjoint, algebra.index
         basis = self._basis
         def _mapping(i):
             vec = defaultdict(lambda : zero)
@@ -230,7 +230,7 @@ class IdealBasis(SOSBasis):
         N, n = len(self.algebra), len(self)
 
         if isinstance(domain, Domain):
-            rows = defaultdict(lambda : dict())
+            rows = defaultdict(lambda : {})
             for i in range(n):
                 for t, v in mapping(i).items():
                     rows[t][i] = v

--- a/triples/core/sdpsos/algebra/moment_algebra.py
+++ b/triples/core/sdpsos/algebra/moment_algebra.py
@@ -1,7 +1,7 @@
 from itertools import combinations
-from typing import List, Dict, Any, Optional, Callable
+from typing import Dict, Any, Optional, Callable
 
-from sympy import Expr, Poly, Symbol, Add, Mul
+from sympy import Expr, Poly, Add, Mul
 
 from .state_algebra import CommutativeStateAlgebra, TERM, MONOM
 from .basis import QmoduleBasis, IdealBasis

--- a/triples/core/sdpsos/algebra/nc_poly_ring.py
+++ b/triples/core/sdpsos/algebra/nc_poly_ring.py
@@ -62,7 +62,7 @@ class NCPolyRing(StateAlgebra):
 
     def gen_monom(self, i: Optional[int]) -> MONOM:
         if i is None:
-            return tuple()
+            return ()
         return ((i, 1),)
 
     def total_degree(self, monom: MONOM) -> int:

--- a/triples/core/sdpsos/algebra/pseudo_poly.py
+++ b/triples/core/sdpsos/algebra/pseudo_poly.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from typing import List, Any
 
-from sympy import Basic, Poly, Expr, Symbol, Add, Mul, Integer, sympify
+from sympy import Basic, Poly, Expr, Symbol, Integer, sympify
 from sympy.polys.constructor import construct_domain
 from sympy.matrices.expressions import MatPow
 from sympy.combinatorics.permutations import Permutation

--- a/triples/core/sdpsos/manifold.py
+++ b/triples/core/sdpsos/manifold.py
@@ -89,7 +89,7 @@ class _bilinear():
     def __init__(self, terms: Dict[Tuple[int, ...], set]):
         self.terms = terms
         for m in terms:
-            terms[m] = set(map(lambda uv: self._reg(*uv), terms[m]))
+            terms[m] = {self._reg(*uv) for uv in terms[m]}
 
     def diff(self, i: int) -> '_bilinear':
         def increase_tuple(t, i, v):

--- a/triples/core/sdpsos/manifold.py
+++ b/triples/core/sdpsos/manifold.py
@@ -4,7 +4,6 @@ for SDP via computing the equality cases of the original SOS problem.
 """
 from collections import defaultdict, deque
 from itertools import product
-from time import perf_counter
 from typing import Dict, List, Tuple, Union, Optional, Callable, Any
 
 from sympy import Poly, prod
@@ -12,9 +11,8 @@ from sympy.matrices import MutableDenseMatrix as Matrix
 from sympy.combinatorics import PermutationGroup
 
 from .algebra import SOSBasis
-from ...sdp import SDPProblem
 from ...sdp.arithmetic import ArithmeticTimeout, solve_columnspace, rep_matrix_from_list
-from ...utils import optimize_poly, Root, MonomialManager
+from ...utils import Root, MonomialManager
 from ...utils.roots.roots import _algebraic_extension, _derv
 
 
@@ -311,7 +309,7 @@ def _findroot_binary(poly: Poly, symmetry: PermutationGroup = None) -> List[Root
     return roots
 
 
-def get_nullspace(
+def get_sos_nullspace(
     poly: Poly,
     ineq_constraints: Dict[Any, Poly],
     eq_constraints: Dict[Any, Poly],
@@ -358,72 +356,21 @@ def get_nullspace(
     return nullspaces
 
 
-
-def constrain_root_nullspace(
-    sdp: SDPProblem,
-    poly: Poly,
-    ineq_constraints: Dict,
-    eq_constraints: Dict,
-    ineq_bases: Dict[Any, Any],
-    eq_bases: Dict[Any, Any],
-    degree: int,
-    *,
-    roots: Optional[List[Root]]=None,
-    symmetry: Optional[PermutationGroup]=None,
-    verbose: bool = False,
-    time_limit: Optional[Union[Callable, float]]=None
-) -> Tuple[SDPProblem, List[Root]]:
+def complete_constraints_by_symmetry(polys: List[Poly], symmetry=None):
     """
-    Internal helper function to constrain the nullspace of the SDP problem. It will be called
-    in `SOSProblem.construct`.
+    Complete the constraints in the orbit of the symmetry group.
+    Returns a list of polynomials.
     """
-    def _symmetry_expand(polys):
-        """Add in the permuted polynomoials given a symmetry group."""
-        if symmetry is None or len(polys) == 0 or symmetry.is_trivial:
-            return list(polys)
-        rep_set = set()
-        polylize, gens = polys[0].__class__.new, polys[0].gens
-        for poly in polys:
-            rep = poly.rep
-            rep_set.add(rep)
-            for perm in symmetry.elements:
-                reorder = poly.reorder(*perm(gens)).rep
-                if rep == reorder:
-                    continue
-                rep_set.add(reorder)
-        return [polylize(rep, *gens) for rep in rep_set]
-
-    time_limit = ArithmeticTimeout.make_checker(time_limit)
-    time0 = perf_counter()
-    if roots is None:
-        # find roots automatically
-        all_polys = list(ineq_constraints.values()) + list(eq_constraints.values()) + [poly]
-        if all(p.domain.is_ZZ or p.domain.is_QQ for p in all_polys):
-            ineqs = _symmetry_expand(list(ineq_constraints.values()))
-            eqs   = _symmetry_expand(list(eq_constraints.values()))
-            roots = optimize_poly(poly, ineqs, eqs + [poly], return_type='root')
-            time_limit()
-        else:
-            # TODO: clean this
-            roots = _findroot_binary(poly)# symmetry=self._symmetry)
-        if verbose:
-            print(f"Time for finding roots num = {len(roots):<6d}     : {perf_counter() - time0:.6f} seconds.")
-            time0 = perf_counter()
-    else:
-        roots = [Root(_) if not isinstance(_, Root) else _ for _ in roots]
-    time_limit()
-
-    time0 = perf_counter()
-    nullspaces = get_nullspace(poly, ineq_constraints, eq_constraints, ineq_bases, eq_bases,
-                        degree=degree, roots=roots)
-    if verbose:
-        print(f"Time for computing nullspace            : {perf_counter() - time0:.6f} seconds.")
-        time0 = perf_counter()
-
-    new_sdp = sdp.constrain_nullspace(nullspaces, to_child=True, time_limit=time_limit)
-
-    if verbose:
-        print(f"Time for constraining nullspace         : {perf_counter() - time0:.6f} seconds. Dof = {sdp.get_last_child().dof}")
-        time0 = perf_counter()
-
-    return new_sdp, roots
+    if symmetry is None or len(polys) == 0 or symmetry.is_trivial:
+        return list(polys)
+    rep_set = set()
+    polylize, gens = polys[0].__class__.new, polys[0].gens
+    for poly in polys:
+        rep = poly.rep
+        rep_set.add(rep)
+        for perm in symmetry.elements:
+            reorder = poly.reorder(*perm(gens)).rep
+            if rep == reorder:
+                continue
+            rep_set.add(reorder)
+    return [polylize(rep, *gens) for rep in rep_set]

--- a/triples/core/sdpsos/sdpsos.py
+++ b/triples/core/sdpsos/sdpsos.py
@@ -344,7 +344,7 @@ class SDPSOSSolver(ProofNode):
             time0 = perf_counter()
             self._constrain_poly_qmodule(sos, len(qmodule), len(poly_qmodule))
             if configs["verbose"]:
-                print(f"Time to constrain poly_qmodule          :"\
+                print("Time to constrain poly_qmodule          :"\
                       + f" {perf_counter() - time0:.6f} seconds. Dof = {sos.sdpp.dof}")
 
         return sos

--- a/triples/core/sdpsos/sdpsos.py
+++ b/triples/core/sdpsos/sdpsos.py
@@ -81,7 +81,7 @@ def _get_qmodule_list(
     Generate the (generators of the) qmodule for the given problem.
     """
     _ACCEPTED_PREORDERINGS = ['none', 'linear', 'linear-progressive']
-    if not preordering in _ACCEPTED_PREORDERINGS:
+    if preordering not in _ACCEPTED_PREORDERINGS:
         raise ValueError("Invalid preordering method, expected one of %s, received %s." % (str(_ACCEPTED_PREORDERINGS), preordering))
 
     if degree is None:

--- a/triples/core/sdpsos/sdpsos.py
+++ b/triples/core/sdpsos/sdpsos.py
@@ -328,7 +328,7 @@ class SDPSOSSolver(ProofNode):
                 qmodule = qmodule + poly_qmodule, ideal = ideal,
                 symmetry = symmetry.perm_group, roots = roots, degree=degree
             )
-        sdp = sos.construct(
+        sos.construct(
             wedderburn=configs['wedderburn'],
             verbose=configs['verbose'],
             time_limit=configs['expected_end_time'] - perf_counter()
@@ -410,7 +410,7 @@ class SDPSOSSolver(ProofNode):
 
         problem = self._wrapped_problem[0]
         poly = problem.expr
-        ineq_constraints = problem.ineq_constraints
+        # ineq_constraints = problem.ineq_constraints
         eq_constraints = problem.eq_constraints
 
         verbose = configs["verbose"]

--- a/triples/core/sdpsos/sohs.py
+++ b/triples/core/sdpsos/sohs.py
@@ -6,7 +6,6 @@ from .abstract import AtomSOSElement
 from .algebra import NCPolyRing
 from .solution import SolutionSDP
 
-from ...utils import CyclicSum
 
 def DEFAULT_ADJOINT(x):
     if x.is_Mul:

--- a/triples/core/sdpsos/solution.py
+++ b/triples/core/sdpsos/solution.py
@@ -93,7 +93,7 @@ def _get_ideal_expr(
         vec = _as_expr(_invarraylize(ideal_bases[key], vec, gens), state_operator=state_operator)
         ideal_exprs.append(vec * expr.together())
     if state_operator is not None:
-        ideal_exprs = map(lambda x: state_operator(x), ideal_exprs)
+        ideal_exprs = [state_operator(x) for x in ideal_exprs]
     return Add(*ideal_exprs)
 
 def _get_qmodule_expr(

--- a/triples/core/sdpsos/sos.py
+++ b/triples/core/sdpsos/sos.py
@@ -250,6 +250,8 @@ class SOSPoly(AtomSOSElement):
         time_limit = ArithmeticTimeout.make_checker(time_limit)
         if roots is None:
             roots = self.find_roots(verbose=verbose, time_limit=time_limit)
+        else:
+            roots = [Root(r) for r in roots]
 
         insert_prefix = lambda d: {(self, k): v for k, v in d.items()}
 

--- a/triples/core/sdpsos/sos.py
+++ b/triples/core/sdpsos/sos.py
@@ -1,12 +1,14 @@
 from typing import List, Tuple, Dict, Union, Optional, Callable, Any
 # from warnings import warn
+from time import perf_counter
 
 from sympy import Poly, Expr, Symbol
 from sympy.combinatorics import PermutationGroup
+from sympy import MutableDenseMatrix as Matrix
 
 from .algebra import PolyRing
 from .abstract import AtomSOSElement, ArithmeticTimeout
-from .manifold import constrain_root_nullspace
+from .manifold import get_sos_nullspace, complete_constraints_by_symmetry
 from .solution import SolutionSDP
 from ...utils import CyclicSum, Root
 
@@ -203,6 +205,71 @@ class SOSPoly(AtomSOSElement):
 
         self.roots = roots
 
+    def find_roots(self,
+        verbose: bool = False,
+        time_limit: Optional[Union[Callable, float]] = None
+    ) -> List[Root]:
+        """
+        Heuristically find the roots of the problem. See
+        more details in the documentation of `optimize_poly`.
+        """
+        if self.roots is not None:
+            self.roots = [Root(r) if not isinstance(r, Root) else r for r in self.roots]
+            return self.roots
+        time_limit = ArithmeticTimeout.make_checker(time_limit)
+        time0 = perf_counter()
+
+        from ...utils.roots import optimize_poly
+        poly = self.poly
+        symmetry = self.algebra.symmetry
+        ineqs = list(self._qmodule.values())
+        eqs = list(self._ideal.values())
+        all_polys = ineqs + eqs + [poly]
+        roots = []
+        if all(p.domain.is_ZZ or p.domain.is_QQ for p in all_polys):
+            ineqs = complete_constraints_by_symmetry(ineqs, symmetry)
+            eqs   = complete_constraints_by_symmetry(eqs, symmetry)
+            roots = optimize_poly(poly, ineqs, eqs + [poly], return_type='root')
+            time_limit()
+        # else:
+        #     roots = _findroot_binary(poly)# symmetry=self._symmetry)
+        if verbose:
+            print(f"Time for finding roots num = {len(roots):<6d}     : {perf_counter() - time0:.6f} seconds.")
+            time0 = perf_counter()
+        self.roots = roots
+        return roots
+
+    def get_nullspace(self,
+        roots: Optional[List[Root]] = None,
+        verbose: bool = False,
+        time_limit: Optional[Union[Callable, float]] = None
+    ) -> Dict[Any, Matrix]:
+        """
+        Compute the nullspaces of the matrices from the equality cases.
+        """
+        time_limit = ArithmeticTimeout.make_checker(time_limit)
+        if roots is None:
+            roots = self.find_roots(verbose=verbose, time_limit=time_limit)
+
+        insert_prefix = lambda d: {(self, k): v for k, v in d.items()}
+
+        time0 = perf_counter()
+        ns = get_sos_nullspace(
+            self.poly,
+            insert_prefix(self._qmodule),
+            insert_prefix(self._ideal),
+            ineq_bases=insert_prefix(self._qmodule_bases),
+            eq_bases=insert_prefix(self._ideal_bases),
+            degree=self.algebra.degree,
+            roots=roots,
+            perm_group=self.algebra.symmetry,
+            time_limit=time_limit
+        )
+        if verbose:
+            print(f"Time for computing nullspace            : {perf_counter() - time0:.6f} seconds.")
+            time0 = perf_counter()
+        return ns
+
     def _post_construct(self,
         wedderburn: bool = True,
         verbose: bool = False,
@@ -219,22 +286,17 @@ class SOSPoly(AtomSOSElement):
             **kwargs
         )
 
-        insert_prefix = lambda d: {(self, k): v for k, v in d.items()}
+        ns = self.get_nullspace(verbose=verbose, time_limit=time_limit)
 
-        _, roots = constrain_root_nullspace(
-            self.sdp,
-            self.poly,
-            insert_prefix(self._qmodule),
-            insert_prefix(self._ideal),
-            ineq_bases=insert_prefix(self._qmodule_bases),
-            eq_bases=insert_prefix(self._ideal_bases),
-            degree=self.algebra.degree,
-            roots=self.roots,
-            symmetry=self.algebra.symmetry,
-            verbose=verbose,
-            time_limit=time_limit
-        )
-        self.roots = roots
+        time0 = perf_counter()
+        new_sdp = self.sdp.constrain_nullspace(ns, to_child=True, time_limit=time_limit)
+
+        if verbose:
+            print(f"Time for constraining nullspace         : {perf_counter() - time0:.6f} seconds."
+                   f" Dof = {self.sdp.get_last_child().dof}")
+
+        return new_sdp
+
 
     def as_solution(
         self,

--- a/triples/core/sdpsos/tests/test_sos_obj.py
+++ b/triples/core/sdpsos/tests/test_sos_obj.py
@@ -1,4 +1,4 @@
-from sympy.abc import a, b, c, d, x, y, t
+from sympy.abc import a, b, c, t
 from sympy.combinatorics import SymmetricGroup
 
 import pytest

--- a/triples/core/sdpsos/tests/test_sos_obj.py
+++ b/triples/core/sdpsos/tests/test_sos_obj.py
@@ -38,6 +38,6 @@ class SOSObjProblems:
     ids=SOSObjProblems.collect().keys())
 def test_sos_obj(problem, tol=1e-5):
     sdp, obj, constraints, val = problem()
-    y = sdp.solve_obj(obj, constraints=constraints)
+    sdp.solve_obj(obj, constraints=constraints)
     val2 = obj.xreplace(sdp.as_params())
     assert abs(val - val2) < tol

--- a/triples/core/shared.py
+++ b/triples/core/shared.py
@@ -6,7 +6,7 @@ warn("This file is deprecated. Do not use it.",
      DeprecationWarning,
      stacklevel=2)
 
-from typing import Tuple, Dict, List, Union, Optional
+from typing import Tuple, List, Union, Optional
 
 import sympy as sp
 from sympy import Poly, Expr, Symbol

--- a/triples/core/solution.py
+++ b/triples/core/solution.py
@@ -59,8 +59,8 @@ class Solution(SolutionBase[T]):
     ):
 
         if not isinstance(problem, InequalityProblem):
-            ineq_constraints = ineq_constraints if ineq_constraints is not None else dict()
-            eq_constraints = eq_constraints if eq_constraints is not None else dict()
+            ineq_constraints = ineq_constraints if ineq_constraints is not None else {}
+            eq_constraints = eq_constraints if eq_constraints is not None else {}
             problem = InequalityProblem(problem, ineq_constraints, eq_constraints)
             problem.solution = solution
         else:
@@ -551,7 +551,7 @@ class Solution(SolutionBase[T]):
             if len(cyc_exprs) <= 1:
                 return self
 
-            perms = set([_.args[1:] for _ in cyc_exprs])
+            perms = {_.args[1:] for _ in cyc_exprs}
             if len(perms) == 1:
                 return self
 

--- a/triples/core/structsos/__init__.py
+++ b/triples/core/structsos/__init__.py
@@ -3,6 +3,6 @@ from .univariate import prove_univariate
 from .solution import SolutionStructural
 
 __all__ = [
-    'StructuralSOS', 'StructuralSOSSolver',
+    'StructuralSOS', 'StructuralSOSSolver', '_structural_sos',
     'prove_univariate', 'SolutionStructural'
 ]

--- a/triples/core/structsos/constrained/acute.py
+++ b/triples/core/structsos/constrained/acute.py
@@ -257,7 +257,7 @@ def _constrained_acute_quartic(coeff: Coeff, F):
     Note: s((b2+c2-a2)(a-b)(a-c))*s((2a+b+c)(a-b)(a-c)) = s((2a+b+c)(b2+c2-a2)(a-b)2(a-c)2)
     """
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     # 1. Write it in the form of s((b^2+c^2-a^2)*quadratic)
     c400, c310, c220, c301, c211 = [coeff(_) for _ in [(4,0,0), (3,1,0), (2,2,0), (3,0,1), (2,1,1)]]

--- a/triples/core/structsos/constrained/acute.py
+++ b/triples/core/structsos/constrained/acute.py
@@ -1,4 +1,4 @@
-from sympy import Poly, Symbol, Function, Integer, Rational, Add, sqrt
+from sympy import Poly, Function, Integer, Add, sqrt
 from sympy.polys.polyerrors import CoercionFailed
 
 from ..solution import SolutionStructural
@@ -9,7 +9,7 @@ from ..ternary import (
 )
 from ..ternary.dense_symmetric import sym_axis, _homogenize_sym_proof
 from ..utils import (
-    Coeff, uniquely_named_symbol, rationalize_func, congruence
+    Coeff, uniquely_named_symbol, rationalize_func
 )
 from ..univariate import prove_univariate
 

--- a/triples/core/structsos/constrained/linear.py
+++ b/triples/core/structsos/constrained/linear.py
@@ -1,4 +1,4 @@
-from sympy import Poly, Dummy, Integer
+from sympy import Poly, Integer
 from sympy.core.symbol import uniquely_named_symbol
 
 def _eliminate_linear_ineq(poly, var, ineq_constraints, eq_constraints):

--- a/triples/core/structsos/constrained/linear.py
+++ b/triples/core/structsos/constrained/linear.py
@@ -7,7 +7,6 @@ def _eliminate_linear_ineq(poly, var, ineq_constraints, eq_constraints):
     and (f, g, None, 0) if the sign of f cannot be determined.
     NOTE: fsol == f, but in a sum-of-squares form.
     """
-    gens = list(poly.gens)
     k = poly.diff(var).subs(var, 0)
     b = poly.subs(var, 0)
 

--- a/triples/core/structsos/constrained/solver.py
+++ b/triples/core/structsos/constrained/solver.py
@@ -6,7 +6,6 @@ from .linear import elimination_linear
 from .acute import constrained_acute
 
 
-from ..utils import clear_free_symbols, has_gen
 
 _SOLVERS = [
     constrained_acute

--- a/triples/core/structsos/nvars/quadratic.py
+++ b/triples/core/structsos/nvars/quadratic.py
@@ -93,7 +93,7 @@ def _identify_matrix_symmetry(S: Matrix) -> List[List[int]]:
             cluster_dict[root] = []
         cluster_dict[root].append(i)
 
-    clusters = sorted(list(cluster_dict.values()), key=lambda x: x[0])
+    clusters = sorted(cluster_dict.values(), key=lambda x: x[0])
     return clusters
 
 def _isotopic_decomposition(S: Matrix, clusters: List[List[int]]):

--- a/triples/core/structsos/quaternary/__init__.py
+++ b/triples/core/structsos/quaternary/__init__.py
@@ -3,4 +3,8 @@ from .quartic import quaternary_quartic
 
 from .solver import structural_sos_4vars
 
-__all__ = ['structural_sos_4vars']
+__all__ = [
+    'quaternary_cubic_symmetric',
+    'quaternary_quartic',
+    'structural_sos_4vars'
+]

--- a/triples/core/structsos/quaternary/dense_symmetric.py
+++ b/triples/core/structsos/quaternary/dense_symmetric.py
@@ -206,12 +206,14 @@ def _quaternary_dense_symmetric_vanish2_liftfree(coeff: Coeff, sym=None):
     that
     `(d-a)*(d-c)*(b-a)*(b-c) + (c-a)*(c-d)*(b-a)*(b-d) = (a-b)**2*(c-d)**2`
 
-    
+
     Examples
     --------
     :: sym = "sym"
 
     => s(1/4a4b4-a4b3c+1/2a4b2c2+a3b3cd-a3b2c2d+1/4a2b2c2d2)
+
+    => s(a2b3(a-b)2(c-d)2)
 
     => s(a6b4c2+a6b4cd-a6b3c3-a6b2c2d2+a5b5c2+a5b5cd-4a5b4c2d-2a5b3c3d+2a5b3c2d2-a4b4c4+2a4b4c3d+a4b4c2d2-a4b3c3d2+a3b3c3d3)
     """

--- a/triples/core/structsos/quaternary/dense_symmetric.py
+++ b/triples/core/structsos/quaternary/dense_symmetric.py
@@ -13,9 +13,9 @@ def _sym_sum_poly(poly: Poly) -> Poly:
     return invarraylize(rep, poly.gens, degree=poly.total_degree(), sym=True)
 
 
-def _lift_sym_axis_to_D4(
+def _lift_sym_axis_to_D4_part1(
     poly: Poly,
-    gens: Tuple[Symbol, Symbol, Symbol, Symbol],
+    gens: Tuple[Symbol, Symbol],
     degree: int
 ) -> Optional[Poly]:
     """
@@ -33,9 +33,6 @@ def _lift_sym_axis_to_D4(
             continue
         d_rem = degree - n - m
         if d_rem * 2 > degree:
-            continue
-        if n == m and d_rem == n + m:
-            # this should be handled separately
             continue
         if d_rem % 2 != 0:
             v = v/2
@@ -55,15 +52,61 @@ def _lift_sym_axis_to_D4(
     for a in D4:
         q.update({mp(k, a): v for k, v in q.items()})
 
-    if degree % 4 == 0:
-        # determine the coeff of (d/4, d/4, d/4, d/4) by the relation
+    if degree % 2 == 0:
+        # determine the coeff of (r, s, r, s) by the relation
         # poly(1,1) == q(1,1,1,1)
+        r, s = (degree + 2)//4, degree//4
         const = sum(poly.rep.coeffs()) if not poly.is_zero else poly.domain.zero
+        q[(r, s, r, s)] = poly.domain.zero
+        q[(s, r, s, r)] = poly.domain.zero
         const2 = sum(q.values()) if q else poly.domain.zero
-        q[(degree//4,)*4] = const - const2
+        q[(r, s, r, s)] = (const - const2)/2
+        q[(s, r, s, r)] += (const - const2)/2
 
-    q2 = Poly(q, gens, domain=poly.domain)
+
+    q2 = Poly(q, poly.gens + gens, domain=poly.domain)
     return q2
+
+def _lift_sym_axis_to_D4(
+    poly: Poly,
+    gens: Tuple[Symbol, Symbol],
+    degree: int,
+    mod_poly: Optional[Poly] = None
+):
+    """
+    Given a nonhomogeneous f(a,b) such that `f(a,b) == f(b,a)`,
+    compute a homogeneous g(a,b,c,d) so that
+    `f(a,b) == g(a,b,1,1)` and `g(a,b,c,d)` is D4-symmetric
+    (assuming g exists).
+
+    The conversion is not unique so we only return one of them
+    by employing a linear-time algorithm.
+    """
+    if mod_poly is None:
+        mod_poly = _lift_sym_axis_to_D4_part1(poly, gens, degree)
+
+    a, b = poly.gens
+    c, d = gens
+    rest, _ = (poly - mod_poly.eval(3,1).eval(2,1)).div((a-b).as_poly(a,b)**2)
+
+    dt = {}
+    for (m, n), v in rest.rep.terms():
+        if m < n:
+            continue
+        r, s = (degree - m - n + 1 - 2)//2, (degree - m - n - 2)//2
+        if r != s:
+            v = v/2
+        dt[(m, n, r, s)] = v
+        dt[(n, m, r, s)] = v
+        dt[(m, n, s, r)] = v
+        dt[(n, m, s, r)] = v
+
+    all_gens = (a, b, c, d)
+    rest1 = (a-b).as_poly(all_gens)**2 * Poly(dt, all_gens, domain=poly.domain)
+    dt2 = {(r, s, m, n): v for (m, n, r, s), v in dt.items()}
+    rest2 = (c-d).as_poly(all_gens)**2 * Poly(dt2, all_gens, domain=poly.domain)
+
+    return mod_poly + rest1 + rest2
 
 
 def quaternary_dense_symmetric(coeff: Coeff, real=True):
@@ -104,8 +147,12 @@ def _quaternary_dense_symmetric_vanish2(coeff: Coeff):
 
     # if sym.div((c-d).as_poly(c,d,domain=poly.domain)**2)[1].is_zero:
     #     return _quaternary_dense_symmetric_vanish_xyzz(coeff)
+    sol = _quaternary_dense_symmetric_vanish2_liftfree(coeff)
+    if sol is not None:
+        return sol
 
-    dih = _lift_sym_axis_to_D4(sym, (a,b,c,d), poly.total_degree() - 4)
+    dih = _lift_sym_axis_to_D4_part1(sym, (a, b), poly.total_degree() - 4)
+    dih.gens = (a, b, c, d)
     alt_proj, alt_rem = (sym - dih.eval((1,1))).div((c-d).as_poly(c,d,domain=poly.domain)**2)
     if not alt_rem.is_zero:
         # not expected to happen
@@ -151,9 +198,73 @@ def _quaternary_dense_symmetric_vanish2(coeff: Coeff):
     return sol
 
 
+def _quaternary_dense_symmetric_vanish2_liftfree(coeff: Coeff, sym=None):
+    """
+    Solve symmetric quaternary inequalities with
+    `(a-1)**2*(b-1)**2 | F(a,b,1,1)`.
+    without lifting the degree. This is done by noting
+    that
+    `(d-a)*(d-c)*(b-a)*(b-c) + (c-a)*(c-d)*(b-a)*(b-d) = (a-b)**2*(c-d)**2`
+
+    
+    Examples
+    --------
+    :: sym = "sym"
+
+    => s(1/4a4b4-a4b3c+1/2a4b2c2+a3b3cd-a3b2c2d+1/4a2b2c2d2)
+
+    => s(a6b4c2+a6b4cd-a6b3c3-a6b2c2d2+a5b5c2+a5b5cd-4a5b4c2d-2a5b3c3d+2a5b3c2d2-a4b4c4+2a4b4c3d+a4b4c2d2-a4b3c3d2+a3b3c3d3)
+    """
+    a, b, c, d = coeff.gens
+    per = lambda _: Poly(_, coeff.gens, domain = coeff.domain)
+    if sym is None:
+        poly = coeff.as_poly()
+        per = lambda _: Poly(_, poly.gens, domain = poly.domain)
+        margin = poly.eval((1,1))
+        sym, rem = margin.div(((c-1)*(d-1)).as_poly(c,d, domain=poly.domain)**2)
+        if not rem.is_zero:
+            return None
+    wrap = coeff.wrap
+
+    # F = SymmetricSum(D(a,b,c,d)*(a-c)*(a-d)*(b-c)*(b-d))/8 (mod discriminant)
+    dih = _lift_sym_axis_to_D4(sym, (a, b), coeff.total_degree() - 4)
+    dih.gens = (a, b, c, d)
+    dih_c = Poly({(r, n, m, s): v for (m, n, r, s), v in dih.rep.terms()},
+                a, b, c, d, domain=dih.domain)
+    dih_d = Poly({(s, n, r, m): v for (m, n, r, s), v in dih.rep.terms()},
+                a, b, c, d, domain=dih.domain)
+    # F = SymmetricSum(D(a,b,c,d)*(a-b)**2*(c-d)**2)/16 (mod discriminant)
+    dih = dih_c + dih_d - dih
+
+    from .solver import _structural_sos_4vars_dihedral
+    dih_sol = _structural_sos_4vars_dihedral(dih)
+    if dih_sol is None:
+        return None
+
+    main_poly = _sym_sum_poly(dih * per((a-b)*(c-d))**2)
+
+    rest = (coeff.as_poly()*16 - main_poly)
+    rest, rem = rest.div(per((a-b)*(a-c)*(b-c)*(a-d)*(b-d)*(c-d))**2)
+
+    if not rem.is_zero:
+        # not expected to happen
+        return None
+    # print(f'rest = {rest}\nrem = {rem}')
+    if any(wrap(_) < 0 for _ in rest.rep.coeffs()):
+        return None
+
+    disc = 0
+    if not rest.is_zero:
+        disc = ((a - c)**2*(b - c)**2*(a - d)**2*(b - d)**2*(c - d)**2*(a - b)**2)
+
+    SymmetricSum = coeff.symmetric_sum
+    const, rest2 = poly_reduce_by_symmetry(rest, "sym").primitive()
+    rest_expr = const * SymmetricSum(rest2.as_expr())
+    return SymmetricSum(dih_sol * (a-b)**2*(c-d)**2)/16 + disc * rest_expr/16
+
 #####################################################################
 #
-#                              Acyclic
+#                            Asymmetric
 #
 #####################################################################
 
@@ -166,6 +277,10 @@ def _quaternary_dense_dihedral_by_level(coeff: Coeff):
     Solve a 4-var homogeneous dihedral inequality
     by writing it as `Σ f(a,b)*c**r*d**s` where
     `f(a,b)` is symmetric with respect to a, b.
+
+    Examples
+    --------
+    => (a+c)(b+d)(ac+bd)((s(ab)+ac+bd))-3abcds(a)2 # doctest:+SKIP
     """
     a, b, c, d = coeff.gens
     dih = PermutationGroup(Permutation([2,3,1,0]), Permutation([1,0,2,3]))

--- a/triples/core/structsos/quaternary/dense_symmetric.py
+++ b/triples/core/structsos/quaternary/dense_symmetric.py
@@ -1,12 +1,69 @@
-from sympy import Poly
+from typing import Tuple, Optional
 
-from .utils import Coeff
+from sympy import Poly, Symbol, Add
+from sympy.combinatorics import PermutationGroup, Permutation
+
+from .utils import Coeff, CyclicSum, sos_struct_reorder_symmetry
+from ..univariate import prove_univariate
 from ....utils import poly_reduce_by_symmetry, arraylize_sp, invarraylize
 
 def _sym_sum_poly(poly: Poly) -> Poly:
-    """Return the symmetric sum of a polynomial efficiently."""
+    """Compute the symmetric sum of a polynomial efficiently."""
     rep = arraylize_sp(poly, expand_cyc=True, sym=True)
     return invarraylize(rep, poly.gens, degree=poly.total_degree(), sym=True)
+
+
+def _lift_sym_axis_to_D4(
+    poly: Poly,
+    gens: Tuple[Symbol, Symbol, Symbol, Symbol],
+    degree: int
+) -> Optional[Poly]:
+    """
+    Given a nonhomogeneous f(a,b) such that `f(a,b) == f(b,a)`,
+    compute a homogeneous g(a,b,c,d) so that
+    `f(a,b) == g(a,b,1,1) (mod (a-b)**2)` and `g(a,b,c,d)` is D4-symmetric
+    (assuming g exists).
+
+    The conversion is not unique so we only return one of them
+    by employing a linear-time algorithm.
+    """
+    q = {}
+    for (n, m), v in poly.rep.terms():
+        if n < m:
+            continue
+        d_rem = degree - n - m
+        if d_rem * 2 > degree:
+            continue
+        if n == m and d_rem == n + m:
+            # this should be handled separately
+            continue
+        if d_rem % 2 != 0:
+            v = v/2
+        q[(n, m, (d_rem+1)//2, d_rem//2)] = v
+
+    D4 = [[0, 1, 2, 3],
+        [1, 0, 2, 3],
+        [2, 3, 0, 1],
+        [3, 2, 0, 1],
+        [0, 1, 3, 2],
+        [1, 0, 3, 2],
+        [2, 3, 1, 0],
+        [3, 2, 1, 0]]
+    def mp(k, a):
+        return tuple(k[i] for i in a)
+
+    for a in D4:
+        q.update({mp(k, a): v for k, v in q.items()})
+
+    if degree % 4 == 0:
+        # determine the coeff of (d/4, d/4, d/4, d/4) by the relation
+        # poly(1,1) == q(1,1,1,1)
+        const = sum(poly.rep.coeffs()) if not poly.is_zero else poly.domain.zero
+        const2 = sum(q.values()) if q else poly.domain.zero
+        q[(degree//4,)*4] = const - const2
+
+    q2 = Poly(q, gens, domain=poly.domain)
+    return q2
 
 
 def quaternary_dense_symmetric(coeff: Coeff, real=True):
@@ -16,40 +73,69 @@ def quaternary_dense_symmetric(coeff: Coeff, real=True):
     return _quaternary_dense_symmetric(coeff, real=real)
 
 def _quaternary_dense_symmetric(coeff: Coeff, real=True):
-    return _quarternary_dense_symmetric_vanish_xyzz(coeff)
+    return _quaternary_dense_symmetric_vanish2(coeff)
 
-def _quarternary_dense_symmetric_vanish_xyzz(coeff: Coeff):
+
+def _quaternary_dense_symmetric_vanish2(coeff: Coeff):
     """
+    Solve symmetric quaternary inequalities with
+    `(a-1)**2*(b-1)**2 | F(a,b,1,1)`.
+
     Examples
     --------
     :: sym = "sym"
+
+    => s((a+b-c-d)2(a-c)(a-d)(b-c)(b-d))
+
+    => s(a4b(a-c)(a-d)(b-c)(b-d)) # doctest:+SKIP
+
+    => s(a4bd(27ac2+acd+bc2+5bcd+2bd2)(a-c)(a-d)(b-c)(b-d))
 
     => 4s(ab(c-d)2((a+b)2-(a-b)2))s(ab(c-d)2(a+b-c-d)2)-4s(ab(a+b)(c-d)2(a+b-c-d))2
     """
     poly = coeff.as_poly()
     a, b, c, d = poly.gens
     per = lambda _: Poly(_, poly.gens, domain = poly.domain)
-
     margin = poly.eval((1,1))
-    sym, rem = margin.div(((c-1)*(d-1)*(c-d)).as_poly(c,d,domain=poly.domain)**2)
+    sym, rem = margin.div(((c-1)*(d-1)).as_poly(c,d, domain=poly.domain)**2)
     if not rem.is_zero:
         return None
     wrap = coeff.wrap
-    if any(wrap(_) < 0 for _ in sym.rep.coeffs()):
+
+    # if sym.div((c-d).as_poly(c,d,domain=poly.domain)**2)[1].is_zero:
+    #     return _quaternary_dense_symmetric_vanish_xyzz(coeff)
+
+    dih = _lift_sym_axis_to_D4(sym, (a,b,c,d), poly.total_degree() - 4)
+    alt_proj, alt_rem = (sym - dih.eval((1,1))).div((c-d).as_poly(c,d,domain=poly.domain)**2)
+    if not alt_rem.is_zero:
+        # not expected to happen
+        return None
+
+    # print(f'dih = {dih}\nalt_proj = {alt_proj}')
+    if any(wrap(_) < 0 for _ in alt_proj.rep.coeffs()):
+        return None
+
+    from .solver import _structural_sos_4vars_dihedral
+    dih_sol = _structural_sos_4vars_dihedral(dih)
+    if dih_sol is None:
         return None
 
     n = poly.total_degree() - 6
-    lift = per({((n-(i+j))//2, (n-(i+j)+1)//2, i, j): v/2
-        for (i,j), v in sym.rep.terms()})
-    lift = lift + per({(m[1], m[0], m[2], m[3]): v
-        for m, v in lift.rep.terms()})
+    alt = per({((n-(i+j))//2, (n-(i+j)+1)//2, i, j): v/2
+        for (i,j), v in alt_proj.rep.terms()})
+    alt = alt + per({(m[1], m[0], m[2], m[3]): v
+        for m, v in alt.rep.terms()})
 
-    main_poly = _sym_sum_poly(per((a-c)*(b-c)*(a-d)*(b-d)*(c-d))**2 * lift).mul_ground(4)
+    main_poly = _sym_sum_poly(
+        per((a-c)*(b-c)*(a-d)*(b-d))**2 * (alt*(per(c-d)**2)*4 + dih*2)
+    )
 
     rest = (poly * _sym_sum_poly(per((a-b)*(c-d))**2) - main_poly)
     rest, rem = rest.div(per((a-b)*(a-c)*(b-c)*(a-d)*(b-d)*(c-d))**2)
     if not rem.is_zero:
+        # not expected to happen
         return None
+    # print(f'rest = {rest}\nrem = {rem}')
     if any(wrap(_) < 0 for _ in rest.rep.coeffs()):
         return None
 
@@ -58,7 +144,87 @@ def _quarternary_dense_symmetric_vanish_xyzz(coeff: Coeff):
     rest_expr = const * SymmetricSum(rest2.as_expr())
     disc = ((a - c)**2*(b - c)**2*(a - d)**2*(b - d)**2*(c - d)**2*(a - b)**2)
 
-    const, lift = lift.primitive()
-    main = 4*const*SymmetricSum((a - c)**2*(b - c)**2*(a - d)**2*(b - d)**2*(c - d)**2*lift.as_expr())
+    const, alt = alt.primitive()
+    main = 4*const*SymmetricSum((a - c)**2*(b - c)**2*(a - d)**2*(b - d)**2*(c - d)**2*alt.as_expr())\
+        + 2*SymmetricSum((a - c)**2*(a - d)**2*(b - c)**2*(b - d)**2*dih_sol)
     sol = (rest_expr*disc + main)/SymmetricSum((a-b)**2*(c-d)**2)
+    return sol
+
+
+#####################################################################
+#
+#                              Acyclic
+#
+#####################################################################
+
+@sos_struct_reorder_symmetry(groups=(2, 2))
+def quaternary_dense_dihedral(coeff: Coeff):
+    return _quaternary_dense_dihedral_by_level(coeff)
+
+def _quaternary_dense_dihedral_by_level(coeff: Coeff):
+    """
+    Solve a 4-var homogeneous dihedral inequality
+    by writing it as `Σ f(a,b)*c**r*d**s` where
+    `f(a,b)` is symmetric with respect to a, b.
+    """
+    a, b, c, d = coeff.gens
+    dih = PermutationGroup(Permutation([2,3,1,0]), Permutation([1,0,2,3]))
+    reduced = poly_reduce_by_symmetry(coeff.as_poly(), dih)
+
+    wrap = coeff.wrap
+    is_nng_cfs = all(wrap(_) >= 0 for _ in coeff.coeffs())
+    def _nng_fallback():
+        """
+        When it is nonnegative over real numbers but has
+        nonnegative coefficients, fall back to solver for
+        non-negative coefficients, which generates neater solutions.
+        """
+        return CyclicSum(reduced.as_expr(), coeff.gens, dih)
+
+    # marginalize over c, d
+    margin = reduced.eject(a, b)
+    levels = margin.rep.terms()
+
+    if is_nng_cfs and any(r % 2 != 0 or s % 2 != 0 for (r, s), cfs in levels):
+        # has odd-degree terms -> fall back to solver for non-negative coefficients
+        return _nng_fallback()
+
+    level_proof = {}
+    def hom_proof(proof, gen: Symbol, degree: int):
+        """
+        Restore the solution from the homogenized proof.
+        """
+        lst = []
+        for i, (extra, source) in enumerate(proof):
+            for c, v in source:
+                if v.is_zero:
+                    continue
+                v = v.homogenize(gen)
+                codegree = degree - 2*v.total_degree() - i
+                lst.append(c * extra * v.as_expr()**2 * gen**(codegree))
+        return Add(*lst)
+
+    degree = coeff.total_degree()
+    for (r, s), cfs in levels:
+        # compute q = f(a,b) + f(b,a)
+        q = Poly(dict(cfs), a, b, domain=coeff.domain)
+        q = q + Poly({(m, n): v for (n, m), v in cfs.items()},
+                     a, b, domain=coeff.domain)
+        q = q.eval((1,)).mul_ground(q.domain.one/2)
+
+        # print(r, s,  Poly(dict(cfs), coeff.gens[:2], domain=coeff.domain))
+        proof = prove_univariate(q, return_type='list')
+        if proof is None:
+            # prove on R+
+            if is_nng_cfs:
+                return _nng_fallback()
+            proof = prove_univariate(q, (0, None), return_type='list')
+        if proof is None:
+            return None
+        level_proof[(r, s)] = hom_proof(proof, coeff.gens[0], degree - r - s)
+
+    sol = Add(*[
+        CyclicSum(c**r*d**s*proof, coeff.gens, dih)
+            for (r, s), proof in level_proof.items()
+    ])
     return sol

--- a/triples/core/structsos/quaternary/quartic_symmetric.py
+++ b/triples/core/structsos/quaternary/quartic_symmetric.py
@@ -22,7 +22,7 @@ def _free_symbol(coeff: Coeff):
         for symbol in coeff.domain.symbols:
             gens = gens.union(symbol.free_symbols)
     for s in "efghij":
-        if not (Symbol(s) in gens):
+        if Symbol(s) not in gens:
             return Symbol(s)
     return Dummy("x")
 

--- a/triples/core/structsos/quaternary/quintic.py
+++ b/triples/core/structsos/quaternary/quintic.py
@@ -4,7 +4,7 @@ from sympy import Add
 
 from .utils import congruence, sum_y_exprs
 
-def quaternary_quintic_symmetric(coeff):
+def quaternary_quintic_symmetric(coeff, real=True):
     """
     Solve quaternary symmetric quintic polynomials. Symmetry is not checked here.
 

--- a/triples/core/structsos/quaternary/quintic.py
+++ b/triples/core/structsos/quaternary/quintic.py
@@ -398,7 +398,7 @@ def _quaternary_quintic_symmetric_c3axis(coeff: Coeff):
         (c221 + c311 + 2*c32 + 2*c41 + c5)/8,
         (c2111 + 3*c221 + 3*c311 + 3*c32 + 3*c41 + c5)/6
     ]
-    if not all([_ >= 0 for _ in y]):
+    if not all(_ >= 0 for _ in y):
         return None
 
     ker = _quaternary_quintic_symmetric_c3axis_t(t, coeff, c5)
@@ -435,7 +435,7 @@ def _quaternary_quintic_symmetric_surface(coeff: Coeff):
         (c221 + c311 + 2*c32 + 2*c41 + c5)/8,
         (c2111 + 3*c221 + 3*c311 + 3*c32 + 3*c41 + c5)/6
     ]
-    if not all([_ >= 0 for _ in y]):
+    if not all(_ >= 0 for _ in y):
         return None
 
     ker = _quaternary_quintic_symmetric_surface_t(t, coeff, c5)

--- a/triples/core/structsos/quaternary/solver.py
+++ b/triples/core/structsos/quaternary/solver.py
@@ -1,6 +1,6 @@
 from typing import Union, Dict, Optional
 
-from sympy import Poly, Expr, Function
+from sympy import Poly, Expr, Function, Mul
 from sympy.core.symbol import uniquely_named_symbol
 from sympy.combinatorics import PermutationGroup, Permutation
 
@@ -8,7 +8,7 @@ from .cubic import quaternary_cubic_symmetric, _quaternary_cubic_partial_symmetr
 from .quartic import quaternary_quartic
 from .quartic_symmetric import quaternary_quartic_symmetric
 from .quintic import quaternary_quintic_symmetric
-from .dense_symmetric import quaternary_dense_symmetric
+from .dense_symmetric import quaternary_dense_symmetric, quaternary_dense_dihedral
 
 from ..utils import Coeff, PolynomialNonpositiveError, PolynomialUnsolvableError
 from ..sparse import sos_struct_common, sos_struct_degree_specified_solver
@@ -51,7 +51,7 @@ def _structural_sos_4vars_cyclic(
     real: int = 1
 ) -> Optional[Expr]:
     """
-    Internal function to solve a 4-var homogeneous symmetric polynomial using structural SOS.
+    Internal function to solve a 4-var homogeneous cyclic polynomial using structural SOS.
     It does not check the homogeneous / cyclic property of the polynomial to save time.
     """
     if not isinstance(coeff, Coeff):
@@ -79,6 +79,53 @@ def _structural_sos_4vars_partial_symmetric(
         real=real
     )
 
+def _structural_sos_4vars_dihedral(
+    coeff: Union[Poly, Coeff, Dict],
+    real: int = 1
+) -> Optional[Expr]:
+    """
+    Internal function to solve a 4-var homogeneous dihedral polynomial using structural SOS.
+    It does not check the homogeneous / dihedral property of the polynomial to save time.
+
+    The permutation group is assumed to be [[2,3,0,1], [1,0,2,3]].
+    """
+    if not isinstance(coeff, Coeff):
+        coeff = Coeff(coeff)
+    if coeff.total_degree() <= 2:
+        from ..nvars.quadratic import sos_struct_nvars_quadratic
+        sol = sos_struct_nvars_quadratic(coeff)
+        if sol is not None:
+            return sol
+
+    poly = coeff.as_poly()
+    const, factors = poly.factor_list()
+
+    if const < 0:
+        return None
+
+    factor_sols = [const]
+    dih = PermutationGroup(Permutation([2,3,0,1]), Permutation([1,0,2,3]))
+    for factor, mul in factors:
+        if mul % 2 == 1:
+            factor_coeff = Coeff(factor)
+            if not factor_coeff.is_cyclic(dih):
+                # factors of a D4-symmetric polynomial might not
+                # still be cyclic under D4
+                # e.g. a*b*c*d
+                wrap = factor_coeff.wrap
+                if all(wrap(z) >= 0 for z in factor_coeff.coeffs()):
+                    factor_sols.append(factor.as_expr() ** mul)
+                    continue
+                return None
+            sol = quaternary_dense_dihedral(factor_coeff)
+            if sol is None:
+                return None
+            factor_sols.append(sol ** mul)
+        else:
+            factor_sols.append(factor.as_expr() ** mul)
+
+    return Mul(*factor_sols)
+
 
 def structural_sos_4vars(
     poly: Poly,
@@ -104,6 +151,11 @@ def structural_sos_4vars(
         pg = PermutationGroup(Permutation([1,2,0,3]), Permutation([1,0,2,3]))
         if coeff.is_cyclic(pg):
             func = _structural_sos_4vars_partial_symmetric
+
+        # TODO: dihedral belongs to cyclic
+        pg = PermutationGroup(Permutation([2,3,0,1]), Permutation([1,0,2,3]))
+        if coeff.is_cyclic(pg):
+            func = _structural_sos_4vars_dihedral
 
     try:
         if func is not None:

--- a/triples/core/structsos/quaternary/utils.py
+++ b/triples/core/structsos/quaternary/utils.py
@@ -8,3 +8,13 @@ from ....utils import (
     nroots, rationalize, rationalize_bound, univariate_intervals,
     CyclicExpr, CyclicSum, CyclicProduct, SymmetricSum, SymmetricProduct
 )
+
+(
+    Coeff,
+    radsimp, sum_y_exprs, rationalize_func, quadratic_weighting, zip_longest, intervals, congruence,
+    StructuralSOSError, PolynomialNonpositiveError, PolynomialUnsolvableError
+)
+(
+    nroots, rationalize, rationalize_bound, univariate_intervals,
+    CyclicExpr, CyclicSum, CyclicProduct, SymmetricSum, SymmetricProduct
+)

--- a/triples/core/structsos/quaternary/utils.py
+++ b/triples/core/structsos/quaternary/utils.py
@@ -1,5 +1,5 @@
 from ..utils import (
-    Coeff,
+    Coeff, sos_struct_reorder_symmetry,
     radsimp, sum_y_exprs, rationalize_func, quadratic_weighting, zip_longest, intervals, congruence,
     StructuralSOSError, PolynomialNonpositiveError, PolynomialUnsolvableError
 )
@@ -10,7 +10,7 @@ from ....utils import (
 )
 
 (
-    Coeff,
+    Coeff, sos_struct_reorder_symmetry,
     radsimp, sum_y_exprs, rationalize_func, quadratic_weighting, zip_longest, intervals, congruence,
     StructuralSOSError, PolynomialNonpositiveError, PolynomialUnsolvableError
 )

--- a/triples/core/structsos/solution.py
+++ b/triples/core/structsos/solution.py
@@ -1,8 +1,6 @@
-from functools import reduce
-from typing import Dict, Optional, Callable
+from typing import Optional, Callable
 
 import sympy as sp
-from sympy.core.singleton import S
 
 from ..solution import Solution
 from ...utils import CyclicSum, CyclicProduct

--- a/triples/core/structsos/solution.py
+++ b/triples/core/structsos/solution.py
@@ -84,7 +84,8 @@ class SolutionStructural(Solution):
                     elif isinstance(base, sp.Mul) and all(is_pow2(_) for _ in base.args):
                         return arg
                     # ensure each arg is nonnegative by expanding
-                    each_args = [dfs(_) for _ in arg.doit(deep=False).args]
+                    each_arg = [dfs(_) for _ in arg.doit(deep=False).args]
+                    assert len(each_arg) >= 0
                     return arg.func(dfs(base), *arg.args[1:])
             return arg
 

--- a/triples/core/structsos/sparse.py
+++ b/triples/core/structsos/sparse.py
@@ -41,7 +41,7 @@ def sos_struct_extract_factors(poly: Union[Poly, Coeff], solver: Callable, real:
         new_coeff = coeff_to_poly(new_coeff)
         solution = solver(new_coeff, real = False if (i % 2 == 0) else real, **kwargs)
         if solution is not None:
-            solution = solution.xreplace(dict((s, s**i) for s in symbols))
+            solution = solution.xreplace({s: s**i for s in symbols})
             return solution
         return None
 

--- a/triples/core/structsos/sparse.py
+++ b/triples/core/structsos/sparse.py
@@ -3,7 +3,7 @@ from typing import Callable, Union, Dict
 from sympy import Poly, Expr, Integer, Mul
 
 from .utils import Coeff, PolynomialUnsolvableError, PolynomialNonpositiveError
-from ...utils import CyclicSum, CyclicProduct
+from ...utils import CyclicProduct
 
 def _null_solver(*args, **kwargs):
     return None

--- a/triples/core/structsos/structsos.py
+++ b/triples/core/structsos/structsos.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Union, Optional
 from sympy import Poly, Expr, Integer, construct_domain
 from sympy.polys.polyerrors import BasePolynomialError
 
-from .utils import Coeff, clear_free_symbols
+from .utils import clear_free_symbols
 from .solution import SolutionStructural
 from .constrained import structural_sos_constrained
 from .pivoting    import structural_sos_2vars

--- a/triples/core/structsos/ternary/__init__.py
+++ b/triples/core/structsos/ternary/__init__.py
@@ -14,5 +14,23 @@ from .solver import structural_sos_3vars, _structural_sos_3vars_cyclic, _structu
 
 
 __all__ = [
-    'structural_sos_3vars'
+    'sos_struct_sparse',
+    'sos_struct_heuristic',
+    'sos_struct_dense_symmetric',
+    'sos_struct_liftfree_for_six',
+    'sos_struct_quadratic',
+    'sos_struct_acyclic_quadratic',
+    'sos_struct_cubic',
+    'sos_struct_acyclic_cubic',
+    'sos_struct_quartic',
+    'sos_struct_acyclic_quartic',
+    'sos_struct_quintic',
+    'sos_struct_sextic',
+    'sos_struct_septic',
+    'sos_struct_octic',
+    'sos_struct_nonic',
+    'sos_struct_acyclic_sparse',
+    'structural_sos_3vars',
+    '_structural_sos_3vars_cyclic',
+    '_structural_sos_3vars_acyclic'
 ]

--- a/triples/core/structsos/ternary/acyclic.py
+++ b/triples/core/structsos/ternary/acyclic.py
@@ -1,6 +1,4 @@
-import sympy as sp
 
-from .quadratic import sos_struct_acyclic_quadratic
 
 def sos_struct_acyclic_sparse(coeff, real = True):
     """

--- a/triples/core/structsos/ternary/cubic.py
+++ b/triples/core/structsos/ternary/cubic.py
@@ -549,7 +549,7 @@ def _sos_struct_acyclic_cubic_symmetric(coeff: Coeff):
     if w is None:
         return None
 
-    w = coeff.convert(w) if not (w is Infinity) else w
+    w = coeff.convert(w) if w is not Infinity else w
     w0 = 2*(5*t**2 - 2*t*z + 2*z**2)/3
     y0 = 4*(-2*t + z)**3/27
     if w is Infinity:

--- a/triples/core/structsos/ternary/cubic.py
+++ b/triples/core/structsos/ternary/cubic.py
@@ -199,7 +199,7 @@ def _sos_struct_cubic_nontrivial(coeff: Coeff):
         return None
 
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
     exprs = [
         CyclicSum((a**2 - b**2 + (p_+2*q_)/3*a*c - (2*p_+q_)/3*b*c + (p_- q_)/3*a*b).together()**2),
         CyclicSum(a**2*(b - c)**2),

--- a/triples/core/structsos/ternary/cubic.py
+++ b/triples/core/structsos/ternary/cubic.py
@@ -404,6 +404,8 @@ def _sos_struct_acyclic_cubic_symmetric(coeff: Coeff):
     => 8(a(a-b-c)2+b(b-a-c)2)+4c(c-a-b)2-16abc
 
     => (81a3-77a2b-135a2c-77ab2+225abc+27ac2+81b3-135b2c+27bc2+27c3)
+
+    => (96b3+152b2c+152b2a-288bc2-320bca-288ba2+127c3+121c2a+121ca2+127a3)
     """
     a, b, c = coeff.gens
     x0, x1, x2, x3, x4, x5 = [coeff(_) for _ in ((0,0,3),(1,0,2),(2,0,1),(3,0,0),(2,1,0),(1,1,1))]

--- a/triples/core/structsos/ternary/cubic.py
+++ b/triples/core/structsos/ternary/cubic.py
@@ -3,7 +3,8 @@ from sympy import oo as Infinity
 
 from .utils import (
     Coeff, CommonExpr,
-    sum_y_exprs, rationalize_func, quadratic_weighting
+    sum_y_exprs, rationalize_func, quadratic_weighting,
+    sos_struct_reorder_symmetry
 )
 
 def sos_struct_cubic(coeff, real = True):
@@ -354,6 +355,7 @@ def _sos_struct_acyclic_cubic_hexagon(coeff: Coeff):
         return sum(exprs) + (center - sum(zs))*(a*b*c)
 
 
+@sos_struct_reorder_symmetry(groups=(2, 1))
 def _sos_struct_acyclic_cubic_symmetric(coeff: Coeff):
     """
     Solve acyclic cubic polynomials that are symmetric with respect to two variables.
@@ -403,19 +405,8 @@ def _sos_struct_acyclic_cubic_symmetric(coeff: Coeff):
 
     => (81a3-77a2b-135a2c-77ab2+225abc+27ac2+81b3-135b2c+27bc2+27c3)
     """
-    a, b, c = None, None, None
-    if all(coeff((i,j,k)) == coeff((j,i,k)) for (i,j,k) in ((3,0,0),(2,1,0),(2,0,1),(1,0,2))):
-        a, b, c = coeff.gens
-        x0, x1, x2, x3, x4, x5 = [coeff(_) for _ in ((0,0,3),(1,0,2),(2,0,1),(3,0,0),(2,1,0),(1,1,1))]
-    if all(coeff((i,j,k)) == coeff((i,k,j)) for (i,j,k) in ((0,3,0),(0,2,1),(1,2,0),(2,1,0))):
-        a, b, c = coeff.gens
-        a, b, c = b, c, a
-        x0, x1, x2, x3, x4, x5 = [coeff(_) for _ in ((3,0,0),(2,1,0),(1,2,0),(0,3,0),(0,2,1),(1,1,1))]
-    if all(coeff((i,j,k)) == coeff((k,j,i)) for (i,j,k) in ((0,0,3),(1,0,2),(0,1,2),(0,2,1))):
-        a, b, c = coeff.gens
-        a, b, c = c, a, b
-        x0, x1, x2, x3, x4, x5 = [coeff(_) for _ in ((0,3,0),(0,2,1),(0,1,2),(0,0,3),(1,0,2),(1,1,1))]
-
+    a, b, c = coeff.gens
+    x0, x1, x2, x3, x4, x5 = [coeff(_) for _ in ((0,0,3),(1,0,2),(2,0,1),(3,0,0),(2,1,0),(1,1,1))]
 
     if a is None:
         # it is not symmetric
@@ -424,7 +415,7 @@ def _sos_struct_acyclic_cubic_symmetric(coeff: Coeff):
         return None
 
     if x0 == 0:
-        # This is a degeneated case, the symmetric axis and the border are now quadratic.
+        # This is a degenerated case, the symmetric axis and the border are now quadratic.
         if x1 < 0 or x3 < 0:
             return None
         if x3 == 0:

--- a/triples/core/structsos/ternary/dense_symmetric.py
+++ b/triples/core/structsos/ternary/dense_symmetric.py
@@ -5,6 +5,7 @@ from sympy.polys.polyclasses import ANP, DMP
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.combinatorics.named_groups import CyclicGroup
 from sympy.ntheory import factorint, nextprime, sqrt_mod
+from sympy.external.gmpy import sqrt as isqrt
 from sympy.utilities import subsets
 
 from .utils import (
@@ -531,6 +532,9 @@ def _sos_struct_complex_factorizable_fp(coeff: Coeff):
     # return const*A.as_expr()**2 + 3*const*B.as_expr()**2
     return _complex_factorizable_from_AB(coeff, A, B, const)
 
+def is_square(x):
+    return isqrt(x)**2 == x
+
 def _sqf_complex_factorizable_fp(poly: Poly, p: Optional[int]=None):
     """
     Express `poly = A**2 + 3*B**2` assuming poly is on ZZ and square-free.
@@ -558,7 +562,7 @@ def _sqf_complex_factorizable_fp(poly: Poly, p: Optional[int]=None):
         return poly, poly
     if not poly.domain.is_ZZ:
         return None
-    if not ZZ.is_square(poly.rep.LC()):
+    if not is_square(poly.rep.LC()):
         return None
     d = poly.total_degree()
     if d % 2 != 0:

--- a/triples/core/structsos/ternary/dense_symmetric.py
+++ b/triples/core/structsos/ternary/dense_symmetric.py
@@ -1,15 +1,18 @@
 from typing import Tuple, Optional, Union
 
-from sympy import Poly, Expr, Add, QQ, sqrt
-from sympy.polys.polyclasses import ANP
+from sympy import Poly, Expr, Add, ZZ, QQ, FiniteField, sqrt, prod
+from sympy.polys.polyclasses import ANP, DMP
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.combinatorics.named_groups import CyclicGroup
+from sympy.ntheory import factorint, nextprime, sqrt_mod
+from sympy.utilities import subsets
 
 from .utils import (
     Coeff, sos_struct_handle_uncentered, sos_struct_reorder_symmetry,
 )
 from ..univariate import prove_univariate
 from ....utils import verify_symmetry, poly_reduce_by_symmetry
+from ....utils.polytools import dmp_gf_factor, FLINT_VERSION
 
 
 def _linear_invert(u, v, d: int = 0) -> Optional[Tuple[int, Expr, Expr]]:
@@ -187,7 +190,10 @@ def _sos_struct_lift_for_six(coeff: Coeff, real=True):
     if d % 2 == 0:
         factors = div[0].factor_list()[1]
         if all(m % 2 == 0 for _, m in factors):
-            sol = _sos_struct_complex_factorizable(coeff)
+            # XXX: currently modp factorization is slow
+            # unless flint is installed
+            sol = _sos_struct_complex_factorizable(coeff,
+                    modp=(FLINT_VERSION >= (0, 7, 0)))
             if sol is not None:
                 return sol
 
@@ -352,7 +358,6 @@ def _sos_struct_liftfree_for_six_ord4(coeff: Coeff, div2=None, real=True):
         return CyclicSum(lifted_sym * (a-b)**2*(a-c)**2) + CyclicProduct((a-b)**2) * sol_diff
 
 
-
 def _conjugate_factor(poly: Poly, conj):
     const, factors = poly.factor_list()
     if const < 0:
@@ -385,7 +390,7 @@ def _conjugate_factor(poly: Poly, conj):
         odd_factors[conj_f] = 0
     return const, even_factors
 
-def _sos_struct_complex_factorizable(coeff: Coeff, test=True):
+def _sos_struct_complex_factorizable(coeff: Coeff, test=True, modp=True):
     """
     Solve a cyclic ternary polynomial inequality if it is
     factorizable over Q[sqrt(-3)].
@@ -403,13 +408,16 @@ def _sos_struct_complex_factorizable(coeff: Coeff, test=True):
     d = coeff.total_degree()
     if d % 2 != 0:
         return None
-    
+
     poly0 = coeff.as_poly().eval((1,))
     if test:
         # test whether the poly > 0 for real numbers
         for point in ((0, -1), (-2, -3)):
             if poly0(*point) < 0:
                 return None
+
+    if modp and (coeff.domain.is_QQ or coeff.domain.is_ZZ):
+        return _sos_struct_complex_factorizable_fp(coeff)
 
     dom0 = coeff.domain
     dom = dom0.unify(QQ.algebraic_field(sqrt(-3)))
@@ -457,21 +465,176 @@ def _sos_struct_complex_factorizable(coeff: Coeff, test=True):
     conj_half = conj_poly(half)
 
     a = coeff.gens[0]
-    CyclicSum = coeff.cyclic_sum
     real = (half + conj_half).mul_ground(dom.one/2).homogenize(a)
     imag = (half - conj_half).mul_ground(dom.convert(1/(2*sqrt(-3)))).homogenize(a)
 
+    return _complex_factorizable_from_AB(coeff, real, imag, const)
+
+def _complex_factorizable_from_AB(coeff: Coeff, A: Poly, B: Poly, const, k=3):
+    """
+    Returns `coeff.as_poly() == const*A**2 + 3*const*B**2` in
+    a graceful form.
+    """
     is_cyclic = coeff.is_cyclic()
+    CyclicSum = coeff.cyclic_sum
     def sym_sq(p):
         if verify_symmetry(p, CyclicGroup(3)):
             return CyclicSum(poly_reduce_by_symmetry(p, CyclicGroup(3)).as_expr())**2
         if is_cyclic:
             return CyclicSum(p.as_expr()**2)/3
         return p.as_expr()**2
-    realsq = sym_sq(real)
-    imagsq = sym_sq(imag)
+    sqa = sym_sq(A)
+    sqb = sym_sq(B)
 
-    return const*realsq + 3*const*imagsq
+    return const*sqa + k*const*sqb
+
+
+def _sos_struct_complex_factorizable_fp(coeff: Coeff):
+    """
+    Solve a homogeneous inequality F(a,b,c) = const*(A^2 + 3*B^2) >= 0
+    where const in QQ and (F, A, B) in QQ[a,b,c] by computing on
+    the Fp field. This is faster than computing on Q[sqrt(-3)].
+    """
+    poly = coeff.as_poly()
+    if not (poly.domain.is_QQ or poly.domain.is_ZZ):
+        return None
+    poly = poly.eval((1,))
+    const, factors = poly.factor_list()
+    if const < 0:
+        return None
+
+    const = poly.domain.to_sympy(const)
+
+    A, B = poly.one, poly.zero
+    for factor, m in factors:
+        if m > 0:
+            fpow = factor**(m//2)
+            A, B = A * fpow, B * fpow
+        if m % 2 == 0:
+            continue
+        f = factor.set_domain(ZZ)
+
+        # make the leading term a square
+        lcfactors = factorint(int(f.LC()))
+        mul = int(prod([f for f, m in lcfactors.items() if m % 2 == 1]))
+        if mul != 1:
+            f = f.mul_ground(mul)
+            const = const / mul
+
+        result = _sqf_complex_factorizable_fp(f)
+        if result is None:
+            return None
+        A1, B1 = result
+        A, B = A*A1 + 3*B*B1, A*B1 + B*A1
+    a = coeff.gens[0]
+    A, B = A.homogenize(a), B.homogenize(a)
+    # return const*A.as_expr()**2 + 3*const*B.as_expr()**2
+    return _complex_factorizable_from_AB(coeff, A, B, const)
+
+def _sqf_complex_factorizable_fp(poly: Poly, p: Optional[int]=None):
+    """
+    Express `poly = A**2 + 3*B**2` assuming poly is on ZZ and square-free.
+
+    Note
+    -----
+    * The poly should have domain ZZ.
+    * The leading coefficient should be a square.
+
+    Examples
+    --------
+    >>> from sympy.abc import a, b, c
+
+    Examples
+    --------
+    >>> from sympy.abc import a, b
+    >>> c = 1
+    >>> p1 = (a**2+b**2+c**2)**2 - 3*(a**3*b + b**3*c + c**3*a)
+    >>> p1 = p1.as_poly(a, b)
+    >>> A, B = _sqf_complex_factorizable_fp(p1)
+    >>> (A**2 + 3*B**2 - p1).is_zero
+    True
+    """
+    if poly.is_zero:
+        return poly, poly
+    if not poly.domain.is_ZZ:
+        return None
+    if not ZZ.is_square(poly.rep.LC()):
+        return None
+    d = poly.total_degree()
+    if d % 2 != 0:
+        return None
+
+    u = len(poly.gens) - 1
+
+    if p is None:
+        # mignotte bound is too large (even for ZZ)
+        # from sympy.polys.factortools import dmp_zz_mignotte_bound
+        # bound = dmp_zz_mignotte_bound(f, u, ZZ)
+
+        # we just use a heuristic bound
+        bound = poly.max_norm() * 5 + 10
+
+        p = 2*bound
+        while p % 6 != 1:
+            p = nextprime(p)
+    w = sqrt_mod(-3, p)
+    if w is None:
+        return None
+    K = FiniteField(p)
+    invw = 1/K(w)
+
+    poly_K = poly.set_domain(K)
+    const, factors = dmp_gf_factor(poly_K.rep.to_list(), u, K)
+    if len(factors) % 2 == 1:
+        return None
+    sqrt_const = sqrt_mod(int(const), p)
+    if sqrt_const is None:
+        return None
+
+    factors = [(Poly.new(DMP(factor, K, u), *poly.gens), m) for factor, m in factors]
+    degrees = [f.total_degree()*m for f, m in factors]
+
+    def reconstruct(s):
+        p1 = poly_K.one
+        for i in s:
+            f, m = factors[i]
+            p1 *= f**m
+        return p1
+    def to_zz(p1):
+        half_p = p//2
+        p1 = p1.set_domain(ZZ)
+        dt = {k: v if v <= half_p else v - p
+              for k, v in p1.rep.to_dict().items()}
+        return Poly.from_dict(dt, *poly.gens, domain=ZZ)
+
+    point = [2]
+    while len(point) <= u: # len(point) < len(poly.gens)
+        point.append(nextprime(point[-1]))
+    points = [point]
+
+    inds = list(range(len(factors)))
+    for s in subsets(inds, len(factors)//2):
+        ns = tuple([i for i in range(len(factors)) if i not in s])
+        if s > ns:
+            continue
+        ds = sum(degrees[i] for i in s)
+        if ds * 2 != d:
+            continue
+
+        A = reconstruct(s).mul_ground(sqrt_const)
+        B = reconstruct(ns).mul_ground(sqrt_const)
+        A, B = to_zz((A + B)), to_zz((A - B).mul_ground(invw))
+
+        if any(A(*point)**2 + B(*point)**2*3 != 4*poly(*point)
+               for point in points):
+            # quick check before expensive check
+            continue
+
+        if (A**2 + B**2*3 - 4*poly).is_zero:
+            half = QQ.one/2
+            return A.set_domain(QQ).mul_ground(half),\
+                B.set_domain(QQ).mul_ground(half)
+    return None
 
 #####################################################################
 #

--- a/triples/core/structsos/ternary/dense_symmetric.py
+++ b/triples/core/structsos/ternary/dense_symmetric.py
@@ -643,7 +643,7 @@ def _sqf_complex_factorizable_fp(poly: Poly, p: Optional[int]=None):
 #####################################################################
 
 @sos_struct_reorder_symmetry(groups=(2, 1))
-def sos_struct_ternary_partial_symmetric(coeff: Coeff, real=True):
+def sos_struct_ternary_dense_partial_symmetric(coeff: Coeff, real=True):
     """
     Solve a homogeneous 3-var inequality `f(a,b,c) >= 0` where
     `f(a, b, c) == f(b, a, c)`.
@@ -651,6 +651,8 @@ def sos_struct_ternary_partial_symmetric(coeff: Coeff, real=True):
     Examples
     --------
     => ((2a+2b+c)c-2ab)2(a+b)+3ab(4((a-b)2+c2)s(a)+8c(ab-c2)-9c2(a+b))
+
+    => (a2+b2+2c2)3-4(2abc+(a+b)c2)2
     """
     if all(v >= 0 for v in coeff.coeffs()):
         return coeff.as_poly().as_expr()
@@ -684,12 +686,12 @@ def sos_struct_ternary_partial_symmetric(coeff: Coeff, real=True):
         subtractor = a**m*b**m*c**n*(u2/2*c*(a + b) + v2*a*b)*(2*c - a - b)**2/4
 
     remain = poly - subtractor.as_poly(a, b, c, domain=coeff.domain)
-    sol = _sos_struct_ternary_partial_symmetric_ord4(coeff.from_poly(remain))
+    sol = _sos_struct_ternary_dense_partial_symmetric_ord4(coeff.from_poly(remain))
     if sol is not None:
         return subtractor + sol
 
 
-def _sos_struct_ternary_partial_symmetric_ord4(coeff: Coeff):
+def _sos_struct_ternary_dense_partial_symmetric_ord4(coeff: Coeff):
     """
     Solve a homogeneous 3-var inequality `f(a,b,c) >= 0` where
     `f(a, b, c) == f(b, a, c)` and `(c - 1)**4 | f(1, 1, c)`.
@@ -714,6 +716,7 @@ def _sos_struct_ternary_partial_symmetric_ord4(coeff: Coeff):
         # not expected to happen
         return None
 
-    sol = sos_struct_ternary_partial_symmetric(coeff.from_poly(div3))
+    from .solver import _structural_sos_3vars_acyclic
+    sol = _structural_sos_3vars_acyclic(coeff.from_poly(div3))
     if sol is not None:
         return sym * (a-c)**2*(b-c)**2 + sol * (a-b)**2

--- a/triples/core/structsos/ternary/dense_symmetric.py
+++ b/triples/core/structsos/ternary/dense_symmetric.py
@@ -1,6 +1,6 @@
-from typing import Tuple, List, Optional, Union
+from typing import Tuple, Optional, Union
 
-from sympy import Poly, Expr, Symbol, Add
+from sympy import Poly, Expr, Add
 
 from .utils import (
     Coeff, sos_struct_handle_uncentered, sos_struct_reorder_symmetry

--- a/triples/core/structsos/ternary/dense_symmetric.py
+++ b/triples/core/structsos/ternary/dense_symmetric.py
@@ -532,8 +532,6 @@ def _sos_struct_complex_factorizable_fp(coeff: Coeff):
     # return const*A.as_expr()**2 + 3*const*B.as_expr()**2
     return _complex_factorizable_from_AB(coeff, A, B, const)
 
-def is_square(x):
-    return isqrt(x)**2 == x
 
 def _sqf_complex_factorizable_fp(poly: Poly, p: Optional[int]=None):
     """
@@ -562,6 +560,8 @@ def _sqf_complex_factorizable_fp(poly: Poly, p: Optional[int]=None):
         return poly, poly
     if not poly.domain.is_ZZ:
         return None
+    def is_square(x):
+        return isqrt(x)**2 == x
     if not is_square(poly.rep.LC()):
         return None
     d = poly.total_degree()
@@ -657,6 +657,8 @@ def sos_struct_ternary_dense_partial_symmetric(coeff: Coeff, real=True):
     => ((2a+2b+c)c-2ab)2(a+b)+3ab(4((a-b)2+c2)s(a)+8c(ab-c2)-9c2(a+b))
 
     => (a2+b2+2c2)3-4(2abc+(a+b)c2)2
+
+    => s(a4(a-b)(a-c))+2a4(a-c)2+2b4(b-c)2
     """
     if all(v >= 0 for v in coeff.coeffs()):
         return coeff.as_poly().as_expr()
@@ -671,31 +673,91 @@ def sos_struct_ternary_dense_partial_symmetric(coeff: Coeff, real=True):
         return None
     div, rem = div.div(Poly([1,-2,1], c, domain=div.domain))
 
-    # subtract something so that the remaining f(a,b,c) has (c-1)**4 | f(1, 1, c)
+    subtractors = []
+    factories = [
+        _get_ternary_dense_partial_symmetric_default_subtractor,
+        _get_ternary_dense_partial_symmetric_cubic_subtractor,
+    ]
+    for factory in factories:
+        subtractors.extend(factory(coeff, rem))
+    # print(subtractors)
+    for subtractor in subtractors:
+        remain = poly - subtractor.as_poly(a, b, c, domain=coeff.domain)
+        sol = _ternary_dense_partial_symmetric_ord4(coeff.from_poly(remain))
+        if sol is not None:
+            return subtractor + sol
+
+def _get_ternary_dense_partial_symmetric_default_subtractor(coeff: Coeff, rem: Poly) -> list:
     d = coeff.total_degree()
+    a, b, c = coeff.gens
+
+    # subtract something so that the remaining f(a,b,c) has (c-1)**4 | f(1, 1, c)
     inv = _linear_invert(rem.coeff_monomial((1,)), rem.coeff_monomial((0,)),
                          (d+1)//3 - 1)
     if inv is None:
-        return None
+        return []
     n, u2, v2 = inv
 
     subtractor = Add()
     m = (d - n - 3) // 2
     if m < 0:
-        return None
+        return []
     elif (d - n - 3) % 2 == 0:
         subtractor = a**m*b**m*c**n*(u2*c + v2/2*(a + b))*(2*c - a - b)**2/4
     else:
         m = (d - n - 3) // 2
         subtractor = a**m*b**m*c**n*(u2/2*c*(a + b) + v2*a*b)*(2*c - a - b)**2/4
+    return [subtractor]
 
-    remain = poly - subtractor.as_poly(a, b, c, domain=coeff.domain)
-    sol = _sos_struct_ternary_dense_partial_symmetric_ord4(coeff.from_poly(remain))
-    if sol is not None:
-        return subtractor + sol
+def _get_ternary_dense_partial_symmetric_cubic_subtractor(coeff: Coeff, rem: Poly) -> list:
+    d = coeff.total_degree()
+    if d <= 5:
+        return []
+    zero, one = rem.domain.zero, rem.domain.one
+
+    m = (d - 6 + 1)//3
+    n = d - 6 - 2*m
+    rem_lift = rem * Poly([-n, n + 1], rem.gens[0], domain=rem.domain)
+    rem_lift = rem_lift.div(Poly([1, -2, 1], rem.gens[0], domain=rem.domain))[1]
+    rem_rep = rem_lift.rep.to_list()
+    r2 = rem_rep[-1] if len(rem_rep) else zero
+    r1 = rem_rep[-2] if len(rem_rep) >= 2 else zero
+
+    if coeff.wrap(r1 + r2) <= 0:
+        return []
+
+    def ab_subtractor(u, v, w = zero, t = one):
+        """f(1,0,t) = (df/db)(1,0,t) = 0, f(1,1,c) = (uc**2 + v*c + w)*(c - 1)"""
+        return [
+            -2*t**3*u + 3*t**2*u/2 - 3*t**2*v/2 + t*v - t*w + w/2,
+            2*t**3*u - 3*t**2*u/2 + 3*t**2*v/2 - t*v + t*w - w,
+            (2*t**3*u - 2*t**2*u + 2*t**2*v - 2*t*v + 2*t*w - w)/(2*t),
+            (-2*t**3*u + 2*t**2*u - 2*t**2*v + t*v - t*w + w)/t,
+            -u/2 + v/2,
+            u
+        ]
+
+    def to_expr(lst):
+        a, b, c = coeff.gens
+        c300, c210, c201, c111, c102, c003 = lst
+        return (r1 + r2)*a**m*b**m*c**n*Add(
+            c**3*c003, a**3*c300, b**3*c300,
+            a*c**2*c102, a*b**2*c210, b*c**2*c102,
+            a**2*b*c210, a**2*c*c201, b**2*c*c201, a*b*c*c111
+        ).together()**2
+
+    u, v = r1/2/(r1 + r2), (r1 + 2*r2)/2/(r1 + r2)
+
+    # c*(-v*c + u + 2*v) == u*c + v (mod (c - 1)**2)
+    subtractors = [
+        ab_subtractor(-v, u + 2*v, zero),
+        ab_subtractor(zero, u, v)
+    ]
+    subtractors = [to_expr(lst) for lst in subtractors]
+    return subtractors
 
 
-def _sos_struct_ternary_dense_partial_symmetric_ord4(coeff: Coeff):
+def _ternary_dense_partial_symmetric_ord4(coeff: Coeff):
     """
     Solve a homogeneous 3-var inequality `f(a,b,c) >= 0` where
     `f(a, b, c) == f(b, a, c)` and `(c - 1)**4 | f(1, 1, c)`.

--- a/triples/core/structsos/ternary/dense_symmetric.py
+++ b/triples/core/structsos/ternary/dense_symmetric.py
@@ -1,11 +1,15 @@
 from typing import Tuple, Optional, Union
 
-from sympy import Poly, Expr, Add
+from sympy import Poly, Expr, Add, QQ, sqrt
+from sympy.polys.polyclasses import ANP
+from sympy.polys.polyerrors import CoercionFailed
+from sympy.combinatorics.named_groups import CyclicGroup
 
 from .utils import (
-    Coeff, sos_struct_handle_uncentered, sos_struct_reorder_symmetry
+    Coeff, sos_struct_handle_uncentered, sos_struct_reorder_symmetry,
 )
 from ..univariate import prove_univariate
+from ....utils import verify_symmetry, poly_reduce_by_symmetry
 
 
 def _linear_invert(u, v, d: int = 0) -> Optional[Tuple[int, Expr, Expr]]:
@@ -180,6 +184,12 @@ def _sos_struct_lift_for_six(coeff: Coeff, real=True):
     # if any(_ < 0 for _ in div[0].coeffs()):
     #     # raise NotImplementedError
     #     return None
+    if d % 2 == 0:
+        factors = div[0].factor_list()[1]
+        if all(m % 2 == 0 for _, m in factors):
+            sol = _sos_struct_complex_factorizable(coeff)
+            if sol is not None:
+                return sol
 
     if all(_ >= 0 for _ in div[0].coeffs()):
         lifted_sym = _homogenize_sym_axis(coeff, div[0], d - 2)
@@ -340,6 +350,128 @@ def _sos_struct_liftfree_for_six_ord4(coeff: Coeff, div2=None, real=True):
     sol_diff = _sos_struct_dense_symmetric(coeff.from_poly(diff))
     if sol_diff is not None:
         return CyclicSum(lifted_sym * (a-b)**2*(a-c)**2) + CyclicProduct((a-b)**2) * sol_diff
+
+
+
+def _conjugate_factor(poly: Poly, conj):
+    const, factors = poly.factor_list()
+    if const < 0:
+        return None
+
+    even_factors = [(f, m//2) for f, m in factors if m % 2 == 0]
+    odd_factors = {f: m for f, m in factors if m % 2 == 1}
+    if len(odd_factors) % 2 == 1:
+        # odd factors must be pairwise conjugate
+        return None
+
+    def conj_poly(x):
+        rep = {m: conj(v) for m, v in x.rep.to_dict().items()}
+        return Poly.from_dict(rep, *x.gens, domain=x.domain)
+
+    for f, mul in odd_factors.items():
+        if mul == 0:
+            # already processed
+            continue
+        conj_f = conj_poly(f)
+        mul2 = odd_factors.get(conj_f, -1)
+        if mul2 != mul:
+            # not conjugate in pairs
+            return None
+        if f == conj_f:
+            # the factor is real but has odd degree
+            return None
+        even_factors.append((f, mul))
+        odd_factors[f] = 0
+        odd_factors[conj_f] = 0
+    return const, even_factors
+
+def _sos_struct_complex_factorizable(coeff: Coeff, test=True):
+    """
+    Solve a cyclic ternary polynomial inequality if it is
+    factorizable over Q[sqrt(-3)].
+
+    Examples
+    --------
+    => s(a2(a-b-c)4(a-b)(a-c))
+
+    => 2/3s(a12-3a11b-3a11c+3a10b2+3a10bc+3a10c2+2a6b6-6a5b5c2)
+
+    => s((a+b)4(a-c)2(b-c)2)-(8+4sqrt(6))s(ab)p(a-b)2
+    """
+    if not coeff.domain.is_Exact: # RR or CC
+        return None
+    d = coeff.total_degree()
+    if d % 2 != 0:
+        return None
+    
+    poly0 = coeff.as_poly().eval((1,))
+    if test:
+        # test whether the poly > 0 for real numbers
+        for point in ((0, -1), (-2, -3)):
+            if poly0(*point) < 0:
+                return None
+
+    dom0 = coeff.domain
+    dom = dom0.unify(QQ.algebraic_field(sqrt(-3)))
+
+    # dehomogenize to factor faster
+    poly = poly0.set_domain(dom)
+
+    # map from ANP to its conjugate
+    if dom0.is_QQ or dom0.is_ZZ:
+        def conj(x):
+            return ANP([-x.rep[0], x.rep[1]], x.mod, x.dom) if len(x.rep) == 2 else x
+    elif dom0.is_Algebraic:
+        z = ANP([1, 0], dom.mod.to_list(), QQ)
+        try:
+            conj_z = dom.convert(dom.to_sympy(z).conjugate())
+        except CoercionFailed:
+            return None
+        def conj(x):
+            s = dom.zero
+            for ci in x.rep:
+                s = conj_z * s + ci
+            return s
+    else:
+        return None
+
+    def conj_poly(x):
+        rep = {m: conj(v) for m, v in x.rep.to_dict().items()}
+        return Poly.from_dict(rep, *x.gens, domain=x.domain)
+
+    if test:
+        # test if the projection is factorizable, so that
+        # we do not waste time on non-factorizable cases
+        for point in (0, 7, -5):
+            if _conjugate_factor(poly.eval((point,)), conj) is None:
+                return None
+
+    factors = _conjugate_factor(poly, conj)
+    if factors is None:
+        return None
+    const, even_factors = factors
+
+    half = poly.one
+    for f, mul in even_factors:
+        half *= f**mul
+    conj_half = conj_poly(half)
+
+    a = coeff.gens[0]
+    CyclicSum = coeff.cyclic_sum
+    real = (half + conj_half).mul_ground(dom.one/2).homogenize(a)
+    imag = (half - conj_half).mul_ground(dom.convert(1/(2*sqrt(-3)))).homogenize(a)
+
+    is_cyclic = coeff.is_cyclic()
+    def sym_sq(p):
+        if verify_symmetry(p, CyclicGroup(3)):
+            return CyclicSum(poly_reduce_by_symmetry(p, CyclicGroup(3)).as_expr())**2
+        if is_cyclic:
+            return CyclicSum(p.as_expr()**2)/3
+        return p.as_expr()**2
+    realsq = sym_sq(real)
+    imagsq = sym_sq(imag)
+
+    return const*realsq + 3*const*imagsq
 
 #####################################################################
 #

--- a/triples/core/structsos/ternary/dense_symmetric.py
+++ b/triples/core/structsos/ternary/dense_symmetric.py
@@ -1,11 +1,46 @@
-from typing import Tuple, List
+from typing import Tuple, List, Optional
 
 from sympy import Poly, Expr, Symbol, Add
 
 from .utils import (
-    Coeff, sos_struct_handle_uncentered
+    Coeff, sos_struct_handle_uncentered, sos_struct_reorder_symmetry
 )
 from ..univariate import prove_univariate
+
+
+def _linear_invert(u, v, d: int = 0) -> Optional[Tuple[int, Expr, Expr]]:
+    """
+    Returns n, u2, v2 such that `n, u2, v2 >= 0` and
+    `u2 = u - (u + v)*n` and `v2 = v + (u + v)*n`. If
+    `d` is provided, `n` is chosen to be close to `d`.
+    Returns None if no such solution exists.
+
+    This is equivalent to `-v/(u + v) <= n <= u/(u + v)`.
+
+    Note that `a^(-n) == (-n*a + (n+1))  (mod (a-1)^2)` and   
+    `(u*a + v)*(-n*a + (n+1)) + n*u*(a-1)**2 == (u - (u + v)*n)*a + v + (u + v)*n`,
+    so this implies:
+    `u*a + v == (u2*a + v2)*a**n (mod (a-1)**2)`
+    """
+    s = u + v
+    if s == 0:
+        # if u >= 0 and v >= 0:
+        if u == 0 and v == 0:
+            return d, u, v
+        return None
+    if s < 0 or u < 0:
+        return None
+    if -v <= d * s <= u:
+        n = d
+    elif d * s > u:
+        n = u // s
+    else: # d < -v/(u+v) and v < 0
+        # n = (-v - 1)//s + 1
+        n = -(v // s)
+    u2, v2 = u - s * n, v + s * n
+    if not (n >= 0 and u2 >= 0 and v2 >= 0):
+        return None
+    return n, u2, v2
 
 
 def sos_struct_dense_symmetric(coeff, real=True):
@@ -16,7 +51,6 @@ def sos_struct_dense_symmetric(coeff, real=True):
     if coeff.total_degree() < 8 or not coeff.is_symmetric():
         return None
     return _sos_struct_dense_symmetric(coeff, real)
-
 
 
 def _sos_struct_dense_symmetric(coeff, real=True):
@@ -180,7 +214,7 @@ def _sos_struct_lift_for_six(coeff: Coeff, real=True):
 
 
 @sos_struct_handle_uncentered
-def sos_struct_liftfree_for_six(coeff, real=True):
+def sos_struct_liftfree_for_six(coeff: Coeff, real=True):
     """
     Solve high-degree (dense) symmetric inequalities without
     lifting the degree. This will be tried in prior because
@@ -223,20 +257,12 @@ def sos_struct_liftfree_for_six(coeff, real=True):
     # so that the symmetric axis of the remaining part is a multiple of (a-1)^4
     u, v = div2[1].coeff_monomial((1,)), div2[1].coeff_monomial((0,))
 
-    # note that a^n = (-n*a + (n+1))  (mod (a-1)^2)
-    # we find integer n such that (u*a + v)*(-n*a + (n+1)) + nu(a-1)^2 >= 0
-    # it is equivalent to -v/(u+v) <= n <= u/(u+v)
-    if u + v <= 0 or u < 0:
+    # find n, u2, v2 >= 0 that (u*a + v) == (u2*a + v2)*a**n (mod (a-1)**2)
+    inv = _linear_invert(u, v, (d+1)//3 - 1)
+    if inv is None:
         return None
-    expected = (d+1)//3 - 1
-    if -v <= expected * (u+v) <= u:
-        n = expected
-    elif expected * (u+v) > u:
-        n = u // (u+v)
-    else: # expected < -v/(u+v) and v < 0
-        n = (-v - 1)//(u+v) + 1
-    u2, v2 = u - (u+v)*n, v + (u+v)*n
-    if not (n <= d - 3 and n >= 0 and u2 >= 0 and v2 >= 0):
+    n, u2, v2 = inv
+    if not n <= d - 3:
         return None
 
     m = (d - n - 3) // 2
@@ -281,7 +307,7 @@ def sos_struct_liftfree_for_six(coeff, real=True):
         return subtractor + solution
 
 
-def _sos_struct_liftfree_for_six_ord4(coeff, div2=None, real=True):
+def _sos_struct_liftfree_for_six_ord4(coeff: Coeff, div2=None, real=True):
     """
     Solve a high-degree (dense) symmetric inequality where (a-1)^4 is a factor
     of the symmetric axis. Such polynomial can be seen as:
@@ -315,3 +341,13 @@ def _sos_struct_liftfree_for_six_ord4(coeff, div2=None, real=True):
     sol_diff = _sos_struct_dense_symmetric(coeff.from_poly(diff))
     if sol_diff is not None:
         return CyclicSum(lifted_sym * (a-b)**2*(a-c)**2) + CyclicProduct((a-b)**2) * sol_diff
+
+#####################################################################
+#
+#                              Acyclic
+#
+#####################################################################
+
+@sos_struct_reorder_symmetry(groups=(2, 1))
+def sos_struct_ternary_partial_symmetric(coeff: Coeff):
+    return None

--- a/triples/core/structsos/ternary/dense_symmetric.py
+++ b/triples/core/structsos/ternary/dense_symmetric.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Optional
+from typing import Tuple, List, Optional, Union
 
 from sympy import Poly, Expr, Symbol, Add
 
@@ -99,8 +99,6 @@ def _sos_struct_trivial_additive(coeff: Coeff, real=True):
     return CyclicSum(Add(*exprs))
 
 
-
-
 def sym_axis(coeff: Coeff, d: int = -1) -> Poly:
     """Compute f(a,1,1)."""
     if d == -1: d = coeff.total_degree()
@@ -110,7 +108,8 @@ def sym_axis(coeff: Coeff, d: int = -1) -> Poly:
     a = coeff.gens[0]
     return coeff.from_list(coeff_list[::-1], gens=(a,)).as_poly()
 
-def _homogenize_sym_axis(coeff: Coeff, sym: Poly, d: int) -> Expr:
+
+def _homogenize_sym_axis(coeff: Union[Coeff, Poly], sym: Poly, d: int) -> Expr:
     """Homogenize f(a,1,1) to f(a,b,c) given degree."""
     a, b, c = coeff.gens
     s = [0]
@@ -350,4 +349,76 @@ def _sos_struct_liftfree_for_six_ord4(coeff: Coeff, div2=None, real=True):
 
 @sos_struct_reorder_symmetry(groups=(2, 1))
 def sos_struct_ternary_partial_symmetric(coeff: Coeff):
-    return None
+    """
+    Solve a homogeneous 3-var inequality `f(a,b,c) >= 0` where
+    `f(a, b, c) == f(b, a, c)`.
+    
+    Examples
+    --------
+    => ((2a+2b+c)c-2ab)2(a+b)+3ab(4((a-b)2+c2)s(a)+8c(ab-c2)-9c2(a+b))
+    """
+    if all(v >= 0 for v in coeff.coeffs()):
+        return coeff.as_poly().as_expr()
+    if coeff.total_degree() <= 1:
+        return None
+
+    a, b, c = coeff.gens
+    poly = coeff.as_poly()
+    axis = poly.eval((1,1))
+    div, rem = axis.div(Poly([1,-2,1], c, domain=axis.domain))
+    if not rem.is_zero:
+        return None
+    div, rem = div.div(Poly([1,-2,1], c, domain=div.domain))
+
+    # subtract something so that the remaining f(a,b,c) has (c-1)**4 | f(1, 1, c)
+    d = coeff.total_degree()
+    inv = _linear_invert(rem.coeff_monomial((1,)), rem.coeff_monomial((0,)),
+                         (d+1)//3 - 1)
+    if inv is None:
+        return None
+    n, u2, v2 = inv
+
+    subtractor = Add()
+    m = (d - n - 3) // 2
+    if m < 0:
+        return None
+    elif (d - n - 3) % 2 == 0:
+        subtractor = a**m*b**m*c**n*(u2*c + v2/2*(a + b))*(2*c - a - b)**2/4
+    else:
+        m = (d - n - 3) // 2
+        subtractor = a**m*b**m*c**n*(u2/2*c*(a + b) + v2*a*b)*(2*c - a - b)**2/4
+
+    remain = poly - subtractor.as_poly(a, b, c, domain=coeff.domain)
+    sol = _sos_struct_ternary_partial_symmetric_ord4(coeff.from_poly(remain))
+    if sol is not None:
+        return subtractor + sol
+
+
+def _sos_struct_ternary_partial_symmetric_ord4(coeff: Coeff):
+    """
+    Solve a homogeneous 3-var inequality `f(a,b,c) >= 0` where
+    `f(a, b, c) == f(b, a, c)` and `(c - 1)**4 | f(1, 1, c)`.
+    """
+    a, b, c = coeff.gens
+    poly = coeff.as_poly()
+    div2, rem2 = poly.eval((1,1)).div(Poly([1, -4, 6, -4, 1], c, domain=poly.domain))
+
+    # print('div2', div2, 'rem2', rem2)
+    if not rem2.is_zero:
+        # not expected to happen
+        return None
+
+    if not all(v >= 0 for v in div2.coeffs()):
+        return None
+
+    d = coeff.total_degree()
+    sym = _homogenize_sym_axis(Poly(0, c, a, b), div2, d - 4)
+    remain2 = poly - (sym*(a - c)**2*(b - c)**2).as_poly(a, b, c, domain=poly.domain)
+    div3, rem3 = remain2.div((a - b).as_poly(a, b, domain=remain2.domain)**2)
+    if not rem3.is_zero:
+        # not expected to happen
+        return None
+
+    sol = sos_struct_ternary_partial_symmetric(coeff.from_poly(div3))
+    if sol is not None:
+        return sym * (a-c)**2*(b-c)**2 + sol * (a-b)**2

--- a/triples/core/structsos/ternary/dense_symmetric.py
+++ b/triples/core/structsos/ternary/dense_symmetric.py
@@ -17,7 +17,7 @@ def _linear_invert(u, v, d: int = 0) -> Optional[Tuple[int, Expr, Expr]]:
 
     This is equivalent to `-v/(u + v) <= n <= u/(u + v)`.
 
-    Note that `a^(-n) == (-n*a + (n+1))  (mod (a-1)^2)` and   
+    Note that `a^(-n) == (-n*a + (n+1))  (mod (a-1)^2)` and
     `(u*a + v)*(-n*a + (n+1)) + n*u*(a-1)**2 == (u - (u + v)*n)*a + v + (u + v)*n`,
     so this implies:
     `u*a + v == (u2*a + v2)*a**n (mod (a-1)**2)`
@@ -348,11 +348,11 @@ def _sos_struct_liftfree_for_six_ord4(coeff: Coeff, div2=None, real=True):
 #####################################################################
 
 @sos_struct_reorder_symmetry(groups=(2, 1))
-def sos_struct_ternary_partial_symmetric(coeff: Coeff):
+def sos_struct_ternary_partial_symmetric(coeff: Coeff, real=True):
     """
     Solve a homogeneous 3-var inequality `f(a,b,c) >= 0` where
     `f(a, b, c) == f(b, a, c)`.
-    
+
     Examples
     --------
     => ((2a+2b+c)c-2ab)2(a+b)+3ab(4((a-b)2+c2)s(a)+8c(ab-c2)-9c2(a+b))

--- a/triples/core/structsos/ternary/nonic.py
+++ b/triples/core/structsos/ternary/nonic.py
@@ -4,7 +4,7 @@ from sympy import Poly, Symbol, Rational, Add
 from .sextic_symmetric import _sos_struct_sextic_hexagram_symmetric, _sos_struct_sextic_tree
 from .utils import (
     Coeff, CommonExpr,
-    sum_y_exprs, rationalize_func, inverse_substitution, nroots, align_cyclic_group
+    sum_y_exprs, rationalize_func, inverse_substitution, align_cyclic_group
 )
 
 def sos_struct_nonic(coeff, real = True):

--- a/triples/core/structsos/ternary/octic.py
+++ b/triples/core/structsos/ternary/octic.py
@@ -16,8 +16,6 @@ def sos_struct_octic(coeff: Coeff, real = True):
         return None
 
     if not any(coeff(_) for _ in [(6,2,0), (6,1,1), (6,0,2)]):
-        a, b, c = coeff.gens
-        CyclicSum = coeff.cyclic_sum
         # equivalent to degree-7 hexagon when applying (a,b,c) -> (1/a,1/b,1/c)
         poly2 = [((i, j, 7-i-j), coeff((i+j-2,5-i,5-j))) for i in range(5, -1, -1) for j in range(5, -1, -1) if 0 <= 7-i-j <= 5]
         poly2 = coeff.from_dict(dict(poly2))

--- a/triples/core/structsos/ternary/octic_symmetric.py
+++ b/triples/core/structsos/ternary/octic_symmetric.py
@@ -2,7 +2,7 @@ import sympy as sp
 from sympy import Poly, Symbol, Integer, Rational, Add, sign
 from sympy import MutableDenseMatrix as Matrix
 
-from .sextic_symmetric import _restructure_quartic_polynomial
+# from .sextic_symmetric import _restructure_quartic_polynomial
 
 from .utils import (
     Coeff, CommonExpr, DomainExpr,
@@ -774,38 +774,38 @@ def _sos_struct_octic_symmetric_quadratic_form(poly, coeff: Coeff):
     """
     return
 
-    a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    # a, b, c = coeff.gens
+    # CyclicSum = coeff.cyclic_sum
 
-    # We require multiplicity 2 at (1,1,0) along the symmetric axis.
-    sym = poly.subs({b:1,c:1}).div(Poly([1,-2,1,0,0], a))
-    if not sym[1].is_zero:
-        return None
+    # # We require multiplicity 2 at (1,1,0) along the symmetric axis.
+    # sym = poly.subs({b:1,c:1}).div(Poly([1,-2,1,0,0], a))
+    # if not sym[1].is_zero:
+    #     return None
 
-    sym_axis = _restructure_quartic_polynomial(sym[0])
-    if sym_axis is None:
-        return None
-    t, coeff0, x, y, rem_coeff, rem_ratio = sym_axis
+    # sym_axis = _restructure_quartic_polynomial(sym[0])
+    # if sym_axis is None:
+    #     return None
+    # t, coeff0, x, y, rem_coeff, rem_ratio = sym_axis
 
-    # ker_coeff is the remaining coefficient of (a-b)^2(b-c)^2(c-a)^2*s(a^2) and (a-b)^2(b-c)^2(c-a)^2*s(ab)
-    # of Poly - (t*s(a2-ab)s(a3-a2b-a2c+abc)2 + coeff0 * F(x,y) + rem * s(a^2(a-b)(a-c))s(a^2+rab)^2)
-    ker_coeff1 = poly.coeff_monomial((6,2,0)) - (2*t + coeff0 * (2*x**2 - 2*x*y - 2*x + y**2 + 1))
-    ker_coeff2 = poly.coeff_monomial((5,3,0)) - (3*t + coeff0 * (-3*x**2 + 2*x*y + 4*x - y**2 - 2))
-    if rem_ratio is sp.oo:
-        # degenerates to s(a^2(a-b)(a-c))s(ab)^2
-        ker_coeff1 -= rem_coeff
-        ker_coeff2 += rem_coeff
-    else:
-        ker_coeff1 -= rem_coeff*(rem_ratio**2 - 2*rem_ratio + 2)
-        ker_coeff2 -= rem_coeff*(-rem_ratio**2 + 2*rem_ratio - 3)
-    ker_coeff = (ker_coeff1, ker_coeff2 + 2*ker_coeff1)
+    # # ker_coeff is the remaining coefficient of (a-b)^2(b-c)^2(c-a)^2*s(a^2) and (a-b)^2(b-c)^2(c-a)^2*s(ab)
+    # # of Poly - (t*s(a2-ab)s(a3-a2b-a2c+abc)2 + coeff0 * F(x,y) + rem * s(a^2(a-b)(a-c))s(a^2+rab)^2)
+    # ker_coeff1 = poly.coeff_monomial((6,2,0)) - (2*t + coeff0 * (2*x**2 - 2*x*y - 2*x + y**2 + 1))
+    # ker_coeff2 = poly.coeff_monomial((5,3,0)) - (3*t + coeff0 * (-3*x**2 + 2*x*y + 4*x - y**2 - 2))
+    # if rem_ratio is sp.oo:
+    #     # degenerates to s(a^2(a-b)(a-c))s(ab)^2
+    #     ker_coeff1 -= rem_coeff
+    #     ker_coeff2 += rem_coeff
+    # else:
+    #     ker_coeff1 -= rem_coeff*(rem_ratio**2 - 2*rem_ratio + 2)
+    #     ker_coeff2 -= rem_coeff*(-rem_ratio**2 + 2*rem_ratio - 3)
+    # ker_coeff = (ker_coeff1, ker_coeff2 + 2*ker_coeff1)
 
-    # print('Coeff =', coeff0, 'ker =', ker_coeff)
-    # print('  (x,y) =', (x, y), 'ker_std =', ker_coeff / coeff0)
+    # # print('Coeff =', coeff0, 'ker =', ker_coeff)
+    # # print('  (x,y) =', (x, y), 'ker_std =', ker_coeff / coeff0)
 
-    return _octic_sym_axis.solve(
-        coeff0, x, y, ker_coeff, t, rem_coeff, rem_ratio
-    )
+    # return _octic_sym_axis.solve(
+    #     coeff0, x, y, ker_coeff, t, rem_coeff, rem_ratio
+    # )
 
 
 class _octic_sym_axis(DomainExpr):
@@ -822,8 +822,8 @@ class _octic_sym_axis(DomainExpr):
     """
 
     def rem_poly(self, rem_coeff, rem_ratio):
-        a, b, c = self.gens
-        CyclicSum, CyclicProduct = self.cyclic_sum, self.cyclic_product
+        a, b, _ = self.gens
+        CyclicSum = self.cyclic_sum
         return rem_coeff * (CyclicSum(a**2 + rem_ratio*a*b)**2 if not rem_ratio is sp.oo else CyclicSum(a*b)**2)
 
     def _wrap_F(self, f_type, f_solver):

--- a/triples/core/structsos/ternary/octic_symmetric.py
+++ b/triples/core/structsos/ternary/octic_symmetric.py
@@ -1,5 +1,5 @@
 import sympy as sp
-from sympy import Poly, Symbol, Rational, Add
+from sympy import Poly, Symbol, Integer, Rational, Add, sign
 from sympy import MutableDenseMatrix as Matrix
 
 from .sextic_symmetric import _restructure_quartic_polynomial
@@ -24,7 +24,7 @@ def _solve_inverse_quartic(coeff: Coeff, m, p, n, r):
         if m != 0 and (n - ((p / m)**2 - 1) * m) >= 0:
             y = [
                 m / 2,
-                (n - ((p / m)**2 - 1) * m) / 2 if m != 0 else sp.S(0),
+                (n - ((p / m)**2 - 1) * m) / 2 if m != 0 else Integer(0),
                 m + 2*p + n + r
             ]
             exprs = [
@@ -118,7 +118,7 @@ def _sos_struct_octic_symmetric_hexagon_sdp(coeff: Coeff):
         return Poly.from_list(_M, gen)
 
     def stack_quad_form(M00t, M01t, M02t, M22t):
-        return sp.Matrix([
+        return Matrix([
             [M00t, M01t, M02t],
             [M01t, M00t, M02t],
             [M02t, M02t, M22t]
@@ -213,7 +213,7 @@ def _sos_struct_octic_symmetric_hexagon_sdp(coeff: Coeff):
 
 
         def _is_valid(t):
-            return sp.sign(det(t)) * sp.sign(t) * sp.sign(t+1) >= 0 and M00t(t) >= abs(M01t(t))
+            return sign(det(t)) * sign(t) * sign(t+1) >= 0 and M00t(t) >= abs(M01t(t))
 
         # det is a 6-degree polynomial with respect to t
         t = rationalize_func(det.diff(), _is_valid)
@@ -230,16 +230,16 @@ def _sos_struct_octic_symmetric_hexagon_sdp(coeff: Coeff):
             if p4 != 0:
                 x_ = -w2/w1/(t+1)*(p4 + 9*t*w1*w2)/p4
                 r = p4**2/(162*t**2*w2**2*w4)
-                u210 = sp.S(1)
+                u210 = Integer(1)
                 u201 = x_ * t
                 u102 = 2 + w2/w1 + x_
                 u111 = u111_/(w1*(t + 1)*p4)
             else:
                 x_ = -w2/w1/(t+1)*(p4 + 9*t*w1*w2)
                 r = x_**2/(162*t**2*w2**2*w4)
-                u210 = sp.S(0)
+                u210 = Integer(0)
                 u201 = t
-                u102 = sp.S(1)
+                u102 = Integer(1)
                 u111 = u111_/(-w2*(p4 + 9*t*w1*w2))
         else:
             # take limit t -> -1
@@ -251,7 +251,7 @@ def _sos_struct_octic_symmetric_hexagon_sdp(coeff: Coeff):
             M22t = (81*c440*w1 + 27*c440*w2 - 81*c611*w1 - 27*c611*w2 + 18*w1**2 - 12*w1*w2 - 7*w2**2)/(27*(3*w1 + w2))
             u111 = -(-9*w1*w2 - 2*w2**2)/(3*w1*w2)
 
-            u210 = sp.S(1)
+            u210 = Integer(1)
             u201 = x_ * t
             u102 = 2 + w2/w1 + x_
 
@@ -306,13 +306,13 @@ def _sos_struct_octic_symmetric_hexagon_sdp(coeff: Coeff):
 
 
         def _is_valid(t):
-            return t != 0 and sp.sign(det(t)) * sp.sign(t) >= 0 and M00t(t) >= abs(M01t(t))
+            return t != 0 and sign(det(t)) * sign(t) >= 0 and M00t(t) >= abs(M01t(t))
 
         t = rationalize_func(det.diff(), _is_valid)
         if t is None:
             return None
 
-        u210 = sp.S(1)
+        u210 = Integer(1)
         u201 = t
         u102 = -(t + 1)*(3*t*w2 - t*w4 + 2*w4)/(3*t*w2 - t*w4 - w4)
         u111 = -(3*t**2*w2 - t**2*w4 - 3*t*w2 + 3*t*w4 - 5*w4)/(3*t*w2 - t*w4 - w4)
@@ -344,7 +344,7 @@ def _sos_struct_octic_symmetric_hexagon_sdp(coeff: Coeff):
         The constraints then converts to.
         """
         def _compute_params(x, y):
-            u210 = sp.S(1)
+            u210 = Integer(1)
             u201 = y
             u102 = x / (-w1) - y - 1
 
@@ -491,8 +491,8 @@ def _sos_struct_octic_symmetric_hexagon_sdp(coeff: Coeff):
 
         if c611 + 2*c620 == 0:
             # r = 0 is a must by the constraint M00 + M01 >= 0 and r >= 0.
-            r = sp.S(0)
-            u111, u102, u201 = sp.S(0), sp.S(0), sp.S(0)
+            r = Integer(0)
+            u111, u102, u201 = Integer(0), Integer(0), Integer(0)
             M00t = c620
             M01t = -c620
             M02t = c530/2
@@ -507,13 +507,13 @@ def _sos_struct_octic_symmetric_hexagon_sdp(coeff: Coeff):
             r = (2*c620 + c611)/2
             M00t = -(c611 + c620)
             M01t = -M00t
-            M02t = sp.S(0)
+            M02t = Integer(0)
             M22t = w5 / (c611 + 2*c620)
 
-        u210 = sp.S(1)
+        u210 = Integer(1)
         if c611 + 2*c620 != 0:
             u102 = -c530/(c611 + 2*c620)
-            u201 = sp.S(0)
+            u201 = Integer(0)
             u111 = -2*u102 - 1
         quad_form = stack_quad_form(M00t, M01t, M02t, M22t)
         return u210, u102, u201, u111, r, quad_form
@@ -573,7 +573,7 @@ def _sos_struct_octic_symmetric_hexagon(coeff: Coeff):
             # use xs((a-b)2((a2b+a2c+ab2-ac2+b2c-bc2)+y(ac2+bc2-2abc))2)+p(a-b)2s(za2+wab)
             # this enables nontrivial equality cases on the symmetric axis
             x_ = (2*c1 + c3)/8
-            y_ = -2*(2*c1 + c2 + c3 + c4)/(2*c1 + c3) if 2*c1 + c3 != 0 else sp.S(0)
+            y_ = -2*(2*c1 + c2 + c3 + c4)/(2*c1 + c3) if 2*c1 + c3 != 0 else Integer(0)
             z_ = (2*c1 - c3)/4
             w_ = (10*c1 + 6*c2 + c3 + 2*c4)/4
             if x_ >= 0 and z_ >= 0 and z_ + w_ >= 0:
@@ -670,15 +670,15 @@ def _sos_struct_octic_symmetric_hexagram(coeff: Coeff):
             h = (u_ - y_*t)/(t**2*x_ - v_)/2
             c2 = v_ - x_*t**2
             c3 = (2*t**3*x_**3 + 2*t*u_*x_*y_ - 2*t*v_*x_**2 - u_**2*x_ - v_*y_**2)/(x_*(v_ - t**2*x_)) + balance
-            c4 = sp.S(0)
+            c4 = Integer(0)
             break
         if bound_ == 0:
             # more special, v = xt^2
             # f = x(a^2 + r1*a(b+c) + t*bc)^2 + (u - ty)abc(b+c)
             #    + (z - y^2/(4x))a^2(b-c)^2 + (balance - (2*t*x**2 + y**2)/x) * a^2bc
             # WLOG z = y^2/(4x)
-            h = sp.S(0)
-            c2 = sp.S(0)
+            h = Integer(0)
+            c2 = Integer(0)
             c3 = balance - (2*t_*x_**2 + y_**2) / x_
             c4 = u_ - t_ * y_
 
@@ -751,8 +751,6 @@ def _sos_struct_octic_symmetric_hexagram(coeff: Coeff):
                 CyclicProduct(a**2) * CyclicSum(a*b) * multiplier,
             ]
             return sum_y_exprs(y, exprs) / multiplier
-
-
 
 
 def _sos_struct_octic_symmetric_quadratic_form(poly, coeff: Coeff):

--- a/triples/core/structsos/ternary/octic_symmetric.py
+++ b/triples/core/structsos/ternary/octic_symmetric.py
@@ -824,7 +824,7 @@ class _octic_sym_axis(DomainExpr):
     def rem_poly(self, rem_coeff, rem_ratio):
         a, b, _ = self.gens
         CyclicSum = self.cyclic_sum
-        return rem_coeff * (CyclicSum(a**2 + rem_ratio*a*b)**2 if not rem_ratio is sp.oo else CyclicSum(a*b)**2)
+        return rem_coeff * (CyclicSum(a**2 + rem_ratio*a*b)**2 if rem_ratio is not sp.oo else CyclicSum(a*b)**2)
 
     def _wrap_F(self, f_type, f_solver):
         if f_type == 0:

--- a/triples/core/structsos/ternary/quartic.py
+++ b/triples/core/structsos/ternary/quartic.py
@@ -512,7 +512,7 @@ def _sos_struct_quartic_uncentered(coeff: Coeff):
                         # already found
                         continue
                     extrema.append((eqn(root), root))
-        except Exception as e:
+        except Exception:
             pass
 
         if len(extrema) == 0:

--- a/triples/core/structsos/ternary/quartic.py
+++ b/triples/core/structsos/ternary/quartic.py
@@ -5,7 +5,7 @@ from sympy import Poly, Expr, Symbol, Rational, Integer, Float, Add
 from sympy import MutableDenseMatrix as Matrix
 
 from .utils import (
-    Coeff,
+    Coeff, sos_struct_reorder_symmetry,
     congruence, sum_y_exprs, quadratic_weighting,
     nroots, rationalize, rationalize_bound, rationalize_func,
     univariate_intervals, common_region_of_conics
@@ -605,6 +605,7 @@ def sos_struct_acyclic_quartic(coeff, real = True):
     return _sos_struct_acyclic_quartic_real(coeff)
 
 
+@sos_struct_reorder_symmetry(groups=(2, 1))
 def _sos_struct_acyclic_quartic_symmetric(coeff: Coeff, real = True):
     """
     Solve acyclic quartic polynomials that are symmetric with respect to two variables.
@@ -656,18 +657,9 @@ def _sos_struct_acyclic_quartic_symmetric(coeff: Coeff, real = True):
         return
 
     monoms = [(4,0),(3,1),(2,2),(3,0),(2,1),(2,0),(1,0),(1,1),(0,0)]
-    mappings = [(lambda i, j: (i,j,4-i-j)), (lambda i, j: (i,4-i-j,j)), (lambda i, j: (4-i-j,i,j))]
-
     a, b, c = coeff.gens
 
-    symbol_orders = [(a,b,c), (a,c,b), (b,c,a)]
-    for symbol_order, mapping in zip(symbol_orders, mappings):
-        if all(coeff(mapping(i,j)) == coeff(mapping(j,i)) for i,j in ((4,0),(3,1),(3,0),(2,1),(2,0))):
-            break
-    else:
-        return None
-
-    c400, c310, c220, c301, c211, c202, c103, c112, c004 = [coeff(mapping(i, j)) for i, j in monoms]
+    c400, c310, c220, c301, c211, c202, c103, c112, c004 = [coeff((i, j, 4-i-j)) for i, j in monoms]
     w4 = c004
     w3 = 2*c103
     w2 = c112 + 2*c202
@@ -692,7 +684,7 @@ def _sos_struct_acyclic_quartic_symmetric(coeff: Coeff, real = True):
         US2 = congruence(M2)
         if US1 is None or US2 is None:
             return None
-        a, b, c = symbol_order
+        a, b, c = coeff.gens
 
         def _US_vec(US, vec):
             U, S = US
@@ -894,7 +886,7 @@ def _sos_struct_acyclic_quartic_real(coeff: Coeff):
     => (20a4-94a3b-12a3c+171a2b2+28a2bc+4a2c2-151ab3-11ab2c-8abc2+77b4-21b3c+7b2c2) # doctest:+SKIP
     """
     poly = coeff.as_poly()
-    roots = _sos_struct_acyclic_quartic_reaL_findroots(coeff, poly)
+    roots = _sos_struct_acyclic_quartic_real_findroots(coeff, poly)
     if roots is None:
         return None
 
@@ -979,7 +971,8 @@ def _sos_struct_acyclic_quartic_real(coeff: Coeff):
         ])
         return base_mat + addition
 
-def _sos_struct_acyclic_quartic_reaL_findroots(
+
+def _sos_struct_acyclic_quartic_real_findroots(
         coeff: Coeff, poly = None
     ) -> List[Tuple[Tuple[Float, Float, Float], Float, Expr]]:
     """

--- a/triples/core/structsos/ternary/quartic.py
+++ b/triples/core/structsos/ternary/quartic.py
@@ -81,7 +81,7 @@ def _sos_struct_quartic_core(coeff: Coeff):
     c1, c2, c3 = [(p+2*q)/m/3, (p-q)/m/3, -(2*p+q)/m/3]
 
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
     exprs = [
         CyclicSum((a**2 - b**2 + c1*a*c + c2*a*b + c3*b*c)**2),
         CyclicSum(a**2*(b-c)**2),
@@ -236,7 +236,7 @@ def _sos_struct_quartic_biased(coeff: Coeff):
         y = (symmetric(u) / (2*(u**2*(u**2 + 1) + 1)) * m)
         if y >= 0:
             a, b, c = coeff.gens
-            CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+            CyclicSum = coeff.cyclic_sum
             solution = y * CyclicSum((a*b*(a-u*b+(u-1)*c)**2)) + rem * CyclicSum(a**2*b*c)
 
             subs = {(3,1,0): y, (2,2,0): -2*u*y, (1,3,0): u**2*y, (2,1,1): rem - (u-1)**2*y}
@@ -269,7 +269,7 @@ def _sos_struct_quartic_degenerate(coeff: Coeff):
     m, p, n, q, r = coeff((4,0,0)), coeff((3,1,0)), coeff((2,2,0)), coeff((1,3,0)), coeff((2,1,1))
 
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     if m == 0 and p == 0 and q == 0 and n >= 0 and n + r >= 0 and r <= 2*n:
         # in this special case the polynomial is positive for real numbers
@@ -409,7 +409,7 @@ def _sos_struct_quartic_uncentered_real(coeff: Coeff):
         candidates = [w1approx, w2approx, w1, w2]
 
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     for w in candidates:
         if is_valid(w):
@@ -467,7 +467,7 @@ def _sos_struct_quartic_uncentered(coeff: Coeff):
         return _sos_struct_quartic_degenerate(coeff)
 
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     # if we reach here, it means that the inequality does not hold for all real numbers
     # we can subtract as many s(a^2bc) as possible
@@ -723,16 +723,16 @@ def _sos_struct_acyclic_quartic_symmetric(coeff: Coeff, real = True):
             # TODO: consider r00 == r01 == 0 or r01 == r11 == 0 separately
 
         # find (a, b, l) such that det1 >= 0
-        det1 = dict([
+        det1 = [
             ((2, 0, 0), -w4**2),
             ((0, 2, 1), -16*w4),
             ((0, 2, 0), w3**2),
             ((0, 0, 0), w4*(-4*c310 + w0))
-        ])
-        det1 = Poly.from_dict(det1, (a, b, l))
+        ]
+        det1 = Poly.from_dict(dict(det1), (a, b, l))
 
         # find (a, b, l) such that det2 >= 0
-        det2 = dict([
+        det2 = [
             ((2, 0, 1), -32*w4**3),
             ((2, 0, 0), w4**2*(8*w2*w4 - w3**2)),
             ((1, 1, 0), 2*w4*(8*w1*w4**2 - 4*w2*w3*w4 + w3**3)),
@@ -744,8 +744,8 @@ def _sos_struct_acyclic_quartic_symmetric(coeff: Coeff, real = True):
             ((0, 1, 1), -16*w4*(4*c202*w3 - 16*c301*w4 + 2*w1*w4 - w2*w3)),
             ((0, 1, 0), 2*w4*(-16*c202*w1*w4 + 8*c202*w2*w3 - 8*c301*w3**2 + 4*w1*w2*w4 + w1*w3**2 - 2*w2**2*w3)),
             ((0, 0, 0), w4**2*(64*c202*c310 + 256*c202*c400 - 32*c202*w0 - 64*c301**2 + 16*c301*w1 - 16*c310*w2 - 64*c400*w2 + 8*w0*w2 - w1**2))
-        ])
-        det2 = Poly.from_dict(det2, (a, b, l))
+        ]
+        det2 = Poly.from_dict(dict(det2), (a, b, l))
 
         def _get_solution_from_ab(a, b, l):
             r11 = (-2*a*c004*w4 + 2*b*c004*w3 - 4*b*c103*w4 - c112*w4 + 2*c202*w4)/(4*w4)
@@ -796,15 +796,15 @@ def _sos_struct_acyclic_quartic_symmetric(coeff: Coeff, real = True):
         if leading_det < 0:
             return None
         elif leading_det > 0:
-            det1 = dict([
+            det1 = [
                 ((2, 0), -c112 - 2*c202),
                 ((1, 1), 2*(c211 + c301)),
                 ((1, 0), -(c112*c220 - 6*c112*c400 + 2*c202*c220 - 12*c202*c400 - c211**2 + 2*c211*c301 + 3*c301**2)/4),
                 ((0, 2), -c220 - 2*c310 - 2*c400),
                 ((0, 1), -(c211*c310 + 4*c211*c400 - 2*c220*c301 - 3*c301*c310)/2),
                 ((0, 0), (4*c112*c220*c400 - c112*c310**2 - 8*c112*c400**2 + 8*c202*c220*c400 - 2*c202*c310**2 - 16*c202*c400**2 - 4*c211**2*c400 + 4*c211*c301*c310 + 8*c211*c301*c400 - 4*c220*c301**2 - 4*c301**2*c310 + 4*c301**2*c400)/16)
-            ])
-            det1 = Poly.from_dict(det1, (a, b))
+            ]
+            det1 = Poly.from_dict(dict(det1), (a, b))
 
             det2 = (r11*a - b**2).as_poly(a, b)
 
@@ -910,18 +910,18 @@ def _sos_struct_acyclic_quartic_real(coeff: Coeff):
         ]
         return Matrix(M)
 
-    def get_constraints(base_mat, root):
-        a0, b0, c0 = root[0]
-        vec = Matrix([a0**2, b0**2, c0**2, a0*b0, b0*c0, c0*a0])
-        target = -base_mat * vec
-        A = [
-            [1, 0, 0, 0, 0, 0],
-            [a0**2/b0**2, 1, 0, 0, 0, 0],
-            [0, b0**2/c0**2, 1, 0, 0, 0],
-            [-2*a0/b0, 0, c0**2/(a0*b0), 1, 0, 0],
-            [0, -2*b0/c0, -c0/b0, 0, 1, 0],
-            [0, 0, -c0/a0, 0, 0, 1]
-        ]
+    # def get_constraints(base_mat, root):
+    #     a0, b0, c0 = root[0]
+    #     vec = Matrix([a0**2, b0**2, c0**2, a0*b0, b0*c0, c0*a0])
+    #     target = -base_mat * vec
+    #     A = [
+    #         [1, 0, 0, 0, 0, 0],
+    #         [a0**2/b0**2, 1, 0, 0, 0, 0],
+    #         [0, b0**2/c0**2, 1, 0, 0, 0],
+    #         [-2*a0/b0, 0, c0**2/(a0*b0), 1, 0, 0],
+    #         [0, -2*b0/c0, -c0/b0, 0, 1, 0],
+    #         [0, 0, -c0/a0, 0, 0, 1]
+    #     ]
 
     def _as_abc2_vec(expr):
         expr = expr.as_poly(a,b,c)

--- a/triples/core/structsos/ternary/quintic.py
+++ b/triples/core/structsos/ternary/quintic.py
@@ -98,7 +98,7 @@ def _solve_sa2minusab_mul_cubic(coeff: Coeff, x, y, mul = 1):
     When `(x, y)` is not on the curve, it would be a linear combination of two points on the curve.
     """
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
     if x >= 0 and y >= 0:
         cubic_poly = coeff.from_dict({(3,0,0): 1, (2,1,0): x, (1,2,0): y, (1,1,1): -3*(x+y+1)})
         return Rational(1,2) * mul * CyclicSum((a-b)**2) * sos_struct_cubic(cubic_poly)
@@ -268,7 +268,7 @@ def _sos_struct_quintic_full(coeff: Coeff):
         return None
 
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     # method 1
     solution = _solve_trivial_quintic_full(coeff)
@@ -725,8 +725,7 @@ def _sos_struct_quintic_windmill(coeff: Coeff):
         sol = _sos_struct_quintic_windmill(coeff.reflect())
         return align_cyclic_group(sol, coeff.gens)
 
-    a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    a = coeff.gens[0]
 
     # now we assume coeff((4,1,0)) == 0
     if coeff((1,4,0)) < 0:
@@ -1090,7 +1089,7 @@ def _sos_struct_quintic_windmill_quadratic(coeff: Coeff):
     """
 
     # Case A.
-    c1, c2, c3, c4 = coeff((1,4,0)), None, coeff((3,2,0)), Integer(0)
+    c1, c2, c3 = coeff((1,4,0)), None, coeff((3,2,0))
     c320, c230, c311, c221 = [coeff(_) for _ in [(3,2,0),(2,3,0),(3,1,1),(2,2,1)]]
 
     # Constraints on c2:

--- a/triples/core/structsos/ternary/septic.py
+++ b/triples/core/structsos/ternary/septic.py
@@ -3,7 +3,7 @@ from sympy import Poly, Rational, Float, Add, sqrt
 from .quartic import sos_struct_quartic
 from .septic_symmetric import sos_struct_septic_symmetric
 from .utils import (
-    Coeff, sum_y_exprs, nroots, rationalize_bound,
+    Coeff, nroots, rationalize_bound,
     zip_longest, align_cyclic_group, congruence_solve,
     sos_struct_handle_uncentered
 )

--- a/triples/core/structsos/ternary/septic.py
+++ b/triples/core/structsos/ternary/septic.py
@@ -176,7 +176,7 @@ def _sos_struct_septic_hexagon_subtract_quintic(coeff: Coeff):
         return None
 
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     p, q = coeff((4,3,0)) / coeff410, coeff((3,4,0)) / coeff410
     m0, p0, n0, q0 = [coeff((5-i,1+i,1)) for i in range(4)]
@@ -312,7 +312,7 @@ def _sos_struct_septic_hexagon_sdp(coeff: Coeff):
         return
 
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     c520, c430, c340, c502, c511, c421, c331, c241 = [
         coeff(_) for _ in [(5,2,0),(4,3,0),(3,4,0),(5,0,2),(5,1,1),(4,2,1),(3,3,1),(2,4,1)]]
@@ -496,7 +496,7 @@ def _sos_struct_septic_star_sdp(coeff: Coeff):
         return
 
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     c520, c430, c340, c502, c511, c421, c331, c241 = [
         coeff(_) for _ in [(5,2,0),(4,3,0),(3,4,0),(5,0,2),(5,1,1),(4,2,1),(3,3,1),(2,4,1)]]

--- a/triples/core/structsos/ternary/septic_symmetric.py
+++ b/triples/core/structsos/ternary/septic_symmetric.py
@@ -385,7 +385,7 @@ class _septic_sym_axis(DomainExpr):
         a, b, c = self.gens
         CyclicSum = self.cyclic_sum
         return rem_coeff * (CyclicSum(a**2 + rem_ratio*a*b)**2 \
-                            if not rem_ratio is Infinity else CyclicSum(a*b)**2)
+                            if rem_ratio is not Infinity else CyclicSum(a*b)**2)
 
     def solve(self, f_coeff, fx, fy, g_coeff, gx, gy, ker_coeff):
         a, b, c = self.gens

--- a/triples/core/structsos/ternary/septic_symmetric.py
+++ b/triples/core/structsos/ternary/septic_symmetric.py
@@ -68,7 +68,7 @@ def _sos_struct_septic_symmetric_quadratic_form(coeff: Coeff):
     => 3s(a)p(2a2+b2+c2)-4s(b(2a2+b2+c2)(2c2+a2+b2))s(a2)-10p(a-b)2s(a) # doctest:+SKIP
     """
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     poly = coeff.as_poly()
     sym = poly.eval((1,1)).div(coeff.from_list([1, -2, 1], (c,)).as_poly())
@@ -171,7 +171,7 @@ class _septic_sym_axis(DomainExpr):
         `F_{x,y} = 1/9 * s(a(a-b)^2(a-c)^2(3*(x-1)*a-(3*x-1)*(b+c)/2)^2) + (x-1)(9x-13)/12 * s(a) * p(a-b)^2`
         """
         a, b, c = self.gens
-        CyclicSum, CyclicProduct = self.cyclic_sum, self.cyclic_product
+        CyclicSum = self.cyclic_sum
 
         if 3*(x + y) == 5:
             p1 = (3*(x - 1)*a - (3*x-1)/2*b - (3*x-1)/2*c).together()
@@ -296,7 +296,7 @@ class _septic_sym_axis(DomainExpr):
         `G(x, y) = CyclicSum(a*(b-c)**2*p1**2)`
         """
         a, b, c = self.gens
-        CyclicSum, CyclicProduct = self.cyclic_sum, self.cyclic_product
+        CyclicSum = self.cyclic_sum
 
         # w = y - 2
         # p1 = a**2*(w + x - y + 1) + a*b*(-w + 2*y - 2) + a*c*(-w + 2*y - 2) + b**2*(x - 1) + b*c*w + c**2*(x - 1)
@@ -383,7 +383,7 @@ class _septic_sym_axis(DomainExpr):
 
     def rem_poly(self, rem_coeff, rem_ratio):
         a, b, c = self.gens
-        CyclicSum, CyclicProduct = self.cyclic_sum, self.cyclic_product
+        CyclicSum = self.cyclic_sum
         return rem_coeff * (CyclicSum(a**2 + rem_ratio*a*b)**2 \
                             if not rem_ratio is Infinity else CyclicSum(a*b)**2)
 

--- a/triples/core/structsos/ternary/sextic.py
+++ b/triples/core/structsos/ternary/sextic.py
@@ -225,7 +225,7 @@ def _sos_struct_sextic_hexagram(coeff: Coeff):
                 y3_bound_var = 729*(x - 8)**3*x/1024
                 if y3 < y3_bound_mean and (y3 - y3_bound_mean)**2 == y3_bound_var:
                     # y3, y3_copy, y, y_copy = y3_bound, y3, y3_bound**Rational(1,3), y
-                    y3, y3_copy, y, y_copy = y3, y3, y, y
+                    y3, _, y, y_copy = y3, y3, y, y
 
                     r = (81*x**5 + 2025*x**4 - 21*x**3*y3 + 17658*x**3 - 2406*x**2*y3 + 62370*x**2 - 16*x*y**6 - 10773*x*y3 + 79461*x + 864*y**6 - 18468*y3 + 32805)\
                         /(y*(27*x**5 + 891*x**4 - 16*x**3*y3 + 9558*x**3 - 1112*x**2*y3 + 41742*x**2 - 6336*x*y3 + 78975*x + 384*y**6 - 10044*y3 + 45927))
@@ -707,24 +707,20 @@ def _sos_struct_sextic_hexagon_sdp2(coeff: Coeff):
     # detur3 = det(M) * 27x^3 * z >= 0
     # To make the quad-form PSD, we let detur3, a cubic poly of z with params (x,y), positive.
     # This is done by optimizing the discriminant.
-    detur3 = _get_detur3()
+    # detur3 = _get_detur3()
 
-    if False:
-        # too slow by computing the exact extrema from the resultant
-        from time import time
-        time0 = time()
-        discriminant = detur3.discriminant().as_poly(x, y)
-        discriminant_diffx = discriminant.diff(0)
-        discriminant_diffy = discriminant.diff(1)
-        discriminant_gcd = discriminant.gcd(discriminant_diffx).factor_list()
-        time1 = time()
-        print('Time:', time1 - time0)
-        print('GCD =', discriminant_gcd)
+    # if False:
+    #     # too slow by computing the exact extrema from the resultant
+    #     from time import time
+    #     time0 = time()
+    #     discriminant = detur3.discriminant().as_poly(x, y)
+    #     discriminant_diffx = discriminant.diff(0)
+    #     discriminant_diffy = discriminant.diff(1)
+    #     discriminant_gcd = discriminant.gcd(discriminant_diffx).factor_list()
+    #     time1 = time()
+    #     print('Time:', time1 - time0)
+    #     print('GCD =', discriminant_gcd)
 
-    # Alternative:
-    if True:
-        # first detect whether ...
-        pass
 
 def _sos_struct_sextic_hexagon_to_hexagram(coeff: Coeff):
     """
@@ -803,14 +799,14 @@ def _sos_struct_sextic_hexagon_to_hexagram(coeff: Coeff):
         if not _check_valid(c3):
             c3 = None
     else:
-        eq = coeff.from_list([1, 0, -4*c1*c2], (a,)).as_poly()
+        eq = coeff.from_list([1, 0, -4*c1*c2], (coeff.gens[0],)).as_poly()
         c3 = rationalize_func(eq, _check_valid, validation_initial = lambda x: x >= 0, direction = -1)
 
     if c3 is not None:
         remain_solution = _sos_struct_sextic_hexagram(_compute_subtracted_params(c3, return_func = True))
         if remain_solution is not None:
             a, b, c = coeff.gens
-            CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+            CyclicSum = coeff.cyclic_sum
 
             mapping = lambda x: CyclicSum((x[0]*a**2*b + x[1]*a*b**2 - (x[0]+x[1])*a*b*c).together())**2
             main_solution = quadratic_weighting(coeff, c1, -c3, c2, mapping = mapping)
@@ -859,7 +855,7 @@ def _sos_struct_sextic_full_sdp(coeff: Coeff):
         return None
 
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     # Working on the sympy polynomial ring, which is faster
     ring = coeff.domain[a, b]
@@ -884,8 +880,8 @@ def _sos_struct_sextic_full_sdp(coeff: Coeff):
             (q[1,1]*(a**2*b-a*b*c)+q[1,2]*(a*b**2-a*b*c)),
             (q[2,2]*(a*b**2-a*b*c))
         ]
-        quad_form_sol = map(lambda x: CyclicSum(x.expand().together())**2, quad_form_sol)
-        return sum_y_exprs(ss, list(quad_form_sol))
+        quad_form_sol = [CyclicSum(x.expand().together())**2 for x in quad_form_sol]
+        return sum_y_exprs(ss, quad_form_sol)
 
     # rest form is what the original polynomial subtracts the quadratic form,
     # corresponding to the coefficients of a^4bc, a^3b^2c, a^2b^3c

--- a/triples/core/structsos/ternary/sextic.py
+++ b/triples/core/structsos/ternary/sextic.py
@@ -1,4 +1,4 @@
-from sympy import Poly, Expr, Symbol, Rational, Float, Add
+from sympy import Poly, Expr, Rational, Float, Add
 from sympy import MutableDenseMatrix as Matrix
 
 from .cubic import sos_struct_cubic

--- a/triples/core/structsos/ternary/sextic.py
+++ b/triples/core/structsos/ternary/sextic.py
@@ -58,7 +58,7 @@ def _sos_struct_sextic_hexagram(coeff: Coeff):
     => s(3a4bc+2a3b3+a3bc2-6a2b2c2)
 
     => s((sqrt(2)+9)a4bc+(4*sqrt(2)+9)a3b3+(-19+3*sqrt(2))a3b2c+(-33*sqrt(2)-12)a3bc2+(13+25*sqrt(2))a2b2c2)
- 
+
     => (s(a2c)s(b2c)+25/2p(a2)-27/4s(a2c)p(a))
 
     => s(a2c)s(b2c)+9p(a2)-15*4^(-2/3)p(a)s(a2b)

--- a/triples/core/structsos/ternary/sextic.py
+++ b/triples/core/structsos/ternary/sextic.py
@@ -45,11 +45,11 @@ def _sos_struct_sextic_hexagram(coeff: Coeff):
 
     Examples
     --------
-    => s(a3b3+7a4bc-29a3b2c+12a3bc2+9a2b2c2) # doctest:+SKIP
+    => s(a3b3+7a4bc-29a3b2c+12a3bc2+9a2b2c2)
 
     => 9s(a3b3)+4s(a4bc)-11abcp(a-b)-37s(a3b2c)+72a2b2c2
 
-    => s(11a4bc+11a3b3+153a3bc2-153a3b2c-22a2b2c2) # doctest:+SKIP
+    => s(11a4bc+11a3b3+153a3bc2-153a3b2c-22a2b2c2)
 
     => s(bc(a2-bc+2(ab-ac)+3(bc-ab))2)
 
@@ -57,6 +57,8 @@ def _sos_struct_sextic_hexagram(coeff: Coeff):
 
     => s(3a4bc+2a3b3+a3bc2-6a2b2c2)
 
+    => s((sqrt(2)+9)a4bc+(4*sqrt(2)+9)a3b3+(-19+3*sqrt(2))a3b2c+(-33*sqrt(2)-12)a3bc2+(13+25*sqrt(2))a2b2c2)
+ 
     => (s(a2c)s(b2c)+25/2p(a2)-27/4s(a2c)p(a))
 
     => s(a2c)s(b2c)+9p(a2)-15*4^(-2/3)p(a)s(a2b)
@@ -310,13 +312,22 @@ def _sos_struct_sextic_hexagram(coeff: Coeff):
             return frac1 / frac2
 
         u_, v_ = None, None
-        for root in nroots(eqv, method = 'factor', real = True, nonnegative = True):
+        eqvdiff = eqv.diff()
+        eqvgcd = eqv.gcd(eqvdiff)
+        if eqvgcd.total_degree() == 1:
+            root = coeff.convert(-eqvgcd.rep.TC() / eqvgcd.rep.LC())
             u_ = compute_u(root)
             if u_ * root > 1:
                 v_ = root
-                break
+            else:
+                u_, v_ = None, None
+        if v_ is None:
+            for root in nroots(eqv, method = 'factor', real = True, nonnegative = True):
+                u_ = compute_u(root)
+                if u_ * root > 1:
+                    v_ = root
+                    break
         if v_ is not None:
-            # now that we have obtained u and v
             # we are sure that f(a,b,c) * s(a) >= coeff((3,3,0)) * s(c(a2c-b2c-w(a2b-abc)+z(ab2-abc))2)
             # where w = (u^2+v)/(uv-1), z = (v^2+u)/(uv-1)
             # so we can subtract the right hand side and apply the quartic theorem
@@ -328,15 +339,16 @@ def _sos_struct_sextic_hexagram(coeff: Coeff):
                 det = 3 * m3 * (m3 + n3) - (p3**2 + p3 * q3 + q3**2)
                 return det, (m3, p3, n3, q3)
             def get_discriminant_uv(u, v):
+                u, v = coeff.convert(u), coeff.convert(v)
                 w, z = (u*u + v) / (u*v - 1), (v*v + u) / (u*v - 1)
                 m2, p2, n2, q2 = 0, r_*(w*w - 2*z), -r_*2*w*z, r_*(z*z - 2*w)
                 return get_discriminant(m2, p2, n2, q2)
 
-
-            det_ = None
-            # print('(u, v) =', (u_, v_))
-            # print('det =', get_discriminant_uv(u_, v_))
-            if get_discriminant_uv(u_, v_)[0] > -coeff.convert(10)**(-14):
+            u0, v0 = coeff.convert(u_), coeff.convert(v_)
+            det_, (m3, p3, n3, q3) = get_discriminant_uv(u0, v0)
+            if det_ == 0:
+                u, v = u0, v0
+            elif det_ > -coeff.convert(10)**(-14):
                 # first check that the result is good
 
                 # do rational approximation for both u and v
@@ -346,9 +358,11 @@ def _sos_struct_sextic_hexagram(coeff: Coeff):
                 ):
                     u, v = coeff.convert(u), coeff.convert(v)
                     det_, (m3, p3, n3, q3) = get_discriminant_uv(u, v)
-                    if isinstance(det_, Rational) and det_ >= 0:
+                    if det_ >= 0:
                         break
                     det_ = None
+            else:
+                det_ = None
 
             if det_ is not None:
                 w, z = (u**2 + v) / (u*v - 1), (v**2 + u) / (u*v - 1)
@@ -448,7 +462,7 @@ def _sos_struct_sextic_rotated_tree(coeff: Coeff):
 
     => s(20a4b2-26a3b2c-29a3bc2+35a2b2c2)
 
-    => s(a2b4+a3b2c-a3bc2-a2b2c2) # doctest:+SKIP
+    => s(a2b4+a3b2c-a3bc2-a2b2c2)
 
     => s(a4b2-14a3b2c+14a3bc2-1a2b2c2)
 
@@ -545,7 +559,7 @@ def _sos_struct_sextic_rotated_tree(coeff: Coeff):
             # Observation:
             # (t^3-3t, -3t(t-1)) and ((1-t)^3-3(1-t), -3(1-t)(1-t-1)) have equal y coordinates
             solution = _solve_regular(1 - t)
-            if solution is None:
+            if solution is not None:
                 return solution
 
     return None

--- a/triples/core/structsos/ternary/sextic_symmetric.py
+++ b/triples/core/structsos/ternary/sextic_symmetric.py
@@ -511,7 +511,7 @@ def _sos_struct_sextic_hexagram_symmetric(coeff: Coeff):
     if coeff((4,1,1)) != 0:
         x_ = coeff((3,3,0)) / coeff((4,1,1))
         y_ = coeff((3,2,1)) / coeff((4,1,1))
-        w_ = coeff((2,2,2)) / coeff((4,1,1))
+        # w_ = coeff((2,2,2)) / coeff((4,1,1))
         if x_ >= ((1 + x_ + y_)**2):
             # apply theorem 1
             # use vieta jumping, a point inside the parabola is a linear combination
@@ -1446,7 +1446,7 @@ class _sextic_sym_axis(DomainExpr):
         F(x,y) * s(mutiplier[0]*a^2 + multiplier[1]*a*b) = p1 + s(c1*a^2 + c2*a*b) * p(a-b)^2
         """
         a, b, c = self.gens
-        CyclicSum, CyclicProduct = self.cyclic_sum, self.cyclic_product
+        CyclicSum = self.cyclic_sum
         # p1 = 2 * (CyclicSum(a**2 - b*c)*CyclicSum(x*a**2 + y*a*b) - CyclicSum(a**4 - a**2*b*c))**2
         # s((x-1)a4+(y-x)a3(b+c)+(2x-y)a2b2-(x+y-1)a2bc)
         p1 = 2 * CyclicSum(a**2*((x-1)*a**2 + (y-x)*a*b + (y-x)*a*c \
@@ -1467,7 +1467,7 @@ class _sextic_sym_axis(DomainExpr):
         F(x,y) * s(mutiplier[0]*a^2 + multiplier[1]*a*b) = p1 + s(c1*a^2 + c2*a*b) * p(a-b)^2
         """
         a, b, c = self.gens
-        CyclicSum, CyclicProduct = self.cyclic_sum, self.cyclic_product
+        CyclicSum = self.cyclic_sum
         z = [-(2*x + y - 2)/(2*(x - 1)), (x + 2*y - 3)/(2*(x - 1))][z_type]
         def _compute_h_c1_c2(z):
             """
@@ -1546,7 +1546,7 @@ class _sextic_sym_axis(DomainExpr):
             return None
 
         a, b, c = self.gens
-        CyclicSum, CyclicProduct = self.cyclic_sum, self.cyclic_product
+        CyclicSum = self.cyclic_sum
         def _compute_h_c1_c2(z):
             h1 = 3*a**2*(x - 1)*w + 3*a*(b + c)*(x**2 + 2*x*y - 4*x + y**2 - 3*y + 3) \
                 + b*c*(3*x*y + 3*y**2 - 9*y + 4)
@@ -1566,7 +1566,7 @@ class _sextic_sym_axis(DomainExpr):
 
     def rem_poly(self, rem_coeff, rem_ratio):
         a, b, c = self.gens
-        CyclicSum, CyclicProduct = self.cyclic_sum, self.cyclic_product
+        CyclicSum = self.cyclic_sum
         return rem_coeff * (CyclicSum(a**2 + rem_ratio*a*b)**2 \
                             if not rem_ratio is Infinity else CyclicSum(a*b)**2)
 
@@ -1638,7 +1638,7 @@ class _sextic_sym_axis(DomainExpr):
         c2 = c12 + c22 + multiplier[1]*ker_coeff
 
         a, b, c = self.gens
-        CyclicSum, CyclicProduct = self.cyclic_sum, self.cyclic_product
+        CyclicProduct = self.cyclic_product
         multiplier_func = CommonExpr.quadratic(multiplier[0], multiplier[1], (a,b,c))
 
         if c1 >= 0 and c1 + c2 >= 0:
@@ -1906,14 +1906,14 @@ def _sos_struct_sextic_symmetric_ultimate(coeff: Coeff, real = True):
 
     => s(414a6-1470a5b-1470a5c+979a4b2+5864a4bc+979a4c2+644a3b3-5584a3b2c-5584a3bc2+5228a2b2c2) # doctest:+SKIP
     """
-    coeff6 = coeff((6,0,0))
+    # coeff6 = coeff((6,0,0))
     x0, x1, x2, x3, x4, x5 = [coeff(_) for _ in [(6,0,0),(5,1,0),(4,2,0),(3,3,0),(4,1,1),(3,2,1)]]
     rem = 3*(x0 + x3 + x4) + 6*(x1 + x2 + x5) + coeff((2,2,2))
 
     poly = None
 
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     # try trivial cases
     if True:

--- a/triples/core/structsos/ternary/sextic_symmetric.py
+++ b/triples/core/structsos/ternary/sextic_symmetric.py
@@ -1568,7 +1568,7 @@ class _sextic_sym_axis(DomainExpr):
         a, b, c = self.gens
         CyclicSum = self.cyclic_sum
         return rem_coeff * (CyclicSum(a**2 + rem_ratio*a*b)**2 \
-                            if not rem_ratio is Infinity else CyclicSum(a*b)**2)
+                            if rem_ratio is not Infinity else CyclicSum(a*b)**2)
 
     def _rem_regular(self, t_coeff, rem_coeff, rem_ratio, multiplier):
         """

--- a/triples/core/structsos/ternary/solver.py
+++ b/triples/core/structsos/ternary/solver.py
@@ -4,6 +4,7 @@ from sympy import Poly, Expr, Function
 from sympy.core.symbol import uniquely_named_symbol
 
 from .sparse  import sos_struct_sparse, sos_struct_heuristic
+from .dense_symmetric import sos_struct_ternary_partial_symmetric
 from .quadratic import sos_struct_quadratic, sos_struct_acyclic_quadratic
 from .cubic   import sos_struct_cubic, sos_struct_acyclic_cubic
 from .quartic import sos_struct_quartic, sos_struct_acyclic_quartic
@@ -68,6 +69,7 @@ def _structural_sos_3vars_acyclic(
     return sos_struct_common(coeff,
         sos_struct_acyclic_sparse,
         sos_struct_degree_specified_solver(SOLVERS_ACYCLIC, homogeneous=True),
+        sos_struct_ternary_partial_symmetric,
         real=real
     )
 

--- a/triples/core/structsos/ternary/solver.py
+++ b/triples/core/structsos/ternary/solver.py
@@ -4,7 +4,7 @@ from sympy import Poly, Expr, Function
 from sympy.core.symbol import uniquely_named_symbol
 
 from .sparse  import sos_struct_sparse, sos_struct_heuristic
-from .dense_symmetric import sos_struct_ternary_partial_symmetric
+from .dense_symmetric import sos_struct_ternary_dense_partial_symmetric
 from .quadratic import sos_struct_quadratic, sos_struct_acyclic_quadratic
 from .cubic   import sos_struct_cubic, sos_struct_acyclic_cubic
 from .quartic import sos_struct_quartic, sos_struct_acyclic_quartic
@@ -69,7 +69,7 @@ def _structural_sos_3vars_acyclic(
     return sos_struct_common(coeff,
         sos_struct_acyclic_sparse,
         sos_struct_degree_specified_solver(SOLVERS_ACYCLIC, homogeneous=True),
-        sos_struct_ternary_partial_symmetric,
+        sos_struct_ternary_dense_partial_symmetric,
         real=real
     )
 

--- a/triples/core/structsos/ternary/solver.py
+++ b/triples/core/structsos/ternary/solver.py
@@ -1,4 +1,4 @@
-from typing import Union, Dict, Optional, Any
+from typing import Union, Dict, Optional
 
 from sympy import Poly, Expr, Function
 from sympy.core.symbol import uniquely_named_symbol

--- a/triples/core/structsos/ternary/sparse.py
+++ b/triples/core/structsos/ternary/sparse.py
@@ -173,7 +173,7 @@ class AMGM3(DomainExpr):
     def solve(self, c1, m1, c2, m2):
         """Solve c1*CyclicSum(a**m1[0]*b**m1[1]*c**m1[2]) + c2*CyclicSum(a**m2[0]*b**m2[1]*c**m2[2]) >= 0."""
         a, b, c = self.gens
-        CyclicSum, CyclicProduct = self.cyclic_sum, self.cyclic_product
+        CyclicSum = self.cyclic_sum
 
         if c1 >= 0 and c2 >= 0: # TODO: handle real numbers??
             return c1*CyclicSum(a**m1[0]*b**m1[1]*c**m1[2]) + c2*CyclicSum(a**m2[0]*b**m2[1]*c**m2[2])
@@ -227,7 +227,7 @@ class AMGM3(DomainExpr):
         hand-side can be factored by (a-1)^2*(a+1)^2.
         """
         a, b, c = self.gens
-        CyclicSum, CyclicProduct = self.cyclic_sum, self.cyclic_product
+        CyclicSum = self.cyclic_sum
 
         v1, v2 = p - m1, m2 - p
         if v1.dot(v2) > 0:
@@ -443,7 +443,7 @@ def _separate_product_wrapper(recursion: Callable, coeff: Coeff) -> Callable:
     For instance, if we have CyclicProduct(a) * (CyclicProduct(a)*F(a,b,c) + G(a,b,c)),
     we had better expand it to CyclicProduct(a**2) * F(a,b,c) + CyclicProduct(a) * G(a,b,c).
     """
-    from ....utils import CyclicSum, CyclicProduct
+    from ....utils import CyclicProduct
     a = coeff.gens[0]
     cg = CyclicGroup(len(coeff))
     def _extract_cyclic_prod(x: Expr) -> Tuple[int, Expr]:

--- a/triples/core/structsos/ternary/sparse.py
+++ b/triples/core/structsos/ternary/sparse.py
@@ -5,7 +5,7 @@ from math import gcd
 from sympy import Poly, Expr, Integer, Rational, Add, Mul
 from sympy.combinatorics import CyclicGroup
 
-from .utils import Coeff, DomainExpr
+from .utils import Coeff, DomainExpr, CyclicSum
 from .dense_symmetric import sos_struct_dense_symmetric
 from .quadratic import sos_struct_quadratic
 from .cubic import sos_struct_cubic
@@ -23,7 +23,7 @@ def sos_struct_sparse(coeff, real = True):
     handled in R.
     """
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     if len(coeff) > 6:
         return None
@@ -126,7 +126,7 @@ class CoeffMonom:
     @classmethod
     def integer_intersection(cls, p1, p2, p3, p4) -> Optional['CoeffMonom']:
         # cls.assert_equal_degrees(p1, p2, p3, p4)
-        (p10, p11, p12), (p20, p21, p22), (p30, p31, p32), (p40, p41, p42) = p1, p2, p3, p4
+        (p10, p11, _), (p20, p21, _), (p30, p31, _), (p40, p41, _) = p1, p2, p3, p4
         det = p10*p31 - p10*p41 - p11*p30 + p11*p40 - p20*p31 + p20*p41 + p21*p30 - p21*p40
         p50 = p10*p21*p30 - p10*p21*p40 - p10*p30*p41 + p10*p31*p40 - p11*p20*p30 + p11*p20*p40 + p20*p30*p41 - p20*p31*p40
         p51 = p10*p21*p31 - p10*p21*p41 - p11*p20*p31 + p11*p20*p41 - p11*p30*p41 + p11*p31*p40 + p21*p30*p41 - p21*p31*p40
@@ -202,7 +202,7 @@ class AMGM3(DomainExpr):
 
     def _solve_amgm(self, m1: CoeffMonom, m2: CoeffMonom):
         a, b, c = self.gens
-        CyclicSum, CyclicProduct = self.cyclic_sum, self.cyclic_product
+        CyclicSum = self.cyclic_sum
 
         weight = m1.weight(m2)
         m2expr = a**m2[0]*b**m2[1]*c**m2[2]
@@ -405,7 +405,7 @@ def _sos_struct_sparse_amgm(coeff):
     """
     if not len(coeff) <= 6:
         return None
-    monoms = set(CoeffMonom(*m).std() for m in coeff.keys())
+    monoms = {CoeffMonom(*m).std() for m in coeff.keys()}
     monoms = list(monoms)
     if len(monoms) == 1:
         degree = coeff.total_degree()
@@ -697,7 +697,7 @@ def sos_struct_heuristic(coeff: Coeff, real=True):
         return None
 
     a, b, c = coeff.gens
-    CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
+    CyclicSum = coeff.cyclic_sum
 
     border1, border2 = [], []
     for (i,j,k), v in monoms[::-1]:

--- a/triples/core/structsos/ternary/utils.py
+++ b/triples/core/structsos/ternary/utils.py
@@ -18,6 +18,18 @@ from ....utils import (
     CyclicExpr, CyclicSum, CyclicProduct
 )
 
+(
+    Coeff, DomainExpr, sos_struct_reorder_symmetry,
+    radsimp, sum_y_exprs, rationalize_func, quadratic_weighting, zip_longest,
+    congruence, congruence_solve,
+    StructuralSOSError, PolynomialNonpositiveError, PolynomialUnsolvableError
+)
+(
+    nroots, rationalize, rationalize_bound, univariate_intervals,
+    cancel_denominator, common_region_of_conics,
+    CyclicExpr, CyclicSum, CyclicProduct
+)
+
 def align_cyclic_group(expr: Optional[Expr], gens: Tuple[Symbol, ...]) -> Expr:
     """
     Replace `CyclicSum(F(a, b, c), (a, c, b))` to `CyclicSum(F(a, b, c), (a, b, c))`.

--- a/triples/core/structsos/ternary/utils.py
+++ b/triples/core/structsos/ternary/utils.py
@@ -6,7 +6,7 @@ from sympy import Poly, Expr, Symbol, Add, Mul, Pow
 from sympy.combinatorics import CyclicGroup
 
 from ..utils import (
-    Coeff, DomainExpr,
+    Coeff, DomainExpr, sos_struct_reorder_symmetry,
     radsimp, sum_y_exprs, rationalize_func, quadratic_weighting, zip_longest,
     congruence, congruence_solve,
     StructuralSOSError, PolynomialNonpositiveError, PolynomialUnsolvableError

--- a/triples/core/structsos/ternary/utils.py
+++ b/triples/core/structsos/ternary/utils.py
@@ -120,7 +120,7 @@ def sos_struct_handle_uncentered(solver: Callable) -> Callable:
         i, j, k = dd3, dd3+(1 if dm3>=2 else 0), dd3+(1 if dm3 else 0)
         dt = dict(poly.terms())
         zero = poly.convert(0)
-        if not ((i,j,k) in dt):
+        if (i,j,k) not in dt:
             dt[(i,j,k)] = zero
             dt[(j,k,i)] = zero
             dt[(k,i,j)] = zero

--- a/triples/core/structsos/univariate.py
+++ b/triples/core/structsos/univariate.py
@@ -463,7 +463,7 @@ def _prove_univariate_from_mat_Rplus(p: Poly, ctx=None,
             return (res, res.zero) if res is not None else None
 
         zero = ctx.float(0)
-        d = len(real_roots)
+        # d = len(real_roots)
         real_part = [ctx.real(v) for v in ctx.polyfromroots(real_roots)]
         major_part = real_part[::2]   # containing the leading term
         minor_part = real_part[1::2] # not containing the leading term

--- a/triples/core/structsos/univariate.py
+++ b/triples/core/structsos/univariate.py
@@ -5,7 +5,7 @@ from mpmath import mp
 import numpy as np
 from numpy.polynomial.polynomial import polyroots as np_polyroots
 from numpy.polynomial.polynomial import polyfromroots as np_polyfromroots
-from sympy import Poly, Expr, Float, Integer, Symbol, QQ, construct_domain, count_roots
+from sympy import Poly, Expr, Integer, Symbol, QQ, construct_domain, count_roots
 from sympy.core import S
 from sympy.matrices import MutableDenseMatrix as Matrix
 from sympy.polys.matrices.ddm import DDM

--- a/triples/core/structsos/univariate.py
+++ b/triples/core/structsos/univariate.py
@@ -719,7 +719,7 @@ def prove_univariate(poly: Union[Poly, Expr, List], interval: Tuple[Optional[Exp
     full rank and strictly positive definite. Then it is possible to perturb and round
     the Gram matrix to obtain a rational sum-of-squares certificate.
     """
-    if not (return_type in ('expr', 'list', 'soslist')):
+    if return_type not in ('expr', 'list', 'soslist'):
         raise ValueError(f"The return_type must be 'expr', 'list', or 'soslist', but got {return_type}.")
 
     if not isinstance(poly, Poly):

--- a/triples/core/structsos/utils.py
+++ b/triples/core/structsos/utils.py
@@ -1,10 +1,12 @@
 from typing import Union, Tuple, List, Dict, Callable, Optional
+from functools import wraps
 
 from sympy import (
     Poly, Expr, Symbol, Integer, Rational, MatrixBase, Add,
     QQ, ZZ, sympify, fraction
 )
 from sympy import MutableDenseMatrix as Matrix
+from sympy.combinatorics import Permutation
 from sympy.core.symbol import uniquely_named_symbol
 
 from ...sdp import congruence
@@ -36,6 +38,12 @@ class DomainExpr:
 
     def cyclic_product(self, expr) -> Expr:
         return self._coeff.cyclic_product(expr)
+
+def ufsfind(ufs: dict, x):
+    if ufs[x] == x:
+        return x
+    ufs[x] = ufsfind(ufs, ufs[x])
+    return ufs[x]
 
 
 def radsimp(expr: Union[Expr, List[Expr]]) -> Expr:
@@ -207,6 +215,7 @@ def zip_longest(*args):
                     return
         yield tuple(lasts)
 
+
 def has_gen(gen: Symbol, *args):
     """
     Test whether a symbol is involved in a (list of) polynomial(s).
@@ -222,38 +231,133 @@ def clear_free_symbols(poly: Poly, ineq_constraints: Dict[Poly, Expr] = {}, eq_c
     we can remove the symbol "a" from the constraints. But we cannot remove the symbol "y"
     even though it is not in the polynomial, as it is correlated with "x".
     """
-    # Construct the "correlation" graph of the free symbols: symbols that are path-connected to free
-    # vars in the polynomial are considered as active symbols.
-    gens = poly.gens
-    ufs = dict((gen, gen) for i, gen in enumerate(gens))
-    def ufsfind(x):
-        if ufs[x] == x:
-            return x
-        ufs[x] = ufsfind(ufs[x])
-        return ufs[x]
-    def ufsunion(p):
-        v = p.free_symbols
-        if len(v):
-            x0 = v.pop()
-            y0 = ufsfind(x0)
-            for x in v:
-                ufs[ufsfind(x)] = y0
-    ufsunion(poly)
-    for p in ineq_constraints:
-        ufsunion(p)
-    for p in eq_constraints:
-        ufsunion(p)
+    from ..problem import InequalityProblem
+    pro = InequalityProblem(poly, ineq_constraints, eq_constraints)
+    pro.remove_redundancy()
+    return pro.expr, pro.ineq_constraints, pro.eq_constraints
 
-    # Using .free_symbols is not the same as .gens. Because free_symbols exclude 0-degree gens.
-    active_gens = set(ufsfind(gen) for gen in poly.free_symbols)
-    active_gens = [x for x in gens if ufsfind(x) in active_gens]
-    if len(active_gens) == 0:
-        active_gens = (gens[0],) # the polynomial is a constant, but we need a gen to create a poly
+    # # Construct the "correlation" graph of the free symbols: symbols that are path-connected to free
+    # # vars in the polynomial are considered as active symbols.
+    # gens = poly.gens
+    # ufs = dict((gen, gen) for i, gen in enumerate(gens))
+    # def ufsunion(ufs: dict, p):
+    #     v = p.free_symbols
+    #     if len(v):
+    #         x0 = v.pop()
+    #         y0 = ufsfind(ufs, x0)
+    #         for x in v:
+    #             ufs[ufsfind(ufs, x)] = y0
+    # ufsunion(ufs, poly)
+    # for p in ineq_constraints:
+    #     ufsunion(ufs, p)
+    # for p in eq_constraints:
+    #     ufsunion(ufs, p)
 
-    def is_active(p):
-        return len(p.free_symbols.intersection(active_gens))
+    # # Using .free_symbols is not the same as .gens. Because free_symbols exclude 0-degree gens.
+    # active_gens = set(ufsfind(ufs, gen) for gen in poly.free_symbols)
+    # active_gens = [x for x in gens if ufsfind(ufs, x) in active_gens]
+    # if len(active_gens) == 0:
+    #     active_gens = (gens[0],) # the polynomial is a constant, but we need a gen to create a poly
 
-    poly = poly.as_poly(active_gens)
-    ineq_constraints = {p.as_poly(active_gens): e for p, e in ineq_constraints.items() if is_active(p)}
-    eq_constraints = {p.as_poly(active_gens): e for p, e in eq_constraints.items() if is_active(p)}
-    return poly, ineq_constraints, eq_constraints
+    # def is_active(p):
+    #     return len(p.free_symbols.intersection(active_gens))
+
+    # poly = poly.as_poly(active_gens)
+    # ineq_constraints = {p.as_poly(active_gens): e for p, e in ineq_constraints.items() if is_active(p)}
+    # eq_constraints = {p.as_poly(active_gens): e for p, e in eq_constraints.items() if is_active(p)}
+    # return poly, ineq_constraints, eq_constraints
+
+
+def block_partition(blocks: List[int], groups: Tuple[int, ...]) -> List[int]:
+    """
+    Returns a vector `c` such that
+    `blocks[k] == sum(groups[i] for i in range(m) if c[i] == k)`
+
+    Examples
+    --------
+    >>> block_partition((2, 4), (1, 2, 3))
+    [1, 0, 1]
+    """
+    if sum(blocks) != sum(groups):
+        raise ValueError("No solution: sum mismatch")
+
+    n, m = len(blocks), len(groups)
+    sorted_groups = sorted(((groups[i], i) for i in range(m)), key=lambda x: (-x[0], x[1]))
+
+    remaining = list(blocks)
+    result = [0] * m
+
+    def backtrack(index: int) -> bool:
+        if index == m:
+            return True
+        val, original_idx = sorted_groups[index]
+        for k in range(n):
+            if remaining[k] >= val:
+                if k > 0 and remaining[k] == remaining[k-1]:
+                    continue
+                remaining[k] -= val
+                result[original_idx] = k
+                if backtrack(index + 1):
+                    return True
+                remaining[k] += val
+        return False
+    if not backtrack(0):
+        raise ValueError("No valid partition found")
+    return result
+
+
+def sos_struct_reorder_symmetry(groups: Tuple[int, ...]) -> Callable:
+    """
+    Decorator for the solver function to reorder the generators
+    so that they are in the given symmetry.
+
+    Parameters
+    ----------
+    groups : Tuple[int, ...]
+        The degree of each symmetric group. E.g., when there are four variables
+        and `groups = (3, 1)`, it makes the resulting polynomial symmetric with
+        respect to the first three variables and then calls the solver.
+    """
+    def wrapper(solver: Callable) -> Callable:
+        @wraps(solver)
+        def _wrapped_solver(poly: Union[Poly, Coeff], *args, need_reorder=True, **kwargs):
+            if not need_reorder:
+                return solver(poly, *args, **kwargs)
+
+            coeff = poly
+            if isinstance(poly, Coeff):
+                pass
+            elif isinstance(poly, Poly):
+                coeff = Coeff(poly)
+            else:
+                raise TypeError("Unsupported polynomial type. Expected Coeff or Poly, but received %s." % type(poly))
+
+            n = len(poly.gens)
+            ufs = {i: i for i in range(n)}
+            for i in range(n):
+                for j in range(i+1, n):
+                    if ufsfind(ufs, i) == ufsfind(ufs, j):
+                        continue
+                    if coeff.is_symmetric(Permutation(size=n)(i, j)):
+                        ufs[ufsfind(ufs, j)] = ufsfind(ufs, i)
+
+            blocks = {i: [] for i in range(n) if ufsfind(ufs, i) == i}
+            for i in range(n):
+                blocks[ufsfind(ufs, i)].append(i)
+            blocks = list(blocks.values())
+            ufs_size = [len(b) for b in blocks]
+
+            partition = []
+            try:
+                partition = block_partition(ufs_size, groups)
+            except ValueError:
+                return None
+
+            inds = []
+            for g, p in zip(groups, partition):
+                inds.extend(blocks[p][:g])
+                blocks[p] = blocks[p][g:]
+            new_coeff = coeff.reorder(inds)
+            return solver(new_coeff, *args, **kwargs)
+        return _wrapped_solver
+    return wrapper

--- a/triples/core/structsos/utils.py
+++ b/triples/core/structsos/utils.py
@@ -13,6 +13,9 @@ from ...sdp import congruence
 from ...utils.expressions import Coeff, CyclicSum, CyclicProduct
 from ...utils.roots import nroots, rationalize_bound
 
+# use imports to keep linter happy
+(uniquely_named_symbol, Coeff, CyclicSum, CyclicProduct)
+
 class StructuralSOSError(Exception): ...
 
 class PolynomialUnsolvableError(StructuralSOSError): ...

--- a/triples/core/sum_of_squares.py
+++ b/triples/core/sum_of_squares.py
@@ -221,10 +221,9 @@ def sum_of_squares_multiple(
         The results as a pandas DataFrame.
     """
     from time import time
+    from importlib.util import find_spec
 
-    try:
-        import pandas as pd
-    except ImportError:
+    if find_spec("pandas") is None:
         raise ImportError('Please install pandas to use this function.')
 
     if 'ignore_errors' not in poly_reader_configs:

--- a/triples/core/sum_of_squares.py
+++ b/triples/core/sum_of_squares.py
@@ -268,7 +268,7 @@ def sum_of_squares_multiple(
                 record['status'] = 'success'
                 record['solution'] = solution
                 record['method'] = solution.method
-        except Exception as e:
+        except Exception:
             used_time = time() - t0
             record['status'] = 'error'
             record['solution'] = None

--- a/triples/core/symsos/basic.py
+++ b/triples/core/symsos/basic.py
@@ -287,7 +287,7 @@ def prove_by_pivoting(poly: Poly, nonnegative_symbols: Set[Symbol]) -> Optional[
             homogenizer = Symbol('_'+poly.gen.name)
             poly = poly.homogenize(homogenizer)
 
-        ineq_constraints = dict()
+        ineq_constraints = {}
         for gen in poly.gens + (homogenizer,):
             if gen is not None and gen in nonnegative_symbols:
                 ineq_constraints[gen.as_poly(*poly.gens)] = gen

--- a/triples/core/symsos/basic.py
+++ b/triples/core/symsos/basic.py
@@ -292,7 +292,7 @@ def prove_by_pivoting(poly: Poly, nonnegative_symbols: Set[Symbol]) -> Optional[
             if gen is not None and gen in nonnegative_symbols:
                 ineq_constraints[gen.as_poly(*poly.gens)] = gen
                 # Thought: shall we wrap the generator as a function?
-        sol = structural_sos_2vars(poly, ineq_constraints=ineq_constraints, eq_constraints=dict())
+        sol = structural_sos_2vars(poly, ineq_constraints=ineq_constraints, eq_constraints={})
         if sol is not None and homogenizer is not None:
             sol = sol.xreplace({homogenizer: Integer(1)})
         return sol

--- a/triples/core/symsos/basic.py
+++ b/triples/core/symsos/basic.py
@@ -277,7 +277,7 @@ def prove_by_pivoting(poly: Poly, nonnegative_symbols: Set[Symbol]) -> Optional[
         return None
 
     for gen in poly.gens:
-        if (not gen in nonnegative_symbols) and poly.degree(gen) % 2 == 1:
+        if (gen not in nonnegative_symbols) and poly.degree(gen) % 2 == 1:
             # do not use % 2 != 0 because degree(gen) = -oo if the degree is zero
             return None
 

--- a/triples/core/symsos/representation.py
+++ b/triples/core/symsos/representation.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict, List, Union, Optional
+from typing import Tuple, Dict, Union, Optional
 
 from sympy import Poly, Expr, Symbol
 
@@ -140,8 +140,8 @@ def sym_transform(
     trans = _get_transform_from_method(method, len(poly.gens))
     numerator, denominator = trans.transform(poly, symbols, return_poly=True)
 
-    ineq_constraints2 = dict()
-    eq_constraints2 = dict()
+    ineq_constraints2 = {}
+    eq_constraints2 = {}
 
     for collection, new_collection in ((ineq_constraints, ineq_constraints2),
                                        (eq_constraints, eq_constraints2)):

--- a/triples/core/symsos/representation.py
+++ b/triples/core/symsos/representation.py
@@ -146,7 +146,6 @@ def sym_transform(
     for collection, new_collection in ((ineq_constraints, ineq_constraints2),
                                        (eq_constraints, eq_constraints2)):
         for p, value in collection.items():
-            pgens = p.gens
             p = p.as_poly(*poly.gens)
             if not verify_symmetry(p, "sym"):
                 continue

--- a/triples/core/symsos/symmetric.py
+++ b/triples/core/symsos/symmetric.py
@@ -100,7 +100,7 @@ class UE3Positive(SymmetricTransform):
             Poly(x, (x,y,z)): x,
             Poly(y, (x,y,z)): y,
             Poly(z, (x,y,z)): z
-        }, dict()
+        }, {}
 
 
 class UE3Real(SymmetricTransform):
@@ -148,7 +148,7 @@ class UE3Real(SymmetricTransform):
     @classmethod
     def _get_default_constraints(cls, new_symbols):
         x, y, z = new_symbols
-        return {Poly(z, (x,y,z)): z}, dict()
+        return {Poly(z, (x,y,z)): z}, {}
 
 
 class UE4Real(SymmetricTransform):
@@ -222,7 +222,7 @@ class UE4Real(SymmetricTransform):
             Poly(y, (x,y,z,w)): y,
             Poly(z, (x,y,z,w)): z,
             Poly(w, (x,y,z,w)): w
-        }, dict()
+        }, {}
 
 
 def _symmetric_real_3vars(

--- a/triples/core/symsos/symmetric.py
+++ b/triples/core/symsos/symmetric.py
@@ -262,8 +262,8 @@ def _symmetric_real_3vars(
         min_x_degree = min(numerator.monoms(), key=lambda _:_[0])[0]
         if min_x_degree > 0:
             # x = p*w
-            dt = dict(((i-min_x_degree, j, k), v)
-                            for (i,j,k), v in numerator.rep.terms())
+            dt = {(i-min_x_degree, j, k): v
+                            for (i,j,k), v in numerator.rep.terms()}
             numerator = Poly(dt, x, y, z, domain=numerator.domain)
             p_degree -= min_x_degree
             w_degree -= min_x_degree
@@ -306,7 +306,7 @@ def _symmetric_real_4vars(
     q_degree = -((degree * 2) % 3)
     r_degree = -(degree % 2)
     # q^3 -> q, r^2 -> r
-    dt = dict(((i,j//3,k//2,l), _) for (i,j,k,l), _ in poly_dehom.rep.terms())
+    dt = {(i,j//3,k//2,l): _ for (i,j,k,l), _ in poly_dehom.rep.terms()}
     poly_dehom = Poly(dt, p, q, r, s, domain=poly_dehom.domain)
 
     # Naive implementation:
@@ -336,10 +336,10 @@ def _symmetric_real_4vars(
 
     _min_degree = lambda poly, i: 0 if poly.is_zero else min(_[i] for _ in poly.monoms())
     min_degrees = [_min_degree(numerator, i) for i in range(5)]
-    numerator = Poly(dict(
-        (tuple(mi - mini for mi, mini in zip(m, min_degrees)), _)
+    numerator = Poly({
+        tuple(mi - mini for mi, mini in zip(m, min_degrees)): _
         for m, _ in numerator.rep.terms()
-    ), x, y, z, ker1, ker2, domain=numerator.domain)
+    }, x, y, z, ker1, ker2, domain=numerator.domain)
 
     # degrees of y, ker1, ker2 in denominator is lifted by homogenization
     # and the degrees are reduced after cancellation

--- a/triples/core/symsos/symsos.py
+++ b/triples/core/symsos/symsos.py
@@ -1,9 +1,8 @@
 from typing import Dict, List, Union, Optional
 
-from sympy import Poly, Expr, Dummy
+from sympy import Expr, Dummy
 
 from .symmetric import UE3Real, UE3Positive, UE4Real
-from .basic import prove_by_pivoting
 from ..node import TransformNode
 from ..preprocess import SolvePolynomial
 from ..solution import Solution

--- a/triples/core/symsos/tests/test_symsos.py
+++ b/triples/core/symsos/tests/test_symsos.py
@@ -1,5 +1,4 @@
-from sympy.abc import a, b, c, d, e, t, x, y, z
-from sympy import Rational
+from sympy.abc import a, b, c, d
 
 from ..symsos import SymmetricSubstitution
 from ...problem import InequalityProblem

--- a/triples/core/tests/test_dispatch.py
+++ b/triples/core/tests/test_dispatch.py
@@ -1,7 +1,5 @@
-from sympy.abc import a, b, c, d, u, v, x, y, z
+from sympy.abc import a, b, c, u, v, x, y, z
 from sympy import Poly, Symbol, Rational, ZZ, QQ, ring, field, cbrt, sqrt, asin
-from sympy.polys.rings import PolyElement
-from sympy.polys.fields import FracElement
 
 from ..dispatch import (
     _dtype_is_homogeneous, _dtype_homogenize

--- a/triples/core/tests/test_problem.py
+++ b/triples/core/tests/test_problem.py
@@ -1,9 +1,7 @@
-from sympy.abc import a, b, c, d, e, u, v, w, x, y, z
+from sympy.abc import a, b, c, u, v, w, x, y, z
 
 from sympy import Poly, Function, ZZ, ring
 from sympy.combinatorics import CyclicGroup
-from sympy.polys.rings import PolyElement
-from sympy.polys.fields import FracElement
 
 from ..problem import InequalityProblem
 from ..dispatch import _fracelement_init

--- a/triples/core/tests/test_problem.py
+++ b/triples/core/tests/test_problem.py
@@ -31,10 +31,10 @@ def test_wrap_constraints():
     pro = InequalityProblem(a+b+c, [2*a+b, 2*b+c, 2*c+a])
     pro1 = pro.wrap_constraints()[0]
     assert set(pro1.ineq_constraints) == {2*a + b, 2*b + c, a + 2*c}
-    assert len(set([_.find(Function).pop().func for _ in pro1.ineq_constraints.values()])) == 3
+    assert len({_.find(Function).pop().func for _ in pro1.ineq_constraints.values()}) == 3
     assert [len(_.free_symbols) for _ in pro1.ineq_constraints.values()] == [2, 2, 2]
 
     pro2 = pro.wrap_constraints(CyclicGroup(3))[0]
     assert set(pro2.ineq_constraints) == {2*a + b, 2*b + c, a + 2*c}
-    assert len(set([_.find(Function).pop().func for _ in pro2.ineq_constraints.values()])) == 1
+    assert len({_.find(Function).pop().func for _ in pro2.ineq_constraints.values()}) == 1
     assert [len(_.free_symbols) for _ in pro2.ineq_constraints.values()] == [2, 2, 2]

--- a/triples/gui/linebreak.py
+++ b/triples/gui/linebreak.py
@@ -295,7 +295,7 @@ if __name__ == '__main__':
     print("\n--- Part 2: wrap_with_aligned_if_needed (with new line length logic) ---")
     expr_to_wrap = "termA+termB+termC+termD+termE+termF+termG"
     print(f"\nInput: '{expr_to_wrap}'")
-    print(f"Wrapped (max_terms=2, max_len=20, max_line_len=15):") # max_terms=2 means 3+ terms trigger align
+    print("Wrapped (max_terms=2, max_len=20, max_line_len=15):") # max_terms=2 means 3+ terms trigger align
     print(wrap_with_aligned_if_needed(expr_to_wrap, max_terms_trigger=2, max_len_trigger=20, max_line_len=15))
     # termA +termB (len approx 6+1+6=13) -> fits
     # termA +termB +termC (len approx 13+1+6=20) -> exceeds 15. Break.
@@ -306,7 +306,7 @@ if __name__ == '__main__':
     # & +termG
 
     print(f"\nInput: '{s_long_sum}' (a+b+c+d+e+f+g+h+i)")
-    print(f"Wrapped (max_terms=2, max_len=5, max_line_len=10):") # triggers align, line length 10
+    print("Wrapped (max_terms=2, max_len=5, max_line_len=10):") # triggers align, line length 10
     print(wrap_with_aligned_if_needed(s_long_sum, max_terms_trigger=2, max_len_trigger=5, max_line_len=10))
     # a (1)
     # a +b (1+1+2=4)
@@ -333,7 +333,7 @@ if __name__ == '__main__':
     # Test with a long expression inside parentheses, requiring internal alignment with line length
     long_paren_expr = "f(x) = (a+b+c+d+e+f+g+h+i+j+k+l+m+n+o+p+q+r) + (s+t+u+v+w) - 2(x+y+z)"
     print(f"\nInput: '{long_paren_expr}'")
-    print(f"Recursively formatted (max_terms_aligned=2, max_len_aligned=30, max_line_len_in_aligned=20):")
+    print("Recursively formatted (max_terms_aligned=2, max_len_aligned=30, max_line_len_in_aligned=20):")
     # First parenthesis content: "a+b+...+r" (18 terms) -> will be wrapped by aligned
     #   Inside that aligned: lines should be <= 20 chars.
     #   a +b +c +d +e +f +g +h +i (9 terms, length ~ 9*2 + 8*1 = 26) -> should break
@@ -345,7 +345,7 @@ if __name__ == '__main__':
     print("-" * 20)
     nested_frac_long_num = "E = \\frac{X_1+X_2+X_3+X_4+X_5+X_6+X_7+X_8+X_9+X_{10}}{k+l+m} + Y"
     print(f"\nInput: '{nested_frac_long_num}'")
-    print(f"Recursively formatted (max_terms_aligned=1, max_len_aligned=10, max_line_len_in_aligned=18):")
+    print("Recursively formatted (max_terms_aligned=1, max_len_aligned=10, max_line_len_in_aligned=18):")
     # Numerator has 10 terms. max_terms_aligned=1 means >=2 terms will trigger aligned.
     # max_line_len_in_aligned=18 for numerator's lines.
     # X_1 +X_2 +X_3 (len ~3+1+3+1+3 = 11)

--- a/triples/gui/linebreak.py
+++ b/triples/gui/linebreak.py
@@ -97,7 +97,7 @@ def get_additive_terms(latex_str):
 
     if terms[0] == "" and len(terms) > 1:
         first_term_candidate = terms[1]
-        if first_term_candidate.startswith('+') or first_term_candidate.startswith('-'):
+        if first_term_candidate.startswith(('+','-')):
             final_terms.append(first_term_candidate)
             start_idx_for_loop = 2
         else:

--- a/triples/sdp/__init__.py
+++ b/triples/sdp/__init__.py
@@ -12,7 +12,7 @@ from .primal import SDPPrimal
 
 from .arithmetic import congruence, ArithmeticTimeout
 from .backends import SDPError, SDPTimeoutError
-from .wedderburn import character_table, symmetry_adapted_basis
+from .wedderburn import character_table, symmetry_adapted_basis, young_symmetrizers
 
 __all__ = [
     # 'solve_column_separated_linear', 'solve_undetermined_linear',
@@ -20,5 +20,5 @@ __all__ = [
     'SDPProblem', 'SDPPrimal',
     'congruence', 'ArithmeticTimeout',
     'SDPError', 'SDPTimeoutError',
-    'character_table', 'symmetry_adapted_basis',
+    'character_table', 'symmetry_adapted_basis', 'young_symmetrizers'
 ]

--- a/triples/sdp/abstract.py
+++ b/triples/sdp/abstract.py
@@ -153,7 +153,7 @@ class SDPProblemBase(ABC):
         if isinstance(y, np.ndarray):
             y = rep_matrix_from_numpy(y.flatten())
         y2 = self.project(y)
-        if (not (y2 is y)) and not project:
+        if (y2 is not y) and not project:
             # FIXME for numpy array
             raise ValueError("The vector y is not feasible by the equality constraints."
                     " Use project=True to project the approximated solution to the feasible region.")

--- a/triples/sdp/abstract.py
+++ b/triples/sdp/abstract.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from time import perf_counter
-from typing import Dict, Tuple, List, Union, Callable, Optional, Any
+from typing import Dict, Tuple, List, Union, Optional, Any
 
 from numpy import ndarray
 import numpy as np
@@ -12,7 +12,7 @@ from .arithmetic import (
     ArithmeticTimeout, sqrtsize_of_mat, is_empty_matrix,
     congruence, rep_matrix_from_numpy, rep_matrix_to_numpy
 )
-from .backends import SDPError, SDPTimeoutError, SDPResult
+from .backends import SDPTimeoutError, SDPResult
 from .rationalize import rationalize_and_decompose
 from .utils import exprs_to_arrays, collect_constraints
 

--- a/triples/sdp/abstract.py
+++ b/triples/sdp/abstract.py
@@ -249,9 +249,9 @@ class SDPProblemBase(ABC):
         cons = [(ineq_lhs, ineq_rhs, '>'), (eq_lhs, eq_rhs, '==')]
 
         kwargs = kwargs.copy()
-        if not ('verbose' in kwargs):
+        if 'verbose' not in kwargs:
             kwargs['verbose'] = verbose
-        if end_time is not None and (not ('time_limit' in kwargs)):
+        if end_time is not None and ('time_limit' not in kwargs):
             kwargs['time_limit'] = end_time - perf_counter()
 
         sol = self._solve_numerical_sdp(objective=obj[0],

--- a/triples/sdp/arithmetic/eigens.py
+++ b/triples/sdp/arithmetic/eigens.py
@@ -261,7 +261,7 @@ def _congruence_numerically(M, perturb=0., upper=True):
     if upper:
         U = silent_chol(M)
 
-        if U is None and (not (perturb is False)):
+        if U is None and (perturb is not False):
             if perturb is True:
                 perturb = 1.
             mineig = float(np.min(eigvalsh(M)))

--- a/triples/sdp/arithmetic/eigens.py
+++ b/triples/sdp/arithmetic/eigens.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union, Optional, overload
+from typing import Tuple, Union, Optional, overload
 
 import numpy as np
 from numpy import ndarray

--- a/triples/sdp/arithmetic/linsolve.py
+++ b/triples/sdp/arithmetic/linsolve.py
@@ -196,7 +196,7 @@ def _row_reduce(M, normalize_last=True, normalize=True, zero_above=True, time_li
 
     sdm = M._rep.to_field().rep
     domain = sdm.domain
-    sdm = {k: {k2: i for k2, i in v.items()} for k, v in sdm.to_sdm().items()}
+    sdm = {k: dict(v.items()) for k, v in sdm.to_sdm().items()}
 
     if _VERBOSE_SOLVE_UNDETERMINED_LINEAR:
         print(">> Time for converting to MPQ:", perf_counter() - time0)
@@ -516,7 +516,7 @@ def solve_csr_linear(A: Matrix, b: Matrix,
     cols = A.shape[1]
     if _VERBOSE_SOLVE_CSR_LINEAR:
         print('SolveCsrLinear A shape', A.shape)
-        time0 = perf_counter()
+        # time0 = perf_counter()
 
     Arep = A._rep.rep.to_sdm()
 
@@ -553,7 +553,7 @@ def solve_csr_linear(A: Matrix, b: Matrix,
         k = mapping[i]
         if not (k in new_force_zeros):
             new_force_zeros[k] = set()
-        new_force_zeros[k].update(set(mapping[j] for j in force_zeros[i]))
+        new_force_zeros[k].update({mapping[j] for j in force_zeros[i]})
     time_limit()
 
     x0, space = _solve_csr_linear_force_zeros(A2, b,

--- a/triples/sdp/arithmetic/linsolve.py
+++ b/triples/sdp/arithmetic/linsolve.py
@@ -1,12 +1,12 @@
 from collections import defaultdict
 from time import perf_counter
-from typing import List, Tuple, Dict, Union, Optional, Callable, Any, overload
+from typing import List, Tuple, Dict, Union, Optional, Callable, overload
 
 from numpy import argsort
-from sympy.external.gmpy import MPQ, MPZ # >= 1.9
+from sympy.external.gmpy import MPQ # >= 1.9
 from sympy.matrices import MutableDenseMatrix as Matrix
 from sympy.matrices.repmatrix import RepMatrix
-from sympy.polys.domains import ZZ, QQ, EX # EXRAW >= 1.9
+from sympy.polys.domains import QQ # EXRAW >= 1.9
 from sympy.polys.matrices.domainmatrix import DomainMatrix # polys.matrices >= 1.8
 from sympy.polys.matrices.sdm import SDM
 try:

--- a/triples/sdp/arithmetic/linsolve.py
+++ b/triples/sdp/arithmetic/linsolve.py
@@ -551,7 +551,7 @@ def solve_csr_linear(A: Matrix, b: Matrix,
     new_force_zeros = {}
     for i in force_zeros:
         k = mapping[i]
-        if not (k in new_force_zeros):
+        if k not in new_force_zeros:
             new_force_zeros[k] = set()
         new_force_zeros[k].update({mapping[j] for j in force_zeros[i]})
     time_limit()
@@ -639,7 +639,7 @@ def _solve_csr_linear_force_zeros(A, b, nonnegative_indices=[], force_zeros={},
             new_zeros = force_zeros.get(i)
             if new_zeros is not None:
                 for j in new_zeros:
-                    if not (j in all_zero_inds):
+                    if j not in all_zero_inds:
                         zero_inds.add(j)
 
             # remove the corresponding column of A

--- a/triples/sdp/arithmetic/matop.py
+++ b/triples/sdp/arithmetic/matop.py
@@ -15,12 +15,12 @@ import numpy as np
 from numpy import ndarray
 from scipy.sparse import spmatrix, csr_matrix
 from sympy import __version__ as _SYMPY_VERSION
-from sympy.external.gmpy import MPQ, MPZ # >= 1.9
+from sympy.external.gmpy import MPZ # >= 1.9
 from sympy.external.importtools import version_tuple
-from sympy import Symbol, Float, MatrixBase, Basic
+from sympy import Float, MatrixBase, Basic
 from sympy.matrices import MutableDenseMatrix as Matrix
 from sympy.matrices.repmatrix import RepMatrix
-from sympy.polys.domains import Domain, ZZ, QQ, RR, CC # EXRAW >= 1.9
+from sympy.polys.domains import Domain, ZZ, RR, CC # EXRAW >= 1.9
 from sympy.polys.matrices.domainmatrix import DomainMatrix # polys.matrices >= 1.8
 from sympy.polys.matrices.ddm import DDM
 from sympy.polys.matrices.sdm import SDM
@@ -52,7 +52,7 @@ try:
     from flint import fmpq, fmpz
     FLINT_TYPE = (fmpq, fmpz)
 except ImportError:
-    FLINT_TYPE = tuple()
+    FLINT_TYPE = ()
 
 class ArithmeticTimeout(Exception):
     @classmethod

--- a/triples/sdp/arithmetic/tests/test_eigens.py
+++ b/triples/sdp/arithmetic/tests/test_eigens.py
@@ -1,4 +1,3 @@
-import numpy as np
 from sympy import MutableDenseMatrix as Matrix
 from sympy import Rational, primerange, re, exp, pi
 

--- a/triples/sdp/backends/backend.py
+++ b/triples/sdp/backends/backend.py
@@ -242,7 +242,7 @@ class DualBackend(SDPBackend):
                     break
             lines = lines[i:]
             m = int(lines[0].split()[0])
-            nBlock = int(lines[1].split()[0])
+            # nBlock = int(lines[1].split()[0])
             block_sizes = list(map(abs, map(int, lines[2].strip().split())))
             c_vector = list(map(float, lines[3].strip().split()))
 

--- a/triples/sdp/backends/backend.py
+++ b/triples/sdp/backends/backend.py
@@ -6,7 +6,7 @@ from numpy import ndarray
 from .settings import SDPResult, SolverConfigs
 
 class SDPBackend:
-    _dependencies = tuple()
+    _dependencies = ()
 
     status = None
 

--- a/triples/sdp/backends/backend.py
+++ b/triples/sdp/backends/backend.py
@@ -163,7 +163,7 @@ class DualBackend(SDPBackend):
             bs = [self._convert_space_to_isometric(b, order=self._opt_isometric) for b in bs]
 
         if self._opt_sparse:
-            if not self._opt_sparse in ('csc', 'csr', 'coo'):
+            if self._opt_sparse not in ('csc', 'csr', 'coo'):
                 raise ValueError('DualBackend._opt_sparse must be one of "csc" or "csr" or "coo".')
             from scipy import sparse
             to_mat = getattr(sparse, self._opt_sparse + '_matrix')

--- a/triples/sdp/backends/caller.py
+++ b/triples/sdp/backends/caller.py
@@ -13,7 +13,7 @@ from .picos_sdp import DualBackendPICOS
 from .qics_sdp import DualBackendQICS
 from .sdpap_sdp import DualBackendSDPAP
 
-from .settings import SDPError, SDPResult
+from .settings import SDPResult
 # from ..utils import collect_constraints
 
 _DUAL_BACKENDS: Dict[str, DualBackend] = {

--- a/triples/sdp/backends/cvxopt_sdp.py
+++ b/triples/sdp/backends/cvxopt_sdp.py
@@ -48,7 +48,7 @@ class DualBackendCVXOPT(DualBackend):
     def _create_problem(self, configs: SolverConfigs=None):
         if configs is None:
             configs = SolverConfigs()
-        from cvxopt import matrix, solvers
+        from cvxopt import matrix
         Gl = matrix(-self.ineq_lhs) if self.ineq_lhs.size > 0 else None
         hl = matrix(-self.ineq_rhs) if self.ineq_rhs.size > 0 else None
         Gs = [matrix(-A) for A in self.As]

--- a/triples/sdp/backends/cvxpy_sdp.py
+++ b/triples/sdp/backends/cvxpy_sdp.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 
 from .backend import DualBackend
-from .settings import SolverConfigs, SDPError
+from .settings import SolverConfigs
 
 _CVXPY_SOLVER_CONFIGS = {
     'CLARABEL': {

--- a/triples/sdp/backends/cvxpy_sdp.py
+++ b/triples/sdp/backends/cvxpy_sdp.py
@@ -128,7 +128,7 @@ class DualBackendCVXPY(DualBackend):
         from cvxpy import settings as s
         problem = self._create_problem()
         solver_options = update_solver_options(problem, configs.solver_options, configs)
-        obj = problem.solve(verbose=bool(configs.verbose), **solver_options)
+        _ = problem.solve(verbose=bool(configs.verbose), **solver_options)
 
         for var in problem.variables():
             if var.name() == 'y':

--- a/triples/sdp/backends/mosek_sdp.py
+++ b/triples/sdp/backends/mosek_sdp.py
@@ -17,7 +17,7 @@ class mosek_problem:
     """Internal wrapper for mosek.fusion.Model which also holds the variable `y`."""
     M = None
     y = None
-    def __init__(self, M, x):
+    def __init__(self, M, y):
         self.M = M
         self.y = y
     def solve(self):

--- a/triples/sdp/backends/settings.py
+++ b/triples/sdp/backends/settings.py
@@ -221,7 +221,7 @@ class SolverConfigs:
     tol_gap_rel = 1e-8
     tol_fsb_abs = 1e-8
     tol_fsb_rel = 1e-8
-    solver_options = dict()
+    solver_options = {}
     _KEYS = ('verbose', 'max_iters', 'time_limit', 'tol_gap_abs', 'tol_gap_rel', 'tol_fsb_abs', 'tol_fsb_rel', 'solver_options')
     def __init__(self, **kwargs):
         for key in self._KEYS:

--- a/triples/sdp/backends/tests/test_backends.py
+++ b/triples/sdp/backends/tests/test_backends.py
@@ -1,10 +1,8 @@
 import numpy as np
 import sympy as sp
 
-from ..caller import (_DUAL_BACKENDS, solve_numerical_dual_sdp, solve_numerical_primal_sdp,
-    DualBackendCVXOPT, DualBackendCLARABEL, DualBackendQICS, DualBackendSDPAP
+from ..caller import (_DUAL_BACKENDS, solve_numerical_dual_sdp, solve_numerical_primal_sdp
 )
-from ..settings import SDPError
 
 SOLVERS = _DUAL_BACKENDS
 # SOLVERS = {'qics': DualBackendQICS}
@@ -103,7 +101,7 @@ class SDPDualProblems:
 
     @classmethod
     def problem_empty0(cls):
-        x0_and_space = dict()
+        x0_and_space = {}
         return (x0_and_space, [], []), 0.
 
     @classmethod
@@ -162,7 +160,7 @@ class SDPPrimalProblems:
 
         new_x0 = objective
         new_obj = []
-        new_space = dict()
+        new_space = {}
         for key, (x0, space) in x0_and_space.items():
             new_obj.append(np.array(x0).astype(float).flatten())
             new_space[key] = np.array(space).astype(float).T
@@ -191,26 +189,26 @@ class SDPPrimalProblems:
 
     @classmethod
     def problem_empty0(cls):
-        x0_and_space = ([], dict())
+        x0_and_space = ([], {})
         return (x0_and_space, [], []), 0.
 
     @classmethod
     def problem_empty1(cls):
-        x0_and_space = ([], dict())
+        x0_and_space = ([], {})
         return (x0_and_space, [],
                     [(np.ones((2,0)), [1,-1e-15], '<'),
                     (np.ones((1,0)), [1e-15], '=')]), 0.
 
     @classmethod
     def problem_empty2(cls):
-        x0_and_space = ([], dict())
+        x0_and_space = ([], {})
         return (x0_and_space, [],
                     [(np.ones((2,0)), [1,-1e-15], '<'),
                     (np.ones((1,0)), [1e-2], '=')]), None
 
     @classmethod
     def problem_empty3(cls):
-        x0_and_space = ([], dict())
+        x0_and_space = ([], {})
         return (x0_and_space, [],
                     [(np.ones((2,0)), [1,-1e-15], '<'),
                     (np.ones((1,0)), [1e-15], '='),

--- a/triples/sdp/dual.py
+++ b/triples/sdp/dual.py
@@ -1172,9 +1172,9 @@ class SDPProblem(TransformableDual):
             raise SDPTimeoutError.from_kwargs() from e
 
         kwargs = kwargs.copy()
-        if (not ('verbose' in kwargs)) and float(verbose) > 1:
+        if ('verbose' not in kwargs) and float(verbose) > 1:
             kwargs['verbose'] = verbose
-        if end_time is not None and (not ('time_limit' in kwargs)):
+        if end_time is not None and ('time_limit' not in kwargs):
             kwargs['time_limit'] = end_time - perf_counter()
 
         sol = solve_numerical_dual_sdp(

--- a/triples/sdp/dual.py
+++ b/triples/sdp/dual.py
@@ -31,10 +31,10 @@ def _get_unique_symbols(used_symbols, dof: int, xname: str = 'y'):
     xname : str
         The prefix of the symbol name.
     """
-    used_symbols = set([_.name for _ in used_symbols])
+    used_symbols = {_.name for _ in used_symbols}
     xname = xname + '_{'
     n = len(xname)
-    used_symbols = set(s[n:-1] for s in used_symbols if s.startswith(xname) and s[-1] == '}')
+    used_symbols = {s[n:-1] for s in used_symbols if s.startswith(xname) and s[-1] == '}'}
     digits = '0123456789'
     used_digits = list(map(int, filter(lambda x: all(d in digits for d in x), used_symbols)))
     max_digit = max(used_digits, default=-1) + 1
@@ -1191,8 +1191,8 @@ class SDPProblem(TransformableDual):
                 solution = self.rationalize(y, verbose=verbose, time_limit=_time_limit)
                 if solution is not None:
                     self.y = solution[0]
-                    self.S = dict((key, S[0]) for key, S in solution[1].items())
-                    self.decompositions = dict((key, S[1:]) for key, S in solution[1].items())
+                    self.S = {key: S[0] for key, S in solution[1].items()}
+                    self.decompositions = {key: S[1:] for key, S in solution[1].items()}
                     success = True
                 elif allow_numer:
                     self.register_y(y, perturb=True, propagate_to_parent=propagate_to_parent)
@@ -1273,7 +1273,7 @@ class SDPProblem(TransformableDual):
         total_qmodule = sum(n**2 for n in psd_size.values())
         total_ideal = sum(linear_size.values())
 
-        eq_list = dict((i, dict(row)) for i, row in enumerate(eq_list))
+        eq_list = {i: dict(row) for i, row in enumerate(eq_list)}
         eq_list = rep_matrix_from_dict(eq_list, (rhs.shape[0], total_qmodule+total_ideal), domain)
         x0, space = solve_csr_linear(eq_list, rhs, x0_equal_indices=equal_indices,
                         nonnegative_indices=nonnegative_indices, force_zeros=force_zeros)

--- a/triples/sdp/dual.py
+++ b/triples/sdp/dual.py
@@ -2,13 +2,13 @@ from time import perf_counter
 from typing import Tuple, List, Dict, Union, Optional, Any, Callable
 
 import numpy as np
-from sympy import Expr, Symbol, Rational, MatrixBase
+from sympy import Expr, Symbol, MatrixBase
 from sympy.core.relational import Relational
 from sympy import MutableDenseMatrix as Matrix
 
 from .abstract import Decomp
 from .arithmetic import (
-    ArithmeticTimeout, solve_undetermined_linear, solve_csr_linear, free_symbols_of_mat,
+    ArithmeticTimeout, solve_csr_linear, free_symbols_of_mat,
     rep_matrix_from_dict, rep_matrix_to_numpy, rep_matrix_from_numpy, sqrtsize_of_mat
 )
 from .backends import SDPResult, SDPError, SDPTimeoutError, solve_numerical_dual_sdp
@@ -298,7 +298,7 @@ class SDPProblem(TransformableDual):
             _free_symbols_in_domain.update(free_symbols_of_mat(x0))
             _free_symbols_in_domain.update(free_symbols_of_mat(space))
 
-        _free_symbols_in_domain = sorted(list(_free_symbols_in_domain), key=lambda x: x.name)
+        _free_symbols_in_domain = sorted(_free_symbols_in_domain, key=lambda x: x.name)
         self._free_symbols_in_domain = _free_symbols_in_domain
 
         if gens is not None:

--- a/triples/sdp/ipm.py
+++ b/triples/sdp/ipm.py
@@ -330,8 +330,19 @@ def sdp_ipm(
                                     'or a infeasible system.')
 
         if callback is not None:
-            params = dict(k = k, X = Xk, diff = diff, z = z - diff, M = M, lam = lam,
-                          eig_mean = eig_mean, eig_std = eig_std, beta = beta, v = v, r = r)
+            params = {
+                "k": k,
+                "X": Xk,
+                "diff": diff,
+                "z": z - diff,
+                "M": M,
+                "lam": lam,
+                "eig_mean": eig_mean,
+                "eig_std": eig_std,
+                "beta": beta,
+                "v": v,
+                "r": r,
+            }
             if callback(params) is True:
                 break
 

--- a/triples/sdp/primal.py
+++ b/triples/sdp/primal.py
@@ -479,9 +479,9 @@ class SDPPrimal(TransformablePrimal):
 
 
         kwargs = kwargs.copy()
-        if (not ('verbose' in kwargs)) and float(verbose) > 1:
+        if ('verbose' not in kwargs) and float(verbose) > 1:
             kwargs['verbose'] = verbose
-        if end_time is not None and (not ('time_limit' in kwargs)):
+        if end_time is not None and ('time_limit' not in kwargs):
             kwargs['time_limit'] = end_time - perf_counter()
 
         sol = solve_numerical_primal_sdp(

--- a/triples/sdp/primal.py
+++ b/triples/sdp/primal.py
@@ -1,10 +1,10 @@
 from time import perf_counter
-from typing import Dict, List, Union, Optional, Tuple, Any, Callable
+from typing import Dict, List, Union, Optional, Tuple, Any
 
 from numpy import ndarray
 import numpy as np
 from sympy import MutableDenseMatrix as Matrix
-from sympy import MatrixBase, Symbol, Float, Expr, Dummy
+from sympy import MatrixBase, Symbol, Expr, Dummy
 from sympy.core.relational import Relational
 
 from .arithmetic import ArithmeticTimeout, sqrtsize_of_mat, vec2mat, is_numerical_mat, rep_matrix_from_numpy, rep_matrix_to_numpy

--- a/triples/sdp/primal.py
+++ b/triples/sdp/primal.py
@@ -213,7 +213,7 @@ class SDPPrimal(TransformablePrimal):
         """
         if self.dof == 0:
             return Matrix.zeros(self._x0_and_space[0].shape[0], 0)
-        return Matrix.hstack(*[space for space in self._x0_and_space[1].values()])
+        return Matrix.hstack(*list(self._x0_and_space[1].values()))
 
     @classmethod
     def from_full_x0_and_space(
@@ -507,8 +507,8 @@ class SDPPrimal(TransformablePrimal):
                     rationalizers=[RationalizeWithMask(), RationalizeSimultaneously([1,1260,1260**3])])
                 if solution is not None:
                     self.y = solution[0]
-                    self.S = dict((key, S[0]) for key, S in solution[1].items())
-                    self.decompositions = dict((key, S[1:]) for key, S in solution[1].items())
+                    self.S = {key: S[0] for key, S in solution[1].items()}
+                    self.decompositions = {key: S[1:] for key, S in solution[1].items()}
                     success = True
                 elif allow_numer:
                     self.register_y(y, perturb=True, propagate_to_parent=propagate_to_parent)

--- a/triples/sdp/rationalize.py
+++ b/triples/sdp/rationalize.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from itertools import chain
 from typing import Union, Optional, Tuple, List, Dict, Callable, Generator, Any
 
 import numpy as np
@@ -135,7 +134,7 @@ class DualRationalizer:
                         v = v[:row, :]
                         break
                 v = v.T
-            except (DMError, ValueError, ZeroDivisionError) as e: # LLL algorithm failed
+            except (DMError, ValueError, ZeroDivisionError): # LLL algorithm failed
                 v = Matrix.zeros(s.shape[0], 0)
 
             V[key] = v

--- a/triples/sdp/rationalize.py
+++ b/triples/sdp/rationalize.py
@@ -130,7 +130,7 @@ class DualRationalizer:
                 vrep = v._rep.rep.to_sdm()
                 v = v[:nullrank, :]
                 for row in range(nullrank):
-                    if any(map(lambda x: abs(x) > trunc, vrep.get(row, {}).values())):
+                    if any(abs(x) > trunc for x in vrep.get(row, {}).values()):
                         v = v[:row, :]
                         break
                 v = v.T

--- a/triples/sdp/tests/test_dual.py
+++ b/triples/sdp/tests/test_dual.py
@@ -1,5 +1,5 @@
 import sympy as sp
-from sympy.abc import a, b, c, x, y, z, t
+from sympy.abc import a, x, t
 from sympy.matrices import MutableDenseMatrix as Matrix
 
 import pytest

--- a/triples/sdp/tests/test_primal.py
+++ b/triples/sdp/tests/test_primal.py
@@ -1,5 +1,4 @@
 import numpy as np
-import sympy as sp
 from sympy import MutableDenseMatrix as Matrix
 from sympy import Symbol
 

--- a/triples/sdp/transforms/diagonalize.py
+++ b/triples/sdp/transforms/diagonalize.py
@@ -91,7 +91,7 @@ class SDPBlockDiagonalization(SDPLinearTransform):
         # then Si*v == 0 for each i in blocks.
         ns = {}
         for key, children in self._child_keys.items():
-            if not key in nullspace:
+            if key not in nullspace:
                 continue
             blocks = self._blocks[key]
             for b, c in zip(blocks, children):

--- a/triples/sdp/transforms/linear.py
+++ b/triples/sdp/transforms/linear.py
@@ -2,7 +2,7 @@
 This module contains basic linear transformations of SDP problems.
 """
 
-from typing import List, Tuple, Dict, Union, Optional, Callable, Any
+from typing import Tuple, Dict, Union, Optional, Callable, Any
 
 from sympy.matrices import MutableDenseMatrix as Matrix
 

--- a/triples/sdp/transforms/polytope.py
+++ b/triples/sdp/transforms/polytope.py
@@ -171,7 +171,7 @@ class SDPRowExtraction(SDPMatrixTransform):
         mats = {key: child.y.zeros(m, m) for key, m in parent.size.items()}
         y = child.y.zeros(parent.dof, 1)
         y_offset = 0
-        decomps = {key: None for key in parent.size.keys()}
+        decomps = dict.fromkeys(parent.size.keys())
         for key, m in parent.size.items():
             extraction = self._extractions[key]
 
@@ -206,13 +206,13 @@ class DualRowExtraction(SDPRowExtraction):
             return cls.apply_zero_diagonals(parent_node)
 
         if masks is not None:
-            masks = {key: masks.get(key, tuple()) for key in parent_node.keys()}
+            masks = {key: masks.get(key, ()) for key in parent_node.keys()}
         if extractions is not None:
             extractions = {key: extractions.get(key, tuple(range(n))) for key, n in parent_node.size.items()}
         if extractions is None:
             extractions = {key: complement(n, masks[key]) for key, n in parent_node.size.items()}
         if masks is None:
-            extractions = {key: extractions.get(key, tuple()) for key in parent_node.keys()}
+            extractions = {key: extractions.get(key, ()) for key in parent_node.keys()}
             masks = {key: complement(n, extractions[key]) for key, n in parent_node.size.items()}
 
         time_limit = ArithmeticTimeout.make_checker(time_limit)

--- a/triples/sdp/transforms/polytope.py
+++ b/triples/sdp/transforms/polytope.py
@@ -39,7 +39,7 @@ def _get_zero_diagonals_of_dual(self) -> Dict[Any, List[int]]:
 
 def _get_zero_diagonals_of_primal(self) -> Dict[Any, List[int]]:
     zero_diagonals = {key: set() for key in self.keys()}
-    zero_eqs = set([i for i in range(self._x0.shape[0]) if self._x0[i] == 0])
+    zero_eqs = {i for i in range(self._x0.shape[0]) if self._x0[i] == 0}
     new_zero_found = True
     while new_zero_found:
         new_zero_found = False
@@ -255,4 +255,4 @@ class DualRowExtraction(SDPRowExtraction):
 
         child_node = parent_node.__class__(new_x0_and_space)
         transform = cls(parent_node, child_node, extractions=extractions, A=A, b=b)
-        return child_node
+        return transform.child_node

--- a/triples/sdp/transforms/tests/test_diagonalize.py
+++ b/triples/sdp/transforms/tests/test_diagonalize.py
@@ -15,7 +15,7 @@ def test_diagonalize():
         {'X': [[0], [1], [2, 3]]}
 
     sdpp = sdp.constrain_block_structures()
-    assert sorted(list(sdpp.size.values())) == [1, 1, 2]
+    assert sorted(sdpp.size.values()) == [1, 1, 2]
 
     # test restoration of solution
     y = sdp.solve_obj([10, 20])

--- a/triples/sdp/transforms/tests/test_linear.py
+++ b/triples/sdp/transforms/tests/test_linear.py
@@ -52,7 +52,7 @@ def fd_example5():
 
 def test_dual_linear_transform():
     sdp = fd_example2()
-    y1, y2, y3 = a, b, c
+    # y1, y2, y3 = a, b, c
 
     # ensure y1 == y2
     for i in range(2):

--- a/triples/sdp/transforms/transformable.py
+++ b/triples/sdp/transforms/transformable.py
@@ -28,7 +28,7 @@ def _propagate_args_to_last(self, next_node, func, recursive, *args):
         start = False
         transform = None
         for _transform in self._transforms[::-1]:
-            if check_transform(_transform, self) and not (get_next(_transform) is self):
+            if check_transform(_transform, self) and get_next(_transform) is not self:
                 transform = _transform
                 break
         if transform is None:

--- a/triples/sdp/transforms/transformable.py
+++ b/triples/sdp/transforms/transformable.py
@@ -66,11 +66,11 @@ class TransformableProblem(SDPProblemBase):
             if int(short) <= 0:
                 sdp_str = sdp.__str__()
             elif int(short) == 1:
-                size = sorted(list(sdp.size.values()), reverse=True)
+                size = sorted(sdp.size.values(), reverse=True)
                 sdp_str = f"<dof={sdp.dof}, size={size}>"
             else:
                 cnt = Counter(sdp.size.values())
-                items = sorted(list(cnt.items()), reverse=True)
+                items = sorted(cnt.items(), reverse=True)
                 size = [f"{k}²×{v}" if v > 1 else f"{k}²" for k, v in items]
                 sdp_str = f"<dof={sdp.dof}, size=({' + '.join(size)})>"
             return sdp_str

--- a/triples/sdp/utils.py
+++ b/triples/sdp/utils.py
@@ -2,7 +2,7 @@ from typing import Union, Optional, Tuple, List, Dict, Callable, Any
 
 from numpy import ndarray
 import numpy as np
-from sympy import Matrix, MatrixBase, Expr, Symbol, Basic, collect
+from sympy import Matrix, MatrixBase, Expr, Basic
 from sympy.core.relational import GreaterThan, StrictGreaterThan, LessThan, StrictLessThan, Equality, Relational
 from sympy.solvers.solveset import linear_eq_to_matrix
 

--- a/triples/sdp/wedderburn/__init__.py
+++ b/triples/sdp/wedderburn/__init__.py
@@ -1,4 +1,9 @@
 from .character_table import character_table
+from .symmetric import murnaghan_nakayama_character_table, young_symmetrizers
 from .decomposition import symmetry_adapted_basis
 
-__all__ = ['character_table', 'symmetry_adapted_basis']
+__all__ = [
+    'character_table',
+    'murnaghan_nakayama_character_table', 'young_symmetrizers',
+    'symmetry_adapted_basis'
+]

--- a/triples/sdp/wedderburn/character_table.py
+++ b/triples/sdp/wedderburn/character_table.py
@@ -3,8 +3,16 @@ from typing import List, Set, Optional
 from sympy.combinatorics import Permutation, PermutationGroup
 
 from .dixon import dixon_character_table
+from .symmetric import murnaghan_nakayama_character_table
 
 def character_table(G: PermutationGroup, cc: Optional[List[Set[Permutation]]]=None):
-    # TODO: implement other logics
-    cc = cc if cc is not None else G.conjugacy_classes()
+    """
+    Computes the character table of a permutation group,
+    the order of rows and columns are not fixed.
+    """
+    if G.is_symmetric:
+        return murnaghan_nakayama_character_table(G.degree, cc=cc)
+
+    if cc is None:
+        cc = G.conjugacy_classes()
     return dixon_character_table(cc)

--- a/triples/sdp/wedderburn/character_table.py
+++ b/triples/sdp/wedderburn/character_table.py
@@ -9,6 +9,14 @@ def character_table(G: PermutationGroup, cc: Optional[List[Set[Permutation]]]=No
     """
     Computes the character table of a permutation group,
     the order of rows and columns are not fixed.
+
+    Parameters
+    ----------
+    G: PermutationGroup
+        The permutation group.
+    cc: Optional[List[Set[Permutation]]], optional
+        The conjugacy classes of G.
+        If provided, columns are sorted to match the conjugacy classes.
     """
     if G.is_symmetric:
         return murnaghan_nakayama_character_table(G.degree, cc=cc)

--- a/triples/sdp/wedderburn/character_table.py
+++ b/triples/sdp/wedderburn/character_table.py
@@ -7,8 +7,8 @@ from .symmetric import murnaghan_nakayama_character_table
 
 def character_table(G: PermutationGroup, cc: Optional[List[Set[Permutation]]]=None):
     """
-    Computes the character table of a permutation group,
-    the order of rows and columns are not fixed.
+    Compute the character table of a permutation group.
+    The order of rows and columns are not fixed.
 
     Parameters
     ----------
@@ -17,6 +17,28 @@ def character_table(G: PermutationGroup, cc: Optional[List[Set[Permutation]]]=No
     cc: Optional[List[Set[Permutation]]], optional
         The conjugacy classes of G.
         If provided, columns are sorted to match the conjugacy classes.
+
+    Returns
+    -------
+    Matrix
+        The character table of G.
+
+    Examples
+    --------
+    >>> from sympy.combinatorics import SymmetricGroup, AlternatingGroup
+    >>> character_table(SymmetricGroup(4)) # doctest: +SKIP
+    Matrix([
+    [1,  1,  1,  1,  1],
+    [1, -1,  1,  1, -1],
+    [2,  0, -1,  2,  0],
+    [3, -1,  0, -1,  1],
+    [3,  1,  0, -1, -1]])
+    >>> character_table(AlternatingGroup(4)) # doctest: +SKIP
+    Matrix([
+    [1,          1,          1,  1],
+    [1, -1 - zeta3,      zeta3,  1],
+    [1,      zeta3, -1 - zeta3,  1],
+    [3,          0,          0, -1]])
     """
     if G.is_symmetric:
         return murnaghan_nakayama_character_table(G.degree, cc=cc)

--- a/triples/sdp/wedderburn/decomposition.py
+++ b/triples/sdp/wedderburn/decomposition.py
@@ -60,11 +60,11 @@ def symmetry_adapted_basis(
     cols = []
     zero = dom.zero
     m = len(ctab)
-    order = sum(len(c) for c in cc)
+    # order = sum(len(c) for c in cc)
 
     K = int(dom.ext.alias.name.lstrip('zeta')) if dom.is_Algebraic else 1 # type: ignore
     ramanujan = _ramanujan_sum(K)
-    QQzero = QQ.zero
+    # QQzero = QQ.zero
     galsum = lambda anp: QQ(sum(
         (r*v for r, v in zip(ramanujan, anp.rep[::-1]))))
 

--- a/triples/sdp/wedderburn/decomposition.py
+++ b/triples/sdp/wedderburn/decomposition.py
@@ -10,6 +10,7 @@ except ImportError:
     from math import gcd
 
 from .character_table import character_table
+from .symmetric import symmetry_adapted_basis_sn
 from ..arithmetic import solve_columnspace
 
 def _ramanujan_sum(K: int):
@@ -31,13 +32,40 @@ def symmetry_adapted_basis(
     """
     Compute the symmetry-adapted basis of the representation of G.
 
+    The returned basis is a list of matrices so that
+    `Q^TAQ = diag([Qi.T * A * Qi for Qi in Qs])`
+    holds if A is symmetric and commutative with the representation matrices.
+    The size of each block matches the total dimension (including multiplicity)
+    of an irreducible representation.
+
+    Each Q is not ensured to be an orthogonal matrix.
+
+    Parameters
+    ----------
+    G: PermutationGroup
+        The permutation group.
+    representation: Optional[Callable[[Permutation], List[int]]], optional]
+        A permutation representation of G. If not provided,
+        it uses the default representation.
+
     Returns
     -------
     List[Matrix]
         A list of matrices `Qs`, so that
         `Q^TAQ = diag([Qi.T * A * Qi for Qi in Qs])`
-        where A is commutative with the representation matrices.
+        if A is symmetric and commutative with the representation matrices.
     """
+    if G.is_symmetric:
+        return symmetry_adapted_basis_sn(G.degree, representation)
+    # TODO: test whether it is isomorphic to Sn
+    return _symmetry_adapted_basis(G, representation)
+
+def _symmetry_adapted_basis(
+    G: PermutationGroup,
+    representation: Optional[Callable[[Permutation], List[int]]]=None
+) -> List[Matrix]:
+    """Internal function to compute the symmetry-adapted_basis
+    for a general permutation group G."""
     if representation is None:
         representation = lambda g: g.array_form
     n = len(representation(G.identity))

--- a/triples/sdp/wedderburn/dixon.py
+++ b/triples/sdp/wedderburn/dixon.py
@@ -1,29 +1,28 @@
-"""
-Implements the Dixon's algorithm for computing the character
-table in Python. Part of the code is adapted from:
-https://github.com/kalmarek/SymbolicWedderburn.jl.
-"""
+from typing import List, Set, Union, Sequence, Generator, Iterable
 
-from typing import List, Set, Union
-
-from sympy import (Poly, Symbol, FiniteField,
+from sympy import (FiniteField,
     sqrt_mod, nextprime, primitive_root,
     primefactors, ZZ, QQ
 )
 from sympy import MutableDenseMatrix as Matrix
 from sympy.external.gmpy import sqrt as isqrt
+from sympy.external.gmpy import MPZ
 try:
     from sympy.external.gmpy import gcd, lcm
 except ImportError:
     from math import gcd
     from functools import reduce
     lcm = lambda *args: reduce(lambda x, y: x*y//gcd(x, y), args, 1)
+from sympy.polys.domains.domain import Domain
 from sympy.polys.domainmatrix import DomainMatrix
+from sympy.polys.factortools import dup_factor_list_include
 from sympy.polys.polyclasses import ANP
 from sympy.combinatorics import Permutation, PermutationGroup
 
 from sympy import __version__ as SYMPY_VERSION
 from sympy.external.importtools import version_tuple
+
+CC = List[Set[Permutation]]
 
 if tuple(version_tuple(SYMPY_VERSION)) >= (1, 11):
     def cyclotomic_field(n: int, alias: str = "zeta"):
@@ -32,6 +31,7 @@ else:
     def cyclotomic_field(n: int, alias: str = "zeta"):
         """Implement QQ.cyclotomic_field to supports low
         versions of SymPy."""
+        from sympy import Symbol
         from sympy.polys.specialpolys import cyclotomic_poly
         from sympy.polys.rootoftools import CRootOf
         from sympy.core.numbers import AlgebraicNumber
@@ -42,131 +42,112 @@ else:
         return field
 
 
-class CMMatrix:
-    """
-    Internal class to represent the class multiplication matrix.
-    """
-    def __init__(self,
-        cc: List[Set[Permutation]],
-        r: int
-    ):
-        self.cc = cc
-        self.r = r
-        self.m = [[-1]*len(cc) for _ in range(len(cc))]
-    @property
-    def shape(self):
-        return len(self.cc), len(self.cc)
-    def __getitem__(self, idx):
-        i, j = idx
-        if isinstance(i, int) and isinstance(j, int):
-            return self.getitem(i,j)
-        if isinstance(i, slice):
-            i = list(range(*i.indices(len(self.cc))))
-        if isinstance(j, slice):
-            j = list(range(*j.indices(len(self.cc))))
-        return [[self.getitem(i_, j_) for j_ in j] for i_ in i]
-    def getitem(self, i, j):
-        m = self.m
-        if m[i][j] != -1:
-            return m[i][j]
-        cc = self.cc
-        n = len(cc)
-        m[i] = [0] * n
-        rmul = Permutation.rmul_with_af
-        for g in cc[self.r]:
-            for t in range(n):
-                out = next(iter(cc[t]))
-                # out = g^{-1} * h
-                h = rmul(out, g)
-                if h in cc[i]:
-                    m[i][t] += 1
-        return m[i][j]
+def _compute_cmmatrices(cc: Sequence[CC], dom: Domain) -> Generator[DomainMatrix, None, None]:
+    n = len(cc)
+    rmul = Permutation.rmul_with_af
+    for ind in range(n):
+        m = [[-1] * n for _ in range(n)]
+        for i in range(n):
+            for j in range(n):
+                if m[i][j] != -1:
+                    continue
+                m[i] = [0] * n
+                for g in cc[ind]:
+                    for t in range(n):
+                        out = next(iter(cc[t]))
+                        # out = g^{-1} * h
+                        h = rmul(out, g)
+                        if h in cc[i]:
+                            m[i][t] += 1
+        yield DomainMatrix.from_list(m, dom)
 
-def _group_exponent_from_cc(cc: List[Set[Permutation]]) -> int:
+def _group_exponent_from_cc(cc: Sequence[CC]) -> MPZ:
     orders = [int(next(iter(c)).order()) for c in cc]
     exponent = lcm(*orders)
     return exponent
 
-def dixon_prime(order: int, exponent: int) -> int:
+def dixon_prime(order: Union[int, MPZ], exponent: Union[int, MPZ]) -> Union[int, MPZ]:
     """Find a prime p so that p > 2*sqrt(order) and p%exponent == 1."""
     if order == 1:
         # trivial group => exponent == 1
         return 3
-    p = 2*isqrt(order)
+    p = 2 * isqrt(order)
     while True:
         p = nextprime(p + 1)
         if p % exponent == 1:
             break
     return p
 
-def eigenspace_decomposition(A: DomainMatrix) -> List[DomainMatrix]:
+def _eigenspace_decomp(A: DomainMatrix) -> List[DomainMatrix]:
     """Compute eigenspaces of A on the ground domain."""
-    A = A.transpose()
-    Fp = A.domain
-    charpoly = Poly(A.charpoly(), Symbol('x'), domain=Fp)
+    charpoly = A.charpoly()
+    factors = dup_factor_list_include(charpoly, A.domain)
     eigens = []
-    for z in charpoly.ground_roots():
-        z = Fp(int(z)) # MPZ -> int -> Fp
-        B = A - A.diag([z] * A.shape[0], Fp)
-        basis = B.nullspace()
-        basis, pivots = basis.rref()
-        eigens.append(basis)
+    for p, _ in factors:
+        if len(p) == 2:
+            # linear factor
+            z = -p[1]/p[0]
+            B = A - A.diag([z] * A.shape[0], A.domain)
+            basis = B.nullspace()
+            basis, pivots = basis.rref()
+            eigens.append(basis)
     return eigens
 
-def refine_spaces(spaces: List[DomainMatrix], N: CMMatrix, Fp) -> List[DomainMatrix]:
+def _eigenspace_split(spaces: List[DomainMatrix], N: DomainMatrix) -> List[DomainMatrix]:
     new_spaces = []
-    _N = N[:, :]
-    dM = DomainMatrix([[Fp(v) for v in row] for row in _N], N.shape, Fp)
     for S in spaces:
         if S.shape[0] <= 1:
             new_spaces.append(S)
             continue
         _, pivots = S.rref()
-        N0 = dM.extract(range(S.shape[1]), pivots)
-        sub_decomp = eigenspace_decomposition(S * N0)
+        N0 = N.extract(range(S.shape[1]), pivots)
+        sub_decomp = _eigenspace_decomp((S * N0).transpose())
         for sub_S in sub_decomp:
             # sub_S: (sub_dim x dim), S: (dim x n) -> (sub_dim x n)
             new_spaces.append(sub_S * S)
     return new_spaces
 
-def common_esd(Ns: List[CMMatrix], Fp: FiniteField, _check_dim: bool=True) -> DomainMatrix:
+def common_esd(mats: Iterable[DomainMatrix], check_dim: bool=True) -> DomainMatrix:
     """
-    Compute the common eigenspace decomposition of a list of CMMatrix
-    over Fp. Returns Z such that Z * N * Z.inv() is diagonal over Fp
-    for all N in Ns (assuming Z exists).
+    Compute the common eigenspace decomposition of a list of DomainMatrices.
+    Returns Z such that Z * N * Z.inv() is diagonal for all N in mats
+    and Z is on the same domain as mats (assuming Z exists).
     """
-    _N = Ns[0][:, :]
-    N0 = DomainMatrix([[Fp(v) for v in row] for row in _N], Ns[0].shape, Fp)
-    spaces = eigenspace_decomposition(N0)
-    n = len(Ns)
-    for i in range(1, n):
+    it = iter(mats)
+    N0 = next(it)
+    spaces = _eigenspace_decomp(N0)
+    n = N0.shape[0]
+    for N in it:
         if len(spaces) == n:
             break
-        spaces = refine_spaces(spaces, Ns[i], Fp)
-    if _check_dim and len(spaces) != n:
+        spaces = _eigenspace_split(spaces, N)
+    if check_dim and len(spaces) != n:
         # not expected to happen
         raise ValueError("Failed to compute the common eigenspace decomposition.")
     return DomainMatrix.vstack(*spaces)
 
-def _get_invmap(cc: List[Set[Permutation]]) -> List[int]:
+def _get_invmap(cc: Sequence[CC]) -> List[int]:
     """Compute inv_map[i] = j such that class[i]**-1 == class[j]."""
-    inv_map = [0] * len(cc)
+    inv_map = [-1] * len(cc)
     reps = [next(iter(c)) for c in cc]
     inv_reps = [~g for g in reps]
     for i, ig in enumerate(inv_reps):
+        if inv_map[i] != -1:
+            continue
         for j, c in enumerate(cc):
             if ig in c:
                 inv_map[i] = j
+                inv_map[j] = i
                 break
     return inv_map
 
-def _get_powermap(cc: List[Set[Permutation]], exponent: int) -> List[List[int]]:
+def _get_powermap(cc: Sequence[CC], exponent: Union[int, MPZ]) -> List[List[int]]:
     """Compute pm[i][pow] = k such that class[i]**pow == k."""
     n = len(cc)
-    pm = [[0] * exponent for _ in range(n)]
+    pm = [[-1] * exponent for _ in range(n)]
     reps = [next(iter(c)) for c in cc]
     rmul = Permutation.rmul_with_af
-    identity = Permutation(size=reps[0].size)
+    identity = rmul(reps[0], ~reps[0])
     for i in range(n):
         g = reps[i]
         gk = identity
@@ -178,11 +159,11 @@ def _get_powermap(cc: List[Set[Permutation]], exponent: int) -> List[List[int]]:
             gk = rmul(gk, g)
     return pm
 
-def normalize_fp(cc: List[Set[Permutation]], esd: DomainMatrix):
+def normalize_fp(cc: Sequence[CC], esd: DomainMatrix) -> List[List]:
     Fp = esd.domain
-    p = Fp.mod
-    rows = esd.to_list()
+    p = Fp.mod # type: ignore
     n = len(cc)
+    rows = esd.to_list()
     cc_sizes = [Fp(len(c)) for c in cc]
     G_order = sum(len(cc[t]) for t in range(len(cc)))
 
@@ -191,7 +172,7 @@ def normalize_fp(cc: List[Set[Permutation]], esd: DomainMatrix):
     for row in rows:
         # 1. normalize so the first class is 1
         scale = 1/Fp(row[0])
-        row = [Fp(x) * scale for x in row]
+        row = [x * scale for x in row]
 
         # 2. chi(1)^2 * sum |Ci| * row[i] * row[inv_i] = |G|
         dot = sum(cc_sizes[k] * row[k] * row[inv_map[k]] for k in range(n))
@@ -201,6 +182,7 @@ def normalize_fp(cc: List[Set[Permutation]], esd: DomainMatrix):
 
         root = sqrt_mod(int(chi1_sq), p)
         if root is None:
+            # not expected to happen
             raise ValueError(f"Failed to compute sqrt({chi1_sq}) on {Fp}")
         chi1 = Fp(root)
 
@@ -209,42 +191,18 @@ def normalize_fp(cc: List[Set[Permutation]], esd: DomainMatrix):
     return normalized_rows
 
 
-def dixon_character_table(
-    G_or_cc: Union[PermutationGroup, List[Set[Permutation]]]
-) -> Matrix:
-    if isinstance(G_or_cc, PermutationGroup):
-        cc = G_or_cc.conjugacy_classes()
-    else:
-        cc = G_or_cc
-
-    order = sum(len(cc[t]) for t in range(len(cc)))
-    exponent = _group_exponent_from_cc(cc)
-    p = dixon_prime(order, exponent)
-    Fp = FiniteField(p)
-
-    Ns = [CMMatrix(cc, i) for i in range(len(cc))]
-    esd = common_esd(Ns, Fp)
-
-    normalized = normalize_fp(cc, esd)
-    pm = _get_powermap(cc, exponent)
-
-    conductor = _get_global_conductor(normalized, pm, exponent)
-    dm = _lift_to_minimal_field(cc, normalized, pm, conductor, exponent, Fp)
-
-    return Matrix._fromrep(dm)
-
-
-def _get_global_conductor(normalized_rows, pm: List[List[int]], m: int):
-    """Find the smallest natural number K such that all values
-    of the character table are in the K-th cyclotomic field.
+def _get_global_conductor(rows: List[List], pm: List[List[int]], m: Union[int, MPZ]) -> Union[int, MPZ]:
     """
-    n = len(normalized_rows)
+    Find the smallest natural number k such that all values of the
+    character table can be embedded in the k-th cyclotomic field.
+    """
+    n = len(rows)
     gal_m = [a for a in range(m) if gcd(a, m) == 1]
     p_factors = primefactors(m)[::-1]
 
     for p in p_factors:
         while m % p == 0:
-            # test m//p
+            # test invariance under m//p
             m = m//p
             r = 1 % m
 
@@ -253,7 +211,7 @@ def _get_global_conductor(normalized_rows, pm: List[List[int]], m: int):
                 if a % m != r:
                     continue
                 for i in range(n):
-                    row = normalized_rows[i]
+                    row = rows[i]
                     for j in range(n):
                         if row[pm[j][a]] != row[j]:
                             fixed = False
@@ -268,29 +226,27 @@ def _get_global_conductor(normalized_rows, pm: List[List[int]], m: int):
                 break
     return m
 
-def _lift_to_minimal_field(cc, normalized_rows, pm, K, exponent, Fp):
-    n = len(cc)
+def _lift_to_minimal_field(normalized_rows, pm, k, e, Fp):
+    n = len(normalized_rows)
     p = Fp.mod
+    half_p = p // 2
 
-    if K == 1:
+    if k == 1:
         # integer character table
-        rows = [None] * n
-        half_p = p // 2
+        int_rows = []
         for i in range(n):
             # abs(every entry) <= sqrt(|G|) <= p//2
-            row = [int(v) for v in normalized_rows[i]]
+            row = [ZZ(int(v)) for v in normalized_rows[i]]
             row = [v if v <= half_p else v - p for v in row]
-            row = [ZZ(v) for v in row]
-            rows[i] = row
-        rows = _sort_characters(rows, ZZ)
-        return DomainMatrix(rows, (n, n), ZZ)
+            int_rows.append(row)
+        _sort_characters(int_rows, ZZ)
+        return DomainMatrix(int_rows, (n, n), ZZ)
 
-    # dom = QQ.cyclotomic_field(K, ss=True)
-    dom = cyclotomic_field(K)
+    dom = QQ.cyclotomic_field(k, ss=True)
 
-    x = Fp(primitive_root(p))**((p - 1) // K)
+    x = Fp(primitive_root(p))**((p - 1) // k)
 
-    gal = [a for a in range(K) if gcd(a, K) == 1]
+    gal = [a for a in range(k) if gcd(a, k) == 1]
     phi = len(gal)
 
     # V[a, i] = (x**a)**i
@@ -301,22 +257,17 @@ def _lift_to_minimal_field(cc, normalized_rows, pm, K, exponent, Fp):
         V.append(row)
 
     V_mat = DomainMatrix(V, (phi, phi), Fp)
-    try:
-        V_inv = V_mat.inv()
-    except ValueError:
-        raise ValueError(f"{K} is not a conductor.")
+    V_inv = V_mat.inv()
 
-    # for a in (Z/K)*, find A in (Z/exp)* that A = a (mod K)
+    # for a in (Z/k)*, find A in (Z/exp)* that A = a (mod k)
     gal_lifted = []
     for a in gal:
         A = a
-        while gcd(A, exponent) != 1:
-            A += K
+        while gcd(A, e) != 1:
+            A += k
         gal_lifted.append(A)
 
-    half_p = p // 2
-    rows = []
-
+    dM = []
     for i in range(n):
         char_row_fp = normalized_rows[i]
         row_anps = []
@@ -325,7 +276,7 @@ def _lift_to_minimal_field(cc, normalized_rows, pm, K, exponent, Fp):
             # [chi(g^A1), chi(g^A2), ...] mod p
             b_vec_data = []
             for A in gal_lifted:
-                class_of_gA = pm[j][A % exponent]
+                class_of_gA = pm[j][A % e]
                 b_vec_data.append([char_row_fp[class_of_gA]])
 
             b_vec = DomainMatrix(b_vec_data, (phi, 1), Fp)
@@ -338,21 +289,55 @@ def _lift_to_minimal_field(cc, normalized_rows, pm, K, exponent, Fp):
 
             row_anps.append(ANP(c_ints[::-1], dom.mod, QQ))
 
-        rows.append(row_anps)
+        dM.append(row_anps)
 
-    rows = _sort_characters(rows, dom)
-    return DomainMatrix(rows, (n, n), dom)
+    _sort_characters(dM, dom)
+    return DomainMatrix(dM, (n, n), dom)
 
-
-def _sort_characters(rows, dom):
+def _sort_characters(rows: List[List], dom: Domain):
     """
     Sort the character table and move the trivial
     character to the first row. Done in-place.
     """
     one = dom.one
     rows.sort()
-    for i, row in enumerate(rows):
-        if all(v == one for v in row):
-            rows[0], rows[i] = row, rows[0]
+    for i in range(len(rows)):
+        if all(v == one for v in rows[i]):
+            rows[0], rows[i] = rows[i], rows[0]
             break
-    return rows
+
+
+def dixon_character_table(conjugacy_classes: Union[Sequence[CC], PermutationGroup]) -> Matrix:
+    """
+    Computes the character table of a permutation group
+    given its character table, using Dixon's algorithm.
+
+    References
+    ----------
+    [1] John D. Dixon. High speed computation of group characters. Numerische
+    Mathematik, 10:446-450, 1967.
+
+    [2] Gerhard J. A. Schneider. Dixon's character table algorithm revisited. Journal of
+    Symbolic Computation, 9(5-6):601-606, 1990.
+
+    [3] Jean Michel. Handbook of computational group theory. Math. Comput., 75, 01 2006.
+    """
+    if isinstance(conjugacy_classes, PermutationGroup):
+        cc = conjugacy_classes.conjugacy_classes()
+    else:
+        cc = conjugacy_classes
+    order = sum(len(cc[t]) for t in range(len(cc)))
+    exponent = _group_exponent_from_cc(cc)
+    p = dixon_prime(order, exponent)
+    Fp = FiniteField(p)
+
+    mats = _compute_cmmatrices(cc, Fp)
+    esd = common_esd(mats)
+
+    normalized = normalize_fp(cc, esd)
+    pm = _get_powermap(cc, exponent)
+
+    conductor = _get_global_conductor(normalized, pm, exponent)
+    dm = _lift_to_minimal_field(normalized, pm, conductor, exponent, Fp)
+
+    return Matrix._fromrep(dm)

--- a/triples/sdp/wedderburn/dixon.py
+++ b/triples/sdp/wedderburn/dixon.py
@@ -59,7 +59,8 @@ def _compute_cmmatrices(cc: Sequence[CC], dom: Domain) -> Generator[DomainMatrix
                         h = rmul(out, g)
                         if h in cc[i]:
                             m[i][t] += 1
-        yield DomainMatrix.from_list(m, dom)
+        m = [[dom(_) for _ in row] for row in m]
+        yield DomainMatrix(m, (n, n), dom)
 
 def _group_exponent_from_cc(cc: Sequence[CC]) -> MPZ:
     orders = [int(next(iter(c)).order()) for c in cc]
@@ -242,7 +243,8 @@ def _lift_to_minimal_field(normalized_rows, pm, k, e, Fp):
         _sort_characters(int_rows, ZZ)
         return DomainMatrix(int_rows, (n, n), ZZ)
 
-    dom = QQ.cyclotomic_field(k, ss=True)
+    # dom = QQ.cyclotomic_field(k, ss=True)
+    dom = cyclotomic_field(k)
 
     x = Fp(primitive_root(p))**((p - 1) // k)
 

--- a/triples/sdp/wedderburn/dixon.py
+++ b/triples/sdp/wedderburn/dixon.py
@@ -353,6 +353,6 @@ def _sort_characters(rows, dom):
     rows.sort()
     for i, row in enumerate(rows):
         if all(v == one for v in row):
-            rows[0], rows[i] = rows[i], rows[0]
+            rows[0], rows[i] = row, rows[0]
             break
     return rows

--- a/triples/sdp/wedderburn/symmetric.py
+++ b/triples/sdp/wedderburn/symmetric.py
@@ -2,9 +2,13 @@ from typing import Tuple, List, Dict, Set, Callable, Optional, Any
 from collections import defaultdict
 from itertools import permutations, product
 
+from sympy import QQ
 from sympy import MutableDenseMatrix as Matrix
 from sympy.combinatorics.permutations import Permutation, _af_parity
+from sympy.polys.domainmatrix import DomainMatrix
 from sympy.utilities.iterables import ordered_partitions
+
+from .dixon import common_esd
 
 def sign_of(perm: Tuple[int, ...]) -> int:
     """
@@ -159,13 +163,13 @@ def murnaghan_nakayama_character_table(n: int, cc: Optional[List[Set[Permutation
 
         cc_parts = []
         for cls in cc:
-            if not cls:
-                raise ValueError("each conjugacy class set must be nonempty")
+            # if not cls:
+            #     raise ValueError("each conjugacy class set must be nonempty")
             perm = next(iter(cls))
             lengths = [len(c) for c in perm.full_cyclic_form]
             part = tuple(sorted(lengths, reverse=True))
-            if sum(part) != n:
-                raise ValueError("permutations in cc must lie in S_n")
+            # if sum(part) != n:
+            #     raise ValueError("permutations in cc must lie in S_n")
             cc_parts.append(part)
 
         if len(cc_parts) != len(parts):
@@ -289,4 +293,128 @@ def young_symmetrizers(
 
         out[shape] = {k: v for k, v in coeffs.items() if v}
 
+    return out
+
+
+def young_shape_from_contents(contents: Tuple[int, ...]) -> Tuple[int, ...]:
+    """
+    Convert the contents of a young tableaux to its shape. The content
+    of an entry at row-i, col-j is (j - i).
+
+    Parameters
+    ----------
+    contents: Tuple[int, ...]
+        The contents of the young tableaux.
+
+    Returns
+    -------
+    Tuple[int, ...]
+        The shape of the young tableaux.
+
+    Examples
+    --------
+    >>> young_shape_from_contents((0, 1, 2, -1, 0))
+    (3, 2)
+    """
+    shape = []
+    for c in contents:
+        for r, ln in enumerate(shape):
+            if ln - r == c:
+                shape[r] += 1
+                break
+        else:
+            if -len(shape) == c:
+                shape.append(1)
+            else:
+                raise ValueError(f"Invalid content sequence {contents}")
+    return tuple(shape)
+
+
+def symmetry_adapted_basis_sn(
+    n: int,
+    representation: Optional[Callable[[Permutation], List[int]]]=None,
+    reduced: bool = False
+) -> List[Matrix]:
+    """
+    Compute the symmetry-adapted basis of the representation of Sn
+    using the Jucys-Murphy elements.
+
+    The returned basis is a list of matrices so that
+    `Q^TAQ = diag([Qi.T * A * Qi for Qi in Qs])`
+    holds if A is symmetric and commutative with the representation matrices.
+    The size of each block matches the multiplicity of each irreducible
+    representation. The returned matrices are rational.
+
+    Each Q is not ensured to be an orthogonal matrix.
+
+    Parameters
+    ----------
+    n: int
+        The size of the symmetric group.
+    representation: Optional[Callable[[Permutation], List[int]]], optional]
+        A permutation representation of Sn. If not provided,
+        it uses the default representation.
+    reduced: bool, optional
+        If True, returns a reduced list of basis where only one matrix
+        is needed to represent each irreducible representation. Defaults to False.
+
+    Returns
+    -------
+    List[Matrix]
+        A list of matrices `Qs`, so that
+        `Q^TAQ = diag([Qi.T * A * Qi for Qi in Qs])`
+        where A is symmetric and commutative with the representation matrices.
+    """
+    if representation is None:
+        representation = lambda g: g.array_form
+
+    identity = Permutation(size=n)
+    m = len(representation(identity))
+    if m == 0:
+        return []
+    if n <= 1:
+        return [Matrix.eye(m)]
+
+    def rho(key: Tuple[int, ...]) -> DomainMatrix:
+        arr = representation(Permutation(key, size=n))
+        sdm = {arr[j]: {j: QQ.one} for j in range(m)}
+        return DomainMatrix(sdm, (m, m), QQ)
+
+    # jucys-murphy elements
+    jm = []
+    for k in range(1, n):
+        X = DomainMatrix.zeros((m, m), QQ)
+        for j in range(k):
+            X += rho(tuple(Permutation(j, k, size=n).array_form))
+        jm.append(X)
+
+    Z = common_esd(jm, check_dim=False)
+    rows = Z.to_list()
+
+    groups = {}
+    for row in rows:
+        # compute the eigenvalue associated with the row vector
+        # eigenvals of Jucys-Murphy elements are integers
+        nz = next(i for i, a in enumerate(row) if a)
+        row_dm = DomainMatrix([row], (1, m), QQ)
+        sig = tuple(
+            (row_dm * X[:, nz]).to_list()[0][0] / row[nz]
+            for X in jm
+        )
+        groups.setdefault(sig, []).append(row)
+
+    out = []
+    shapes = {}
+    for sig, block_rows in groups.items():
+        shape = young_shape_from_contents((0,) + tuple(int(c) for c in sig))
+        shapes.setdefault(shape, []).append(block_rows)
+
+    shapes = sorted(shapes.items(), key=lambda x: x[0], reverse=True)
+    for shape, block_rows in shapes:
+        for block in block_rows:
+            mat = DomainMatrix(block, (len(block), m), QQ)
+            # mat = _ortho(mat)
+            out.append(mat.to_Matrix().T)
+            if reduced:
+                break
     return out

--- a/triples/sdp/wedderburn/symmetric.py
+++ b/triples/sdp/wedderburn/symmetric.py
@@ -1,0 +1,155 @@
+from typing import List, Set, Optional
+
+from sympy import MutableDenseMatrix as Matrix
+from sympy.combinatorics import Permutation
+from sympy.utilities.iterables import ordered_partitions
+
+
+def murnaghan_nakayama_character_table(n: int, cc: Optional[List[Set[Permutation]]]=None) -> Matrix:
+    """
+    Compute the character table of a symmetric group Sn
+    using the Murnaghan-Nakayama formula.
+
+    Parameters
+    ----------
+    n : int
+        The size of the symmetric group.
+
+    Returns
+    -------
+    Matrix
+        The character table of Sn.
+    """
+    if n < 0:
+        raise ValueError("n must be nonnegative")
+    if n == 0:
+        return Matrix([[1]])
+
+    def normalize(p):
+        return tuple(reversed(p))
+
+    parts = [normalize(p) for p in ordered_partitions(n)]
+    by_size = {0: [()]}
+    for k in range(1, n + 1):
+        by_size[k] = [normalize(p) for p in ordered_partitions(k)]
+
+    hook_memo = {}
+    char_memo = {}
+
+    def rim_hooks(lam, k):
+        key = (lam, k)
+        if key in hook_memo:
+            return hook_memo[key]
+
+        target = sum(lam) - k
+        if target < 0:
+            hook_memo[key] = ()
+            return ()
+
+        res = []
+        for mu in by_size[target]:
+            m = max(len(lam), len(mu))
+            cells = []
+            ok = True
+
+            for i in range(m):
+                a = lam[i] if i < len(lam) else 0
+                b = mu[i] if i < len(mu) else 0
+                if b > a:
+                    ok = False
+                    break
+                for j in range(b + 1, a + 1):
+                    cells.append((i, j))
+
+            if not ok or len(cells) != k:
+                continue
+
+            s = set(cells)
+            stack = [cells[0]]
+            seen = {cells[0]}
+
+            while stack:
+                i, j = stack.pop()
+                for nb in ((i - 1, j), (i + 1, j), (i, j - 1), (i, j + 1)):
+                    if nb in s and nb not in seen:
+                        seen.add(nb)
+                        stack.append(nb)
+
+            if len(seen) != k:
+                continue
+
+            rows = {i for i, _ in s}
+            cols = {j for _, j in s}
+            ribbon = True
+
+            for i in rows:
+                for j in cols:
+                    if ((i, j) in s and (i + 1, j) in s and
+                            (i, j + 1) in s and (i + 1, j + 1) in s):
+                        ribbon = False
+                        break
+                if not ribbon:
+                    break
+
+            if ribbon:
+                res.append((mu, len(rows) - 1))
+
+        hook_memo[key] = tuple(res)
+        return hook_memo[key]
+
+    def chi(lam, mu):
+        key = (lam, mu)
+        if key in char_memo:
+            return char_memo[key]
+
+        if sum(lam) != sum(mu):
+            return 0
+        if not mu:
+            return 1 if not lam else 0
+        if not lam:
+            return 0
+
+        total = 0
+        first = mu[0]
+        rest = mu[1:]
+
+        for nu, height in rim_hooks(lam, first):
+            total += (-1) ** height * chi(nu, rest)
+
+        char_memo[key] = total
+        return total
+
+    raw_rows = [[chi(lam, mu) for mu in parts] for lam in parts]
+
+    rows = sorted(
+        zip(parts, raw_rows),
+        key=lambda t: (t[1][0], 0 if t[0] == (n,) else 1, t[0]),
+    )
+
+    table = [row for _, row in rows]
+
+    if cc is not None:
+        part_to_col = {part: i for i, part in enumerate(parts)}
+
+        cc_parts = []
+        for cls in cc:
+            if not cls:
+                raise ValueError("each conjugacy class set must be nonempty")
+            perm = next(iter(cls))
+            lengths = [len(c) for c in perm.full_cyclic_form]
+            part = tuple(sorted(lengths, reverse=True))
+            if sum(part) != n:
+                raise ValueError("permutations in cc must lie in S_n")
+            cc_parts.append(part)
+
+        if len(cc_parts) != len(parts):
+            raise ValueError("cc must contain exactly p(n) conjugacy classes")
+
+        try:
+            col_order = [part_to_col[p] for p in cc_parts]
+        except KeyError as exc:
+            raise ValueError("cc contains an invalid cycle type for S_n") from exc
+
+        table = [[row[j] for j in col_order] for row in table]
+
+    return Matrix(table)

--- a/triples/sdp/wedderburn/symmetric.py
+++ b/triples/sdp/wedderburn/symmetric.py
@@ -1,8 +1,31 @@
-from typing import List, Set, Optional
+from typing import Tuple, List, Dict, Set, Callable, Optional, Any
+from collections import defaultdict
+from itertools import permutations, product
 
 from sympy import MutableDenseMatrix as Matrix
-from sympy.combinatorics import Permutation
+from sympy.combinatorics.permutations import Permutation, _af_parity
 from sympy.utilities.iterables import ordered_partitions
+
+def sign_of(perm: Tuple[int, ...]) -> int:
+    """
+    Compute the sign of a permutation of 0, 1, ..., n-1.
+
+    Parameters
+    ----------
+    perm: Tuple[int, ...]
+        The permutation to compute the sign of.
+
+    Returns
+    -------
+    int
+        The sign of the permutation.
+
+    Examples
+    --------
+    >>> sign_of((1,2,0,5,4,3))
+    -1
+    """
+    return -1 if _af_parity(perm) % 2 else 1
 
 
 def murnaghan_nakayama_character_table(n: int, cc: Optional[List[Set[Permutation]]]=None) -> Matrix:
@@ -12,8 +35,11 @@ def murnaghan_nakayama_character_table(n: int, cc: Optional[List[Set[Permutation
 
     Parameters
     ----------
-    n : int
+    n: int
         The size of the symmetric group.
+    cc: Optional[List[Set[Permutation]]], optional
+        The conjugacy classes of Sn symmetric group.
+        If provided, columns are sorted to match the conjugacy classes.
 
     Returns
     -------
@@ -153,3 +179,114 @@ def murnaghan_nakayama_character_table(n: int, cc: Optional[List[Set[Permutation
         table = [[row[j] for j in col_order] for row in table]
 
     return Matrix(table)
+
+
+def young_symmetrizers(
+    n: int,
+    action: Optional[Callable[[Tuple[int, ...]], Any]]=None
+) -> Dict[Tuple[int, ...], Dict[Any, int]]:
+    """
+    Compute a dict of young symmetrizers of degree n. The returned dict
+    has partitions as keys and group elements as values.
+    The time and space complexity is at least O(n!).
+
+    Parameters
+    ----------
+    n: int
+        The size of the symmetric group.
+
+    action: Optional[Callable[[Tuple[int, ...]], Any], optional]
+        A homomorphism from Permutations to some hashable values.
+
+    Returns
+    -------
+    Dict[Tuple[int, ...], Dict[Any, int]]
+        A dict of young symmetrizers of degree n.
+
+    Examples
+    --------
+    >>> young_symmetrizers(3) # doctest: +SKIP
+    {(3,): {(0, 1, 2): 1,
+      (0, 2, 1): 1,
+      (1, 0, 2): 1,
+      (1, 2, 0): 1,
+      (2, 0, 1): 1,
+      (2, 1, 0): 1},
+     (2, 1): {(0, 1, 2): 1, (2, 1, 0): -1, (1, 0, 2): 1, (2, 0, 1): -1},
+     (1, 1, 1): {(0, 1, 2): 1,
+      (0, 2, 1): -1,
+      (1, 0, 2): -1,
+      (1, 2, 0): 1,
+      (2, 0, 1): 1,
+      (2, 1, 0): -1}}
+    >>> from sympy.combinatorics import Permutation
+    >>> young_symmetrizers(3, action=Permutation) # doctest: +SKIP
+    {(3,): {Permutation(2): 1,
+      Permutation(1, 2): 1,
+      Permutation(2)(0, 1): 1,
+      Permutation(0, 1, 2): 1,
+      Permutation(0, 2, 1): 1,
+      Permutation(0, 2): 1},
+     (2, 1): {Permutation(2): 1,
+      Permutation(0, 2): -1,
+      Permutation(2)(0, 1): 1,
+      Permutation(0, 2, 1): -1},
+     (1, 1, 1): {Permutation(2): 1,
+      Permutation(1, 2): -1,
+      Permutation(2)(0, 1): -1,
+      Permutation(0, 1, 2): 1,
+      Permutation(0, 2, 1): 1,
+      Permutation(0, 2): -1}}
+    """
+    if action is None:
+        action = lambda x: x
+    if n < 0:
+        raise ValueError("n must be nonnegative")
+    if n == 0:
+        return {(): {action(()): 1}}
+
+    shapes = [tuple(p[::-1]) for p in reversed(list(ordered_partitions(n)))]
+
+    perm_by_len = {0: [()]}
+    sign_by_len = {0: {(): 1}}
+    for k in range(1, n + 1):
+        perms_k = [tuple(p) for p in permutations(range(k))]
+        perm_by_len[k] = perms_k
+        sign_by_len[k] = {p: sign_of(p) for p in perms_k}
+
+    def build_perm(blocks, choice, signed=False):
+        arr = list(range(n))
+        sgn = 1
+        for block, rel in zip(blocks, choice):
+            if signed:
+                sgn *= sign_by_len[len(block)][rel]
+            for pos, idx in zip(block, rel):
+                arr[pos] = block[idx]
+        return tuple(arr), sgn
+
+    out = {}
+    for shape in shapes:
+        rows = []
+        start = 0
+        for ln in shape:
+            rows.append(tuple(range(start, start + ln)))
+            start += ln
+
+        col_blocks = [
+            tuple(row[j] for row in rows if j < len(row))
+            for j in range(shape[0])
+        ]
+
+        col_terms = []
+        for choice in product(*(perm_by_len[len(block)] for block in col_blocks)):
+            col_terms.append(build_perm(col_blocks, choice, signed=True))
+
+        coeffs = defaultdict(int)
+        for choice in product(*(perm_by_len[len(block)] for block in rows)):
+            r, _ = build_perm(rows, choice, signed=False)
+            for c, sgn in col_terms:
+                coeffs[action(tuple(r[i] for i in c))] += sgn
+
+        out[shape] = {k: v for k, v in coeffs.items() if v}
+
+    return out

--- a/triples/sdp/wedderburn/tests/test_symmetric.py
+++ b/triples/sdp/wedderburn/tests/test_symmetric.py
@@ -1,0 +1,22 @@
+from sympy import factorial
+from sympy.combinatorics import SymmetricGroup
+from ..symmetric import murnaghan_nakayama_character_table
+from ..dixon import dixon_character_table
+
+def test_murnaghan_nakayama_character_table():
+    a000041 = [1, 1, 2, 3, 5, 7, 11, 15, 22, 30, 42, 56, 77, 101]
+    for n in range(1, 9):
+        m = a000041[n]
+        X = murnaghan_nakayama_character_table(n)
+        assert X.shape == (m, m)
+        assert all(i == 1 for i in X[0, :].tolist()[0])
+        assert all(X[i+1, 0] >= X[i, 0] for i in range(m - 1))
+        assert (X.T * X).is_diagonal()
+        assert sum(X[:, 0].applyfunc(lambda x: x**2)) == factorial(n)
+
+    for n in range(1, 6):
+        G = SymmetricGroup(n)
+        cc = G.conjugacy_classes()
+        X = murnaghan_nakayama_character_table(n, cc=cc).tolist()
+        Y = dixon_character_table(cc).tolist()
+        assert sorted(X) == sorted(Y)

--- a/triples/sdp/wedderburn/tests/test_symmetric.py
+++ b/triples/sdp/wedderburn/tests/test_symmetric.py
@@ -1,6 +1,8 @@
+from collections import defaultdict
+
 from sympy import factorial
-from sympy.combinatorics import SymmetricGroup
-from ..symmetric import murnaghan_nakayama_character_table
+from sympy.combinatorics import SymmetricGroup, Permutation
+from ..symmetric import murnaghan_nakayama_character_table, young_symmetrizers
 from ..dixon import dixon_character_table
 
 def test_murnaghan_nakayama_character_table():
@@ -20,3 +22,31 @@ def test_murnaghan_nakayama_character_table():
         X = murnaghan_nakayama_character_table(n, cc=cc).tolist()
         Y = dixon_character_table(cc).tolist()
         assert sorted(X) == sorted(Y)
+
+
+def test_young_symmetrizers():
+    def _mul(a, b):
+        d = defaultdict(int)
+        for p, v1 in a.items():
+            for q, v2 in b.items():
+                d[p * q] += v1 * v2
+        return {p: v for p, v in d.items() if v}
+
+    for n in range(1, 6):
+        dims = {}
+        young = list(young_symmetrizers(n, action=Permutation).items())
+        for i in range(len(young)):
+            # idempotent
+            y = young[i][1]
+            y2 = _mul(y, y)
+            c = y2[Permutation(size=n)]
+            dims[young[i][0]] = c
+            assert c != 0 and len(y2) == len(y) and all(y2[k] == c * y[k] for k in y)
+
+            # orthogonality between different shapes
+            for j in range(i+1, len(young)):
+                assert not _mul(y, young[j][1])
+
+        dims = {k:factorial(n)//v for k, v in dims.items()}
+        expected = murnaghan_nakayama_character_table(n)[:, 0]
+        assert sorted(dims.values()) == sorted(expected)

--- a/triples/testing/doctest_parser.py
+++ b/triples/testing/doctest_parser.py
@@ -373,10 +373,10 @@ def _collect_doctest_examples_raw(
     skip: bool = True,
 ):
     lines = [_.strip() for _ in doc.splitlines()]
-    lines = [_ for _ in lines if _.startswith('=>') or _.startswith('::')]
+    lines = [_ for _ in lines if _.startswith(('=>','::'))]
     cases = []
     for line in lines:
-        if not (line.startswith('=>') or line.startswith('::')):
+        if not line.startswith(('=>','::')):
             continue
 
         # Although it can be implemented more carefully,

--- a/triples/testing/doctest_parser.py
+++ b/triples/testing/doctest_parser.py
@@ -270,7 +270,7 @@ def parse_ident_list_like(s: str) -> Union[List[str], Tuple[str, ...], set]:
         if open_ch == "[":
             return []
         if open_ch == "(":
-            return tuple()
+            return ()
         if open_ch == "{":
             return set()
 

--- a/triples/testing/tests/test_dependency.py
+++ b/triples/testing/tests/test_dependency.py
@@ -53,7 +53,7 @@ def test_dependency():
                     if len(imp) == 0:
                         # relative import from current package
                         continue
-                    if not (imp in ALLOWED_LIBS):
+                    if imp not in ALLOWED_LIBS:
                         if imp == "pytest" and file.startswith("test_"):
                             continue
                         forbidden_libraries.add((file_path, line_num, imp))

--- a/triples/testing/tests/test_dependency.py
+++ b/triples/testing/tests/test_dependency.py
@@ -59,7 +59,7 @@ def test_dependency():
                         forbidden_libraries.add((file_path, line_num, imp))
 
     if forbidden_libraries:
-        forbidden_libraries = sorted(list(forbidden_libraries))
+        forbidden_libraries = sorted(forbidden_libraries)
         message = '\n'.join([f"{fp}:line {ln}:import {lib}"%(fp, ln, lib) for fp, ln, lib in forbidden_libraries])
         assert False, (
             f"Forbidden dependencies detected: {message}."

--- a/triples/utils/expressions/coeff.py
+++ b/triples/utils/expressions/coeff.py
@@ -1,4 +1,4 @@
-from typing import Union, Dict, List, Tuple, Optional, Callable, Iterator
+from typing import Union, List, Tuple, Optional, Callable, Iterator
 
 from sympy import Poly, Expr, Basic, Symbol, Rational
 from sympy import MutableDenseMatrix as Matrix

--- a/triples/utils/expressions/coeff.py
+++ b/triples/utils/expressions/coeff.py
@@ -492,6 +492,7 @@ class Coeff():
         """
         if perm_group is None:
             perm_group = "cyc"
+        # TODO: do not convert it to poly
         return verify_symmetry(self.as_poly(), perm_group)
 
     def is_symmetric(self, perm_group: Optional[Union[str, Permutation, List[Permutation], PermutationGroup]] = None) -> bool:
@@ -512,7 +513,7 @@ class Coeff():
         """
         if perm_group is None:
             perm_group = "sym"
-        return verify_symmetry(self.as_poly(), perm_group)
+        return self.is_cyclic(perm_group)
 
     def reflect(self) -> 'Coeff':
         if self.nvars <= 1:

--- a/triples/utils/expressions/cyclic.py
+++ b/triples/utils/expressions/cyclic.py
@@ -388,7 +388,7 @@ class CyclicExpr(Expr):
                 break
         else:
             # check other rules not intersecting self symbols
-            other_rules = [fs(k) | fs(v) for k, v in rule.items() if not k in changed_vars]
+            other_rules = [fs(k) | fs(v) for k, v in rule.items() if k not in changed_vars]
             if not any(_.intersection(self_vars) for _ in other_rules):
                 new_symbols = tuple(rule.get(s, s) for s in self.symbols)
                 if len(set(new_symbols)) == len(new_symbols):

--- a/triples/utils/expressions/cyclic.py
+++ b/triples/utils/expressions/cyclic.py
@@ -4,11 +4,11 @@ CyclicExpr, CyclicSum and CyclicProduct.
 """
 from importlib import import_module
 from numbers import Number
-from typing import List, Tuple, Union, Callable, Any
+from typing import Tuple, Callable
 from typing import Dict
 
 import sympy as sp # for hijacking default behaviors of sympy
-from sympy import sympify, S, Mul, Add, Pow, Symbol, Poly, Expr, Basic
+from sympy import sympify, S, Mul, Add, Pow, Symbol, Expr, Basic
 from sympy.core.cache import cacheit
 from sympy.core.containers import Dict as SympyDict
 from sympy.core.numbers import zoo, nan
@@ -53,7 +53,7 @@ def _std_seq(p: Tuple, perm_group: PermutationGroup) -> Tuple:
     has minimum lexicographical order.
     """
     if len(p) == 0:
-        return tuple()
+        return ()
     # elif len(perm_group.args) == 1 and \
     #         perm_group.args[0].array_form == list(range(1, len(p))) + [0]:
     #     # inv_p = ...
@@ -73,7 +73,7 @@ def _std_seq(p: Tuple, perm_group: PermutationGroup) -> Tuple:
     return tuple(p[i] for i in p2)
 
 def _std_symbols(symbols: Tuple[Symbol, ...], perm_group: PermutationGroup) -> PermutationGroup:
-    p = sorted(list(range(len(symbols))), key = lambda i: symbols[i].name)
+    p = sorted(range(len(symbols)), key = lambda i: symbols[i].name)
     q = _std_seq(tuple(p), perm_group)
     return tuple(symbols[i] for i in q)
 

--- a/triples/utils/expressions/cyclic.py
+++ b/triples/utils/expressions/cyclic.py
@@ -102,8 +102,8 @@ def _func_perm(func: Callable, expr: Expr,
 def _is_same_dict(d1: dict, d2: dict, simpfunc=signsimp) -> bool:
     if len(d1) != len(d2):
         return False
-    d1 = dict((simpfunc(k), simpfunc(v)) for k, v in d1.items())
-    d2 = dict((simpfunc(k), simpfunc(v)) for k, v in d2.items())
+    d1 = {simpfunc(k): simpfunc(v) for k, v in d1.items()}
+    d2 = {simpfunc(k): simpfunc(v) for k, v in d2.items()}
     for k, v in d1.items():
         if k not in d2 or (not simpfunc(d2[k]) == simpfunc(v)):
             return False
@@ -405,7 +405,7 @@ class CyclicExpr(Expr):
             return _fallback_xreplace(self, rule)
         else:
             # changed vars should be brocasted by the permutation group
-            changed_inds = list(i for i, s in enumerate(symbols) if s in changed_vars)
+            changed_inds = [i for i, s in enumerate(symbols) if s in changed_vars]
             changed_inds = self.perm_group.orbit(changed_inds, action='union')
             unchanged_inds = tuple(i for i in range(len(symbols)) if i not in changed_inds)
 
@@ -553,7 +553,7 @@ class CyclicSum(CyclicExpr):
         if isinstance(expr, Mul):
             cyc_args = []
             uncyc_args = []
-            symbol_degrees = {}
+            # symbol_degrees = {}
 
             for arg in expr.args:
                 if is_cyclic_expr(arg, symbols, perm_group):

--- a/triples/utils/expressions/cyclic.py
+++ b/triples/utils/expressions/cyclic.py
@@ -348,7 +348,7 @@ class CyclicExpr(Expr):
 
         def _xreplace_arg0(self, rule, symbols):
             arg0, changed = self.args[0]._xreplace(rule)
-            changed = changed or (not (self.symbols is symbols))
+            changed = changed or (self.symbols is not symbols)
             if not changed:
                 return self, False
             return self.func(arg0, symbols, self.perm_group), changed

--- a/triples/utils/expressions/psatz.py
+++ b/triples/utils/expressions/psatz.py
@@ -342,6 +342,12 @@ class PSatzElement(DomainElement, CantSympify, Generic[Ef]):
     def is_in_ideal(self) -> bool:
         return all(v.is_zero for v in self.numer_preorder.values())
 
+    @property
+    def is_denom_free(self) -> bool:
+        return len(self.denom_ideal) == 0\
+         and all((len(k) == 0 and v == v.one) \
+                 or v.is_zero for k, v in self.denom_preorder.items())
+
     def as_expr(self, preorder_alias: Optional[List[Expr]]=None, ideal_alias: Optional[List[Expr]]=None,
             evaluate: bool=True) -> Expr:
         numer = self.psatz_domain._to_expr(self.numer_preorder, self.numer_ideal,
@@ -989,6 +995,14 @@ class PSatz(Generic[Ef]):
     def denom_ideal(self) -> Dict[int, Expr]:
         alg = self.algebra
         return {k: alg.to_sympy(v) for k, v in self.rep.denom_ideal.items()}
+
+    @property
+    def is_in_ideal(self) -> bool:
+        return self.rep.is_in_ideal
+
+    @property
+    def is_denom_free(self) -> bool:
+        return self.rep.is_denom_free
 
     @classmethod
     def from_sympy(cls, arg,

--- a/triples/utils/expressions/psatz.py
+++ b/triples/utils/expressions/psatz.py
@@ -358,7 +358,6 @@ class PSatzElement(DomainElement, CantSympify, Generic[Ef]):
         return NotImplemented
 
     def _add(a: 'PSatzElement[Ef]', b: 'PSatzElement[Ef]') -> 'PSatzElement[Ef]':
-        preorder, ideal = a.preorder, a.ideal
         # (p1 + i1)/(p2 + i2) + (p3 + i3)/(p4 + i4)
         p1, i1, p2, i2 = a.numer_preorder, a.numer_ideal, a.denom_preorder, a.denom_ideal
         p3, i3, p4, i4 = b.numer_preorder, b.numer_ideal, b.denom_preorder, b.denom_ideal
@@ -437,7 +436,6 @@ class PSatzElement(DomainElement, CantSympify, Generic[Ef]):
         return self._rmul_ground(_other)
 
     def _mul(a: 'PSatzElement[Ef]', b: 'PSatzElement[Ef]') -> 'PSatzElement[Ef]':
-        preorder, ideal = a.preorder, a.ideal
         # (p1 + i1)/(p2 + i2) * (p3 + i3)/(p4 + i4)
         p1, i1, p2, i2 = a.numer_preorder, a.numer_ideal, a.denom_preorder, a.denom_ideal
         p3, i3, p4, i4 = b.numer_preorder, b.numer_ideal, b.denom_preorder, b.denom_ideal
@@ -446,7 +444,6 @@ class PSatzElement(DomainElement, CantSympify, Generic[Ef]):
         return a.per(p5, i5, p6, i6)
 
     def _mul_ground(a: 'PSatzElement[Ef]', b: Ef) -> 'PSatzElement[Ef]':
-        preorder, ideal = a.preorder, a.ideal
         # (p1 + i1)/(p2 + i2) * b
         p1, i1, p2, i2 = a.numer_preorder, a.numer_ideal, a.denom_preorder, a.denom_ideal
         p3 = {k: v._mul_ground(b) for k, v in p1.items()}
@@ -454,7 +451,6 @@ class PSatzElement(DomainElement, CantSympify, Generic[Ef]):
         return a.per(p3, i3, p2, i2)
 
     def _rmul_ground(a: 'PSatzElement[Ef]', b: Ef) -> 'PSatzElement[Ef]':
-        preorder, ideal = a.preorder, a.ideal
         # b * (p1 + i1)/(p2 + i2)
         p1, i1, p2, i2 = a.numer_preorder, a.numer_ideal, a.denom_preorder, a.denom_ideal
         p3 = {k: v._rmul_ground(b) for k, v in p1.items()}
@@ -505,7 +501,6 @@ class PSatzElement(DomainElement, CantSympify, Generic[Ef]):
         return a._mul(b.inverse())
 
     def _truediv_ground(a: 'PSatzElement[Ef]', b: Ef) -> 'PSatzElement[Ef]':
-        preorder, ideal = a.preorder, a.ideal
         # b * (p1 + i1)/(p2 + i2)
         p1, i1, p2, i2 = a.numer_preorder, a.numer_ideal, a.denom_preorder, a.denom_ideal
         p3 = {k: v._mul_ground(b) for k, v in p2.items()}

--- a/triples/utils/expressions/psatz.py
+++ b/triples/utils/expressions/psatz.py
@@ -1,10 +1,8 @@
 from typing import (
-    List, Tuple, Dict, FrozenSet, Union, Optional, Callable,
-    TypeVar, Generic, Iterator
+    List, Tuple, Dict, FrozenSet, Union, Optional, Generic, Iterator
 )
 
-from sympy import Expr, Add, Mul, Rational, Integer, UnevaluatedExpr, fraction, sympify, latex, sqrt, true
-from sympy import Tuple as stuple
+from sympy import Expr, Add, Mul, Integer, UnevaluatedExpr, fraction, sympify
 from sympy.core.sympify import CantSympify, sympify
 from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.polyerrors import CoercionFailed
@@ -1036,7 +1034,7 @@ class PSatz(Generic[Ef]):
                     *[_.free_symbols for _ in preorder.values()],
                     *[_.free_symbols for _ in ideal.values()]
                 )
-                fs = sorted(list(fs), key=lambda x: x.name)
+                fs = sorted(fs, key=lambda x: x.name)
                 algebra = domain[tuple(fs)]
             else:
                 algebra = domain

--- a/triples/utils/expressions/tests/test_coeff.py
+++ b/triples/utils/expressions/tests/test_coeff.py
@@ -1,6 +1,6 @@
-from ..coeff import PartialOrderElement, Coeff
+from ..coeff import Coeff
 
-from sympy import Poly, Expr, Rational, ZZ, QQ, RR, EX, E, sqrt
+from sympy import Poly, Expr, ZZ, QQ, RR, EX, E, sqrt
 from sympy.abc import a, b, c
 
 import pytest

--- a/triples/utils/expressions/tests/test_cyclic.py
+++ b/triples/utils/expressions/tests/test_cyclic.py
@@ -60,7 +60,7 @@ def test_cyclic_sum_random_xreplace():
                 val = CyclicSum(func, symbols, perm_group)
 
                 subset = set(choices(symbols, k = randint(1, min(n, 4))))
-                subset = dict((s, 7 + i) for i, s in enumerate(subset))
+                subset = {s: 7 + i for i, s in enumerate(subset)}
                 assert _compare_replacement(val, subset), '%s(%s).xreplace(%s)'%(val.func, val.args, subset)
 
 def test_cyclic_sum_xreplace_preserve_structure():

--- a/triples/utils/expressions/tests/test_cyclic.py
+++ b/triples/utils/expressions/tests/test_cyclic.py
@@ -38,8 +38,8 @@ def test_cyclic_sum_doit():
     perm_group =  PermutationGroup(Permutation([1,2,5,0,6,3,4]), Permutation([0,1,2,5,4,3,6]))
     val1 = CyclicSum(F(z,x,a,c,d,b,y), (x,d,y,c,z,a,b), perm_group)
     set1 = set(val1.doit().args)
-    set2 = set([F(z,x,a,c,d,b,y).xreplace(dict(zip(
-        (x,d,y,c,z,a,b), g((x,d,y,c,z,a,b))))) for g in perm_group.generate()])
+    set2 = {F(z,x,a,c,d,b,y).xreplace(dict(zip(
+        (x,d,y,c,z,a,b), g((x,d,y,c,z,a,b))))) for g in perm_group.generate()}
     assert set1 == set2
 
     val1 = CyclicSum(F(z,x,a,c,d,b,y), (x,d,y,c,z,a,b), SymmetricGroup(7))

--- a/triples/utils/monomials.py
+++ b/triples/utils/monomials.py
@@ -57,7 +57,7 @@ def generate_partitions(d_list: Union[int, List[int]], degree: int,
 
     n = len(d_list)
     if n == 0:
-        return [tuple()]
+        return [()]
 
     powers = []
     i = 0
@@ -129,7 +129,7 @@ class MonomialManager():
 
         if self.OPTIMIZE_SYMMETRY:
             orbits = self._perm_group.orbits()
-            orbits = [sorted(list(o)) for o in orbits]# if len(o) > 1]
+            orbits = [sorted(o) for o in orbits]# if len(o) > 1]
             order = self._perm_group.order()
             if prod([factorial(len(m)) for m in orbits]) == order:
                 # internal direct product of symmetric groups
@@ -363,7 +363,7 @@ class MonomialManager():
         vec = self._arraylize_list(poly, degree = degree, expand_cyc = expand_cyc)
         rep, dom, ngens, _degree = _poly_rep(poly)
         if SDM is not None:
-            sdm = dict((i, {0: v}) for i, v in enumerate(vec) if v)
+            sdm = {i: {0: v} for i, v in enumerate(vec) if v}
             return Matrix._fromrep(DomainMatrix.from_rep(SDM(sdm, (len(vec), 1), dom)))
         else: # sympy <= 1.7
             to_sympy = dom.to_sympy
@@ -384,7 +384,7 @@ class MonomialManager():
             zero = domain.zero
             # be careful to handle column / row vectors
             if rep.shape[0] == 1:
-                rep_list = list(rep.get(0, dict()).items())
+                rep_list = list(rep.get(0, {}).items())
             elif rep.shape[1] == 1:
                 rep_list = [(i, v.get(0, zero)) for i, v in rep.items()]
             elif rep.shape[0] == 0 or rep.shape[1] == 0:

--- a/triples/utils/polytools.py
+++ b/triples/utils/polytools.py
@@ -1,0 +1,348 @@
+"""
+Compatibility & enhancement tools for SymPy polys module.
+"""
+from sympy import Poly, ZZ
+from sympy import __version__ as _SYMPY_VERSION
+from sympy.external.importtools import version_tuple
+from sympy.polys.rootoftools import ComplexRootOf as CRootOf
+from sympy.polys.densebasic import (
+    dmp_from_dict, dmp_to_dict, dmp_zero_p, dmp_degree_in,
+    dmp_degree, dmp_degree_list, dmp_ground_LC, dmp_convert
+)
+from sympy.polys.densetools import dmp_ground_monic
+from sympy.polys.densearith import dup_mul, dmp_div
+from sympy.polys.factortools import dup_gf_factor, dmp_trial_division
+from sympy.polys.sqfreetools import _dmp_check_degrees
+from sympy.utilities import subsets
+
+_IS_GROUND_TYPES_FLINT = False
+_FLINT_VERSION = ''
+try:
+    from sympy.external.gmpy import GROUND_TYPES
+    _IS_GROUND_TYPES_FLINT = (GROUND_TYPES == 'flint')
+    from flint import __version__ as _FLINT_VERSION
+except ImportError: # sympy <= 1.8 or no flint installed
+    _IS_GROUND_TYPES_FLINT = False
+
+SYMPY_VERSION = tuple(version_tuple(_SYMPY_VERSION))
+FLINT_VERSION = tuple(version_tuple(_FLINT_VERSION))
+
+if SYMPY_VERSION >= (1, 14):
+    def poly_lift(poly: Poly) -> Poly:
+        return poly.lift()
+
+    def crootof_realroots_alg(poly: Poly):
+        """Get real roots of a sqf poly on an algebraic field."""
+        return list(set(CRootOf.real_roots(poly, radicals=False)))
+
+    from sympy.polys.densetools import dup_sign_variations
+    from sympy.polys.rootisolation import dup_count_real_roots
+else:
+    from collections import Counter
+    from sympy.polys.polyclasses import DMP
+    from sympy.polys.densebasic import (
+        dup_LC, dup_convert, dup_degree, dmp_include
+    )
+    from sympy.polys.densetools import dup_eval
+    from sympy.polys.euclidtools import dmp_resultant
+    from sympy.polys.polyerrors import DomainError
+    from sympy.polys.rootisolation import dup_sturm
+    def dmp_alg_inject(f, u, K):
+        fd = dmp_to_dict(f, u, K)
+        h = {}
+        for f_monom, g in fd.items():
+            for g_monom, c in g.to_dict().items():
+                h[g_monom + f_monom] = c
+        F = dmp_from_dict(h, u + 1, K.dom)
+        return F, u + 1, K.dom
+
+    def dmp_lift(f, u, K):
+        F, v, K2 = dmp_alg_inject(f, u, K)
+        p_a = K.mod.to_list()
+        P_A = dmp_include(p_a, list(range(1, v + 1)), 0, K2)
+        return dmp_resultant(F, P_A, v, K2) # type: ignore
+
+    # poly.lift() had a bug before 1.14:
+    # https://github.com/sympy/sympy/pull/26812
+    def poly_lift(poly: Poly) -> Poly:
+        if not poly.domain.is_AlgebraicField:
+            return poly
+        rep = poly.rep
+        dmp = DMP(dmp_lift(rep.rep, rep.lev, rep.dom), rep.dom.dom, rep.lev)
+        return Poly.new(dmp, *poly.gens)
+
+    # https://github.com/sympy/sympy/pull/26813
+    def dup_sign_variations(f, K):
+        """
+        Compute the number of sign variations of ``f`` in ``K[x]``.
+
+        Examples
+        ========
+
+        >>> from sympy.polys import ring, ZZ
+        >>> R, x = ring("x", ZZ)
+
+        >>> R.dup_sign_variations(x**4 - x**2 - x + 1)
+        2
+
+        """
+        def is_negative_sympy(a):
+            if not a:
+                # XXX: requires zero equivalence testing in the domain
+                return False
+            else:
+                # XXX: This is inefficient. It should not be necessary to use a
+                # symbolic expression here at least for algebraic fields. If the
+                # domain elements can be numerically evaluated to real values with
+                # precision then this should work. We first need to rule out zero
+                # elements though.
+                return bool(K.to_sympy(a) < 0)
+
+        # XXX: There should be a way to check for real numeric domains and
+        # Domain.is_negative should be fixed to handle all real numeric domains.
+        # It should not be necessary to special case all these different domains
+        # in this otherwise generic function.
+        if K.is_ZZ or K.is_QQ or K.is_RR:
+            is_negative = K.is_negative
+        elif K.is_AlgebraicField and K.ext.is_comparable:
+            is_negative = is_negative_sympy
+        elif ((K.is_PolynomialRing or K.is_FractionField) and len(K.symbols) == 1 and
+            (K.dom.is_ZZ or K.dom.is_QQ or K.is_AlgebraicField) and
+            K.symbols[0].is_transcendental and K.symbols[0].is_comparable):
+            # We can handle a polynomial ring like QQ[E] if there is a single
+            # transcendental generator because then zero equivalence is assured.
+            is_negative = is_negative_sympy
+        else:
+            raise DomainError("sign variation counting not supported over %s" % K)
+
+        prev, k = K.zero, 0
+
+        for coeff in f:
+            if is_negative(coeff*prev):
+                k += 1
+
+            if coeff:
+                prev = coeff
+
+        return k
+
+    def dup_count_real_roots(f, K, inf=None, sup=None):
+        """Returns the number of distinct real roots of ``f`` in ``[inf, sup]``. """
+        if dup_degree(f) <= 0:
+            return 0
+
+        if not K.is_Field:
+            R, K = K, K.get_field()
+            f = dup_convert(f, R, K)
+
+        sturm = dup_sturm(f, K)
+
+        if inf is None:
+            signs_inf = dup_sign_variations([ dup_LC(s, K)*(-1)**dup_degree(s) for s in sturm ], K)
+        else:
+            signs_inf = dup_sign_variations([ dup_eval(s, inf, K) for s in sturm ], K)
+
+        if sup is None:
+            signs_sup = dup_sign_variations([ dup_LC(s, K) for s in sturm ], K)
+        else:
+            signs_sup = dup_sign_variations([ dup_eval(s, sup, K) for s in sturm ], K)
+
+        count = abs(signs_inf - signs_sup)
+
+        if inf is not None and not dup_eval(f, inf, K):
+            count += 1
+
+        return count
+
+    def _which_roots(f, candidates, num_roots):
+        fe = f.as_expr()
+        x = f.gens[0]
+        prec = 10
+        candidates = list(Counter(candidates).keys())
+
+        while len(candidates) > num_roots:
+            potential_candidates = []
+            for r in candidates:
+                # If f(r) != 0 then f(r).evalf() gives a float/complex with precision.
+                f_r = fe.xreplace({x: r}).evalf(prec, maxn=2*prec)
+                if abs(f_r)._prec < 2:
+                    potential_candidates.append(r)
+
+            candidates = potential_candidates
+            prec *= 2
+
+        return candidates
+
+    def count_real_roots(f, inf=None, sup=None):
+        """Returns the number of distinct real roots of ``f`` in ``[inf, sup]``. """
+        if isinstance(f, Poly):
+            rep = f.rep
+        if hasattr(rep, 'to_DMP_Python'):
+            rep = rep.to_DMP_Python()
+        return dup_count_real_roots(rep.to_list(), f.domain, inf, sup)
+
+    def crootof_realroots_alg(poly: Poly):
+        rts = poly_lift(poly).real_roots()
+        cnt = count_real_roots(poly)
+        return _which_roots(poly, rts, cnt)
+
+
+def _dmp_gf_factor_flint(f, u, K):
+    if K.mod < 2**64:
+        from flint import nmod_mpoly_ctx
+        ctx_func = nmod_mpoly_ctx
+    else:
+        from flint import fmpz_mod_mpoly_ctx
+        ctx_func = fmpz_mod_mpoly_ctx
+    ctx = ctx_func.get([chr(i) for i in range(65, 65 + u + 1)], K.mod)
+    dt = {k: int(v) for k, v in dmp_to_dict(f, u, K).items()}
+    p = ctx.from_dict(dt)
+    c, factors = p.factor()
+    factors = [(dmp_convert(dmp_from_dict(f.to_dict(), u, K), u, K, ZZ), m) for f, m in factors]
+    return K(int(c)), factors
+
+def dmp_gf_factor(f, u, K):
+    """
+    Factor multivariate polynomials over finite fields.
+    K.mod should be prime and this is not checked.
+
+    TODO: 1. review the code 2. use faster algorithms
+    """
+    p = K.mod
+
+    # from sympy.ntheory import isprime
+    # if not isprime(p):
+    #     raise NotImplementedError('multivariate polynomials over GF(p**n)')
+    if _IS_GROUND_TYPES_FLINT and FLINT_VERSION >= (0, 7, 0):
+        return _dmp_gf_factor_flint(f, u, K)
+
+    if not u:
+        return dup_gf_factor(f, K)
+
+    lc = dmp_ground_LC(f, u, K)
+    f = dmp_ground_monic(f, u, K)
+
+    if all(d <= 0 for d in dmp_degree_list(f, u)):
+        return lc, []
+
+    F = f
+    f_dict = dmp_to_dict(f, u, K)
+
+    if all(not any(e % p for e in expv) for expv in f_dict):
+        f_pth = dmp_from_dict({tuple(e // p for e in expv): coeff
+            for expv, coeff in f_dict.items()}, u, K)
+        coeff, factors = dmp_gf_factor(f_pth, u, K)
+        return K.mul(lc, coeff), [(g, k*p) for g, k in factors]
+
+    n = u + 1
+    bounds = [dmp_degree_in(F, i, u) + 1 for i in range(n)]
+    B = max(bounds) + 1
+
+    powers = [1]
+    for _ in range(1, n):
+        powers.append(powers[-1]*B)
+
+    def _encode(expv):
+        return sum(e*w for e, w in zip(reversed(expv), powers))
+
+    def _decode(m):
+        expv = [0]*n
+
+        for i in range(n):
+            expv[n - i - 1] = m % B
+            m //= B
+
+        if m:
+            return None
+
+        return tuple(expv)
+
+    def _to_univariate(g):
+        G = {( _encode(expv), ): coeff for expv, coeff in dmp_to_dict(g, u, K).items()}
+        return dmp_from_dict(G, 0, K)
+
+    def _from_univariate(g):
+        G = {}
+
+        for (m,), coeff in dmp_to_dict(g, 0, K).items():
+            expv = _decode(m)
+
+            if expv is None:
+                return None
+
+            if any(e > dmp_degree_in(F, i, u) for i, e in enumerate(expv)):
+                return None
+
+            G[expv] = coeff
+
+        return dmp_from_dict(G, u, K)
+
+    U = _to_univariate(F)
+    _, ufactors = dup_gf_factor(U, K)
+
+    if not ufactors:
+        return lc, []
+
+    atoms = []
+    for h, k in ufactors:
+        for _ in range(k):
+            atoms.append(h)
+
+    result = []
+    rem = list(range(len(atoms)))
+
+    while rem and dmp_degree(f, u) > 0:
+        found = False
+
+        for size in range(1, len(rem)//2 + 1):
+            for S in subsets(rem, size):
+                h = [K.one]
+
+                deg_sum = sum(dmp_degree(atoms[i], 0) for i in S)
+                expv = _decode(deg_sum)
+
+                if expv is None or any(
+                    e > dmp_degree_in(f, i, u) for i, e in enumerate(expv)):
+                    continue
+
+                for i in S:
+                    h = dup_mul(h, atoms[i], K)
+
+                g = _from_univariate(h)
+
+                if g is None:
+                    continue
+
+                dg = dmp_degree(g, u)
+
+                if dg <= 0 or dg >= dmp_degree(f, u):
+                    continue
+
+                q, r = dmp_div(f, g, u, K)
+
+                if dmp_zero_p(r, u):
+                    result.append(g)
+                    f = q
+                    rem = [i for i in rem if i not in S]
+                    found = True
+                    break
+
+            if found:
+                break
+
+        if not found:
+            break
+
+    if dmp_degree(f, u) > 0:
+        result.append(f)
+
+    factors = []
+    for g in result:
+        if g not in factors:
+            factors.append(g)
+
+    result = dmp_trial_division(F, factors, u, K)
+
+    _dmp_check_degrees(F, u, result)
+
+    return lc, result

--- a/triples/utils/polytools.py
+++ b/triples/utils/polytools.py
@@ -12,7 +12,7 @@ from sympy.polys.densebasic import (
 from sympy.polys.densetools import dmp_ground_monic
 from sympy.polys.densearith import dup_mul, dmp_div
 from sympy.polys.factortools import dup_gf_factor, dmp_trial_division
-from sympy.polys.sqfreetools import _dmp_check_degrees
+# from sympy.polys.sqfreetools import _dmp_check_degrees
 from sympy.utilities import subsets
 
 _IS_GROUND_TYPES_FLINT = False
@@ -343,6 +343,6 @@ def dmp_gf_factor(f, u, K):
 
     result = dmp_trial_division(F, factors, u, K)
 
-    _dmp_check_degrees(F, u, result)
+    # _dmp_check_degrees(F, u, result)
 
     return lc, result

--- a/triples/utils/roots/extrema.py
+++ b/triples/utils/roots/extrema.py
@@ -46,7 +46,7 @@ def polysubs(poly: Poly, subs: Dict[Symbol, Expr], symbols: List[Symbol]) -> Pol
     for monom, coeff in poly.rep.terms():
         m1 = marginalize1(monom)
         m2 = marginalize2(monom)
-        if not (m2 in coeffs):
+        if m2 not in coeffs:
             coeffs[m2] = {}
         coeffs[m2][m1] = coeff
     lev = len(inds) - 1
@@ -740,9 +740,9 @@ def optimize_poly(
      (CRootOf(a**3 - 6*a**2 + 5*a - 1, 2), CRootOf(b**3 - 5*b**2 + 6*b - 1, 2), 1)]
     """
     symbols = _infer_symbols(symbols, poly, ineq_constraints, eq_constraints)
-    if not (objective in ('min', 'max', 'all')):
+    if objective not in ('min', 'max', 'all'):
         raise ValueError('Objective must be either "min" or "max" or "all".')
-    if not (return_type in ('root', 'tuple', 'dict')):
+    if return_type not in ('root', 'tuple', 'dict'):
         raise ValueError('Return type must be either "root" or "tuple" or "dict".')
     if len(symbols) == 0:
         return [] if return_type != 'root' else RootList((), [])

--- a/triples/utils/roots/extrema.py
+++ b/triples/utils/roots/extrema.py
@@ -34,7 +34,6 @@ def polysubs(poly: Poly, subs: Dict[Symbol, Expr], symbols: List[Symbol]) -> Pol
         # TODO: make it faster
         return poly.as_expr().xreplace(subs).expand()
 
-    poly0 = poly
     # poly = poly.as_expr().xreplace(subs)
     # return poly.as_poly(*symbols)
 
@@ -321,7 +320,7 @@ def _optimize_by_eq_kkt(poly, ineq_constraints, eq_constraints, symbols,
     """
     if len(symbols) == 0:
         if all(_ == 0 or (isinstance(_, Poly) and _.is_zero) for _ in eq_constraints):
-            return [tuple()]
+            return [()]
         return []
     elif len(symbols) > max_different:
         return []
@@ -416,8 +415,8 @@ def _eliminate_linear(polys, symbols) -> Tuple[Dict[Symbol, Expr], List[Poly]]:
         else:
             has_eliminated = True
         rest_inds = set(range(len(polys))) - new_eliminated_polys
-        # rest_inds = sorted(list(rest_inds))
-        # new_eliminated_polys = sorted(list(new_eliminated_polys))
+        # rest_inds = sorted(rest_inds)
+        # new_eliminated_polys = sorted(new_eliminated_polys)
         new_eliminated_polys = [polys[i] for i in new_eliminated_polys]
 
         # TODO: clean this

--- a/triples/utils/roots/monotonic_opt.py
+++ b/triples/utils/roots/monotonic_opt.py
@@ -222,7 +222,7 @@ def rpa_monotonic(f, g, h, a, b, tol=1e-5, max_iter=2000, cbv=np.inf, root_solve
                     print('New bounds:', a, b)
 
         # Step 5: Split z_k into new vertices and add them to T
-        fz_k = f(z_k)
+        # fz_k = f(z_k)
         for i in range(n):
             if z_k[i] == x_k[i]:
                 # No change in the coordinate, skip.
@@ -347,7 +347,8 @@ def rpa_gmop(f1_and_f2, g_and_h, a, b, tol=1e-5, max_iter=2000, cbv=np.inf, root
 
     # Extract the solution
     if result.x is not None:
-        x, t, u = result.x[:n], result.x[n], result.x[n+1]
+        # x, t, u = result.x[:n], result.x[n], result.x[n+1]
+        x = result.x[:n]
         f = f1(x) - f2(x) # more accurate than F(x_t_u)
     else:
         x, f = None, np.inf

--- a/triples/utils/roots/num_extrema.py
+++ b/triples/utils/roots/num_extrema.py
@@ -2,7 +2,7 @@
 This module provides heuristic functions to optimize a polynomial
 with inequality and equality constraints NUMERICALLY.
 """
-from typing import List, Union, Tuple, Dict, Optional, Callable
+from typing import List, Union, Dict, Optional, Callable
 from functools import partial
 import warnings
 
@@ -356,7 +356,7 @@ def numeric_optimize_skew_symmetry(
             x0 = x0[:-1]
         extrema.append(tuple(optimizer(f2, x0, jac=f2.g)))
     if is_homogeneous:
-        extrema = [tuple((*_, 1 - sum(_))) for _ in extrema]
+        extrema = [(*_, 1 - sum(_)) for _ in extrema]
     return extrema
 
 

--- a/triples/utils/roots/num_extrema.py
+++ b/triples/utils/roots/num_extrema.py
@@ -483,9 +483,9 @@ def numeric_optimize_poly(
     symbols = _infer_symbols(symbols, poly, ineq_constraints, eq_constraints)
     if len(symbols) == 0:
         return []
-    if not (objective in ('min', 'max', 'all')):
+    if objective not in ('min', 'max', 'all'):
         raise ValueError('Objective must be either "min" or "max" or "all".')
-    if not (return_type in ('root', 'tuple', 'dict', 'result')):
+    if return_type not in ('root', 'tuple', 'dict', 'result'):
         raise ValueError('Return type must be either "root" or "tuple" or "dict" or "result".')
 
     poly, ineq_constraints, eq_constraints = polylize_input(

--- a/triples/utils/roots/polysolve.py
+++ b/triples/utils/roots/polysolve.py
@@ -37,7 +37,7 @@ def _filter_trivial_system(polys: List[Poly]) -> Union[List[Poly], None]:
                 continue
             elif poly.total_degree() == 0: # inconsistent system
                 return None
-        if not (poly in new_polys):
+        if poly not in new_polys:
             new_polys.add(poly)
             ordered_inds.append(ind)
     return [polys[ind] for ind in ordered_inds]
@@ -437,7 +437,7 @@ def solve_triangulated_crt(polys: List[Poly], symbols: List[Symbol]) -> List[Tup
                 zeros = []
 
             for zero in zeros:
-                if not (zero in dom):
+                if zero not in dom:
                     dom_zero = dom.algebraic_field(zero)
                 else:
                     dom_zero = dom

--- a/triples/utils/roots/polysolve.py
+++ b/triples/utils/roots/polysolve.py
@@ -513,7 +513,7 @@ def solve_poly_system_crt(polys: List[Poly], symbols: List[Symbol]) -> List[Tupl
         if len(symbols) == 0:
             filtered = _filter_trivial_system(polys)
             if filtered is not None and len(filtered) == 0:
-                return [tuple()]
+                return [()]
             return []
         sol = solve(polys, symbols, dict=False)
         sol = [_ for _ in sol if all(v.is_real for v in _)]
@@ -535,7 +535,7 @@ def solve_poly_system_crt(polys: List[Poly], symbols: List[Symbol]) -> List[Tupl
         return _solve_poly_system_2vars_resultant(polys, symbols)
     try:
         return solve_triangulated_crt(polys, symbols)
-    except (BasePolynomialError, IndexError) as e:
+    except (BasePolynomialError, IndexError):
         # Cannot ltrim ... (due to nonzero dimensional variety)
         return []
     return default(polys, symbols)

--- a/triples/utils/roots/polysolve.py
+++ b/triples/utils/roots/polysolve.py
@@ -11,9 +11,9 @@ from sympy.polys.polyerrors import BasePolynomialError
 from sympy.polys.polytools import groebner, PurePoly
 from sympy.polys.rootoftools import ComplexRootOf as CRootOf
 from sympy.utilities import postfixes
-from sympy.external.importtools import version_tuple
-from sympy import __version__ as SYMPY_VERSION
 from mpmath.libmp.libhyper import NoConvergence
+
+from ..polytools import crootof_realroots_alg
 
 # Comparison of tuples of sympy Expressions, compatible with sympy <= 1.9
 default_sort_key = lambda x: tuple(_.sort_key() for _ in x) if not isinstance(x, Expr) else x.sort_key()
@@ -43,165 +43,6 @@ def _filter_trivial_system(polys: List[Poly]) -> Union[List[Poly], None]:
     return [polys[ind] for ind in ordered_inds]
 
 
-if tuple(version_tuple(SYMPY_VERSION)) >= (1, 14):
-    def poly_lift(poly: Poly) -> Poly:
-        return poly.lift()
-
-    def _crootof_realroots_alg(poly: Poly):
-        """Get real roots of a sqf poly on an algebraic field."""
-        return list(set(CRootOf.real_roots(poly, radicals=False)))
-
-else:
-    from collections import Counter
-    from sympy.polys.polyclasses import DMP
-    from sympy.polys.densebasic import (
-        dup_LC, dup_degree, dup_convert,
-        dmp_include, dmp_to_dict, dmp_from_dict
-    )
-    from sympy.polys.densetools import dup_eval
-    from sympy.polys.euclidtools import dmp_resultant
-    from sympy.polys.polyerrors import DomainError
-    from sympy.polys.rootisolation import dup_sturm
-    def dmp_alg_inject(f, u, K):
-        fd = dmp_to_dict(f, u, K)
-        h = {}
-        for f_monom, g in fd.items():
-            for g_monom, c in g.to_dict().items():
-                h[g_monom + f_monom] = c
-        F = dmp_from_dict(h, u + 1, K.dom)
-        return F, u + 1, K.dom
-
-    def dmp_lift(f, u, K):
-        F, v, K2 = dmp_alg_inject(f, u, K)
-        p_a = K.mod.to_list()
-        P_A = dmp_include(p_a, list(range(1, v + 1)), 0, K2)
-        return dmp_resultant(F, P_A, v, K2) # type: ignore
-
-    # poly.lift() had a bug before 1.14:
-    # https://github.com/sympy/sympy/pull/26812
-    def poly_lift(poly: Poly) -> Poly:
-        if not poly.domain.is_AlgebraicField:
-            return poly
-        rep = poly.rep
-        dmp = DMP(dmp_lift(rep.rep, rep.lev, rep.dom), rep.dom.dom, rep.lev)
-        return Poly.new(dmp, *poly.gens)
-
-    # https://github.com/sympy/sympy/pull/26813
-    def dup_sign_variations(f, K):
-        """
-        Compute the number of sign variations of ``f`` in ``K[x]``.
-
-        Examples
-        ========
-
-        >>> from sympy.polys import ring, ZZ
-        >>> R, x = ring("x", ZZ)
-
-        >>> R.dup_sign_variations(x**4 - x**2 - x + 1)
-        2
-
-        """
-        def is_negative_sympy(a):
-            if not a:
-                # XXX: requires zero equivalence testing in the domain
-                return False
-            else:
-                # XXX: This is inefficient. It should not be necessary to use a
-                # symbolic expression here at least for algebraic fields. If the
-                # domain elements can be numerically evaluated to real values with
-                # precision then this should work. We first need to rule out zero
-                # elements though.
-                return bool(K.to_sympy(a) < 0)
-
-        # XXX: There should be a way to check for real numeric domains and
-        # Domain.is_negative should be fixed to handle all real numeric domains.
-        # It should not be necessary to special case all these different domains
-        # in this otherwise generic function.
-        if K.is_ZZ or K.is_QQ or K.is_RR:
-            is_negative = K.is_negative
-        elif K.is_AlgebraicField and K.ext.is_comparable:
-            is_negative = is_negative_sympy
-        elif ((K.is_PolynomialRing or K.is_FractionField) and len(K.symbols) == 1 and
-            (K.dom.is_ZZ or K.dom.is_QQ or K.is_AlgebraicField) and
-            K.symbols[0].is_transcendental and K.symbols[0].is_comparable):
-            # We can handle a polynomial ring like QQ[E] if there is a single
-            # transcendental generator because then zero equivalence is assured.
-            is_negative = is_negative_sympy
-        else:
-            raise DomainError("sign variation counting not supported over %s" % K)
-
-        prev, k = K.zero, 0
-
-        for coeff in f:
-            if is_negative(coeff*prev):
-                k += 1
-
-            if coeff:
-                prev = coeff
-
-        return k
-
-    def dup_count_real_roots(f, K, inf=None, sup=None):
-        """Returns the number of distinct real roots of ``f`` in ``[inf, sup]``. """
-        if dup_degree(f) <= 0:
-            return 0
-
-        if not K.is_Field:
-            R, K = K, K.get_field()
-            f = dup_convert(f, R, K)
-
-        sturm = dup_sturm(f, K)
-
-        if inf is None:
-            signs_inf = dup_sign_variations([ dup_LC(s, K)*(-1)**dup_degree(s) for s in sturm ], K)
-        else:
-            signs_inf = dup_sign_variations([ dup_eval(s, inf, K) for s in sturm ], K)
-
-        if sup is None:
-            signs_sup = dup_sign_variations([ dup_LC(s, K) for s in sturm ], K)
-        else:
-            signs_sup = dup_sign_variations([ dup_eval(s, sup, K) for s in sturm ], K)
-
-        count = abs(signs_inf - signs_sup)
-
-        if inf is not None and not dup_eval(f, inf, K):
-            count += 1
-
-        return count
-
-    def _which_roots(f, candidates, num_roots):
-        fe = f.as_expr()
-        x = f.gens[0]
-        prec = 10
-        candidates = list(Counter(candidates).keys())
-
-        while len(candidates) > num_roots:
-            potential_candidates = []
-            for r in candidates:
-                # If f(r) != 0 then f(r).evalf() gives a float/complex with precision.
-                f_r = fe.xreplace({x: r}).evalf(prec, maxn=2*prec)
-                if abs(f_r)._prec < 2:
-                    potential_candidates.append(r)
-
-            candidates = potential_candidates
-            prec *= 2
-
-        return candidates
-
-    def count_real_roots(f, inf=None, sup=None):
-        """Returns the number of distinct real roots of ``f`` in ``[inf, sup]``. """
-        if isinstance(f, Poly):
-            rep = f.rep
-        if hasattr(rep, 'to_DMP_Python'):
-            rep = rep.to_DMP_Python()
-        return dup_count_real_roots(rep.to_list(), f.domain, inf, sup)
-
-    def _crootof_realroots_alg(poly: Poly):
-        rts = poly_lift(poly).real_roots()
-        cnt = count_real_roots(poly)
-        return _which_roots(poly, rts, cnt)
-
-
 def _get_realroots_sqf(poly: Poly) -> List[Union[Rational, CRootOf]]:
     """
     Low level implementation of poly.real_roots() for square-free polynomials.
@@ -210,7 +51,7 @@ def _get_realroots_sqf(poly: Poly) -> List[Union[Rational, CRootOf]]:
         return []
     if not (poly.domain.is_QQ or poly.domain.is_ZZ):
         # fallback
-        return _crootof_realroots_alg(poly)
+        return crootof_realroots_alg(poly)
     if poly.total_degree() == 1:
         return [-poly.coeff_monomial((0,)) / poly.coeff_monomial((1,))]
 

--- a/triples/utils/roots/roots.py
+++ b/triples/utils/roots/roots.py
@@ -91,7 +91,7 @@ def _algebraic_extension(vec: List[ANP], domain: Domain) -> Matrix:
             for i in range(1, l + 1): # len(x.rep) = l >= i
                 if rep(x)[-i] == zero:
                     continue
-                if not (row in sdm):
+                if row not in sdm:
                     sdm[row] = {}
                 sdm[row][i-1] = rep(x)[-i]
         sdm = SDM(sdm, (len(vec), len(mod) - 1), QQ)
@@ -905,7 +905,7 @@ class Root():
             poly = Poly.new(DMP([one, -one, sab, -abc], domain, 0), Symbol('x'))
             a, b, c = poly.all_roots(radicals=False) if poly.domain.is_Exact else poly.nroots()
 
-            if not (a in domain):
+            if a not in domain:
                 u, v = domain.to_sympy(u), domain.to_sympy(v)
                 domain = domain.algebraic_field(a) if not domain.is_QQ_I else QQ.algebraic_field(a, S.ImaginaryUnit)
                 u, v, one = domain.convert(u), domain.convert(v), domain.one

--- a/triples/utils/roots/roots.py
+++ b/triples/utils/roots/roots.py
@@ -459,7 +459,7 @@ class Root():
         Wrap it with cache if it is algebraic but not rational.
         """
         if (not self.is_Rational) and self.is_algebraic:
-            self._single_power_cache = dict((key, {}) for key in range(-1, len(self.root)))
+            self._single_power_cache = {key: {} for key in range(-1, len(self.root))}
             def _single_power(i: int, degree: int) -> ANP:
                 """
                 Return self.rep[i] ** degree.
@@ -887,7 +887,7 @@ class Root():
         is_real = (u0.is_real and v0.is_real) in (S.true, True)
 
         domain, (u, v) = construct_domain((u0, v0), extension=True, field=True)
-        one, zero = domain.one, domain.zero
+        one = domain.one
         if u == -one and v == -one: # infinity line
             raise ValueError('Argument uv = (-1, -1) is not well-defined.')
 

--- a/triples/utils/roots/tests/test_extrema.py
+++ b/triples/utils/roots/tests/test_extrema.py
@@ -46,8 +46,8 @@ def test_extrema():
         result = optimize_poly(poly, ineqs, eqs)
         assert len(result) == len(solutions)
 
-        result_dict = set(tuple(_.n(4) for _ in v) for v in result)
-        solution_dict = set(tuple(Float(_).n(4) for _ in v) for v in solutions)
+        result_dict = {tuple(_.n(4) for _ in v) for v in result}
+        solution_dict = {tuple(Float(_).n(4) for _ in v) for v in solutions}
         assert result_dict == solution_dict
 
 def test_extrema_max_different():

--- a/triples/utils/roots/tests/test_num_extrema.py
+++ b/triples/utils/roots/tests/test_num_extrema.py
@@ -1,6 +1,6 @@
 import numpy as np
 import sympy as sp
-from sympy.abc import a,b,c,d,x,y,z,w
+from sympy.abc import a,b,c,x,y,z,w
 
 from ..num_extrema import NumerFunc
 

--- a/triples/utils/tests/test_polytools.py
+++ b/triples/utils/tests/test_polytools.py
@@ -1,0 +1,65 @@
+from sympy import FiniteField as FF
+from sympy.polys import ring
+
+from ..polytools import dmp_gf_factor
+
+def _R_dmp_factor_list(f):
+    c, factors = dmp_gf_factor(f.to_dense(), f.ring.ngens - 1, f.ring.domain)
+    return (c, [(f.ring.from_dense(g), k) for g, k in factors])
+
+def test_dmp_gf_factor():
+    R, x, y = ring("x,y", FF(2))
+    assert _R_dmp_factor_list(x**2 + y**2) == (1, [(x + y, 2)])
+
+    R, x, y, z = ring("x,y,z", FF(3))
+    assert _R_dmp_factor_list(5*(x + y + z)**3) == (2, [(x + y + z, 3)])
+
+    R, x, y = ring("x,y", FF(5))
+
+    assert _R_dmp_factor_list(x**2 - 1) == (1, [
+        (x + 1, 1),
+        (x - 1, 1),
+    ])
+
+    R, x, y = ring("x,y", FF(7))
+
+    f = (x + y + 1)*(x + y + 2)
+    assert _R_dmp_factor_list(f) == (1, [
+        (x + y + 1, 1),
+        (x + y + 2, 1),
+    ])
+
+    R, x, y = ring("x,y", FF(5))
+
+    f = (x + y + 1)**2*(x + 2*y + 1)*(x**2 + y**2 + 1)
+    coeff, factors = _R_dmp_factor_list(f)
+
+    assert coeff == 1
+    assert factors == [
+        (x + y + 1, 2),
+        (x + 2*y + 1, 1),
+        (x**2 + y**2 + 1, 1),
+    ] or [
+        (x + 2*y + 1, 1),
+        (x + y + 1, 2),
+        (x**2 + y**2 + 1, 1),
+    ]
+
+    R, a, b = ring("a,b", FF(7))
+    c = 1
+
+    f = -2*(-a + c)**4*(a - b)**4*(b - c)**4*(a + b + c)**4 + \
+        9*(a**4*(a - b)**2*(a - c)**2 + b**4*(-a + b)**2*(b - c)**2 +
+           c**4*(-a + c)**2*(-b + c)**2)**2
+
+    coeff, factors = _R_dmp_factor_list(f)
+
+    assert coeff != 0
+    assert len(factors) == 4
+
+    g = coeff
+
+    for h, k in factors:
+        g *= h**k
+
+    assert g == f

--- a/triples/utils/tests/test_text_process.py
+++ b/triples/utils/tests/test_text_process.py
@@ -1,4 +1,4 @@
-from sympy import Poly, QQ, ZZ, sympify, sqrt, cbrt, Rational, Float, Symbol
+from sympy import Poly, sqrt, cbrt, Rational, Float, Symbol
 from sympy.abc import a, b, c, d, e, x, y, z
 from sympy.combinatorics import CyclicGroup, SymmetricGroup, DihedralGroup, PermutationGroup, Permutation
 

--- a/triples/utils/text_process.py
+++ b/triples/utils/text_process.py
@@ -728,7 +728,8 @@ def poly_get_standard_form(
     for monom, coeff in extracted:
         strings.append(get_string(monom, coeff))
     s = ''.join(strings)
-    s = s.removeprefix('+')
+    if s.startswith('+'):
+        s = s[1:]
     if _is_cyc and not symmetry.is_trivial:
         s = '%s(%s)'%(cyclic_sum_func, s)
     else:
@@ -876,7 +877,8 @@ def poly_get_factor_form(
 
     strings = sorted(strings, key = lambda x: (len(x), x))
     s = _get_coeff_str(coeff, MUL) + MUL.join(strings)
-    s = s.removeprefix('+')
+    if s.startswith('+'):
+        s = s[1:]
     return s
 
 

--- a/triples/utils/text_process.py
+++ b/triples/utils/text_process.py
@@ -79,7 +79,7 @@ def _preprocess_text_delatex(poly: str, funcs: Dict[str, Tuple[str, int]]) -> st
 
     if '' in funcs:
         funcs.pop('')
-    funckeys = sorted(list(funcs), key=lambda x: -len(x))
+    funckeys = sorted(funcs, key=lambda x: -len(x))
     def _match_pattern(poly, i):
         for pattern in funckeys:
             if len(poly) >= i + len(pattern) and poly[i:i+len(pattern)] == pattern:
@@ -174,7 +174,7 @@ def _preprocess_text_completion(
         preserve_patterns.add('e')
     if '' in preserve_patterns:
         preserve_patterns.remove('') # will cause infinite loop
-    preserve_patterns = sorted(list(preserve_patterns), key=lambda x: -len(x))
+    preserve_patterns = sorted(preserve_patterns, key=lambda x: -len(x))
     def _pattern_match(poly, i):
         lenp = len(poly)
         for pattern in preserve_patterns:
@@ -215,7 +215,7 @@ def expand_poly(expr: Expr, gens=None) -> Union[Expr, Poly]:
     class UnhandledExpr(Exception):
         pass
     expr = sympify(expr)
-    symbols = tuple(sorted(list(expr.free_symbols), key=lambda x:x.name))
+    symbols = tuple(sorted(expr.free_symbols, key=lambda x:x.name))
     other_symbols = []
     if gens is None:
         gens = symbols
@@ -520,7 +520,7 @@ def preprocess_text(
                 return poly0
             elif return_type == 'frac':
                 return poly0, Poly(1, gens, domain = poly0.domain)
-    except Exception as e:
+    except Exception:
         pass
 
     if return_type == 'frac':
@@ -540,7 +540,7 @@ def preprocess_text(
                     one = Poly(1, gens, domain = div0.domain)
                     return div0, one
             return poly0, poly1
-        except Exception as e:
+        except Exception:
             return None, None
 
     return None
@@ -728,8 +728,7 @@ def poly_get_standard_form(
     for monom, coeff in extracted:
         strings.append(get_string(monom, coeff))
     s = ''.join(strings)
-    if s.startswith('+'):
-        s = s[1:]
+    s = s.removeprefix('+')
     if _is_cyc and not symmetry.is_trivial:
         s = '%s(%s)'%(cyclic_sum_func, s)
     else:
@@ -768,8 +767,8 @@ def _reduce_factor_list(poly: Poly, perm_group: PermutationGroup) -> Tuple[Expr,
      [(Poly(c, a, b, c, domain='ZZ'), 3), (Poly(b - c, a, b, c, domain='ZZ'), 6)])
     """
     coeff, factors = poly.factor_list()
-    pow_dict = dict((p, power) for p, power in factors)
-    rep_dict = dict((p.rep, p) for p, _ in factors)
+    pow_dict = dict(factors) # {p: power for p, power in factors}
+    rep_dict = {p.rep: p for p, _ in factors}
     cyc_factors = []
     for base, power in factors:
         subdict = defaultdict(int)
@@ -877,7 +876,7 @@ def poly_get_factor_form(
 
     strings = sorted(strings, key = lambda x: (len(x), x))
     s = _get_coeff_str(coeff, MUL) + MUL.join(strings)
-    if s.startswith('+'): s = s[1:]
+    s = s.removeprefix('+')
     return s
 
 
@@ -960,10 +959,11 @@ def coefficient_triangle_latex(poly, tabular: bool = True, document: bool = True
     if poly is None:
         return ''
     if isinstance(poly, str):
-        poly_str = poly
+        # poly_str = poly
         poly = pl(poly)
     else:
-        poly_str = 'f(%s)'%','.join([str(_) for _ in poly.gens])
+        # poly_str = 'f(%s)'%','.join([str(_) for _ in poly.gens])
+        pass
 
     zero_wrapper = lambda x: x
     if zeros is not None and len(zeros):

--- a/triples/utils/text_process.py
+++ b/triples/utils/text_process.py
@@ -1088,10 +1088,7 @@ class PolyReader:
             with open(polys, 'r') as f:
                 polys = f.readlines()
 
-        polys = map(
-            lambda x: x.strip() if isinstance(x, str) else x,
-            polys
-        )
+        polys = [x.strip() if isinstance(x, str) else x for x in polys]
 
         polys = list(filter(
             lambda x: (isinstance(x, str) and len(x)) or isinstance(x, Poly),

--- a/triples/utils/tree_predictor.py
+++ b/triples/utils/tree_predictor.py
@@ -262,7 +262,7 @@ class TreePredictor:
             scalars = {'intercept', 'method', '__version__'}
             obj = object.__new__(cls)
             for k in attrs:
-                if not k in data:
+                if not (k in data):
                     raise ValueError(f"Missing key: {k} in {filename}")
                 d = data[k]
                 if k in scalars and isinstance(d, np.ndarray):

--- a/triples/utils/tree_predictor.py
+++ b/triples/utils/tree_predictor.py
@@ -262,7 +262,7 @@ class TreePredictor:
             scalars = {'intercept', 'method', '__version__'}
             obj = object.__new__(cls)
             for k in attrs:
-                if not (k in data):
+                if k not in data:
                     raise ValueError(f"Missing key: {k} in {filename}")
                 d = data[k]
                 if k in scalars and isinstance(d, np.ndarray):


### PR DESCRIPTION
### Key Improvements

* Ruff is introduced to check the code style. Unnecessary imports are removed.
* Adds a `triples/utils/polytools.py` for polynomial method patches, including factorization over Fp and roots counting over algebraic fields.
* StructuralSOS now has better support for 4-var-S4-symmetric and 3-var-C2-symmetric inequalities, etc.
* `triples/core/sdp/manifold.py` removes the old `constrain_root_nullspace` function and is replaced by a more decoupled `get_sos_nullspace` function.
* Adds a `triples/sdp/wedderburn/symmetric.py` to compute character tables, young symmetrizers, and symmetry adapted basis for Sn efficiently. Restructure the code in `triples/sdp/wedderburn/dixon.py`.