### PR TITLE
Enhance reformulation

### DIFF
--- a/triples/benchmarks/problems/books/vasile.py
+++ b/triples/benchmarks/problems/books/vasile.py
@@ -2632,7 +2632,7 @@ class MathematicalInequalitiesVol3(MathematicalInequalities):
     def problem_vasile_p31172_p1(self):
         return (sqrt(5)-1)/4 - c5s(a*b)/c5s(a**2), [], [c5s(a)]
 
-    def problem_vasile_p31172_p1(self):
+    def problem_vasile_p31172_p2(self):
         return (sqrt(5)+1)/4 + c5s(a*b)/c5s(a**2), [], [c5s(a)]
 
     def problem_vasile_p31173(self):

--- a/triples/benchmarks/problems/books/vasile.py
+++ b/triples/benchmarks/problems/books/vasile.py
@@ -739,7 +739,6 @@ class MathematicalInequalitiesVol1(MathematicalInequalities):
     def problem_vasile_p13098(self):
         return c4p(a-1) - (x-1)**4, [a,b,c,d], [c4s(1/a**2) - 4/x**2]
 
-    @mark(mark.skip)
     def problem_vasile_p13099(self):
         return c4p((1+a**3)/(1+a**2)) - (1+c4p(a))/2, [a,b,c,d], []
 
@@ -806,15 +805,12 @@ class MathematicalInequalitiesVol1(MathematicalInequalities):
     def problem_vasile_p13115(self):
         return 31*c5s(a**2)-150-c5s(a**4), [a,b,c,d,e], [c5s(a)-5]
 
-    @mark(mark.skip)
     def problem_vasile_p13116(self):
         return 5 - c5p(a)*c5s(a**4), [a,b,c,d,e], [c5s(a**2)-5]
 
-    @mark(mark.skip)
     def problem_vasile_p13117(self):
         return c5s(1/a) + 20/c5s(a**2) - 9, [a,b,c,d,e], [c5s(a)-5]
 
-    @mark(mark.skip)
     def problem_vasile_p13118(self):
         return c5p(a+1/a) + 68 - 4*c5s(a)*c5s(1/a), [a-1,b-1,c-1,d-1,e-1], []
 
@@ -1005,11 +1001,9 @@ class MathematicalInequalitiesVol2(MathematicalInequalities):
     def problem_vasile_p21042_p1(self):
         return Rational(3,2) - c3s(1/(3-a*b)), [a,b,c], [c3s(a**2)-3]
 
-    @mark(mark.skip)
     def problem_vasile_p21042_p2(self):
         return 3/(sqrt(6)-1) - c3s(1/(sqrt(6)-a*b)), [a,b,c], [c3s(a**2)-3]
 
-    @mark(mark.skip)
     def problem_vasile_p21043(self):
         return c3s(1/(1+a**5)) - Rational(3,2), [a,b,c], [c3s(a**2)-3]
 
@@ -1122,7 +1116,6 @@ class MathematicalInequalitiesVol2(MathematicalInequalities):
     def problem_vasile_p21071(self):
         return c3s((a*b+(k-1)*b*c+c*a)/(b**2+k*b*c+c**2)) - 3*(k+1)/(k+2), [a,b,c,k+2], []
 
-    @mark(mark.skip)
     def problem_vasile_p21072(self):
         return 3/(k+2) - c3s((3*b*c-a*(b+c))/(b**2+k*b*c+c**2)), [a,b,c,k+2], []
 
@@ -1153,11 +1146,9 @@ class MathematicalInequalitiesVol2(MathematicalInequalities):
     def problem_vasile_p21081(self):
         return c3s((2*a**2+5*b*c)/(b+c)**2) - Rational(21,4), [a,b,c], []
 
-    @mark(mark.skip)
     def problem_vasile_p21082(self):
         return c3s((2*a**2+(2*k+1)*b*c)/(b**2+k*b*c+c**2)) - 3*(2*k+3)/(k+2), [a,b,c,k+2], []
 
-    @mark(mark.skip)
     def problem_vasile_p21083(self):
         return 3/(k+2) - c3s((3*b*c-2*a**2)/(b**2+k*b*c+c**2)), [a,b,c,k+2], []
 
@@ -1170,11 +1161,9 @@ class MathematicalInequalitiesVol2(MathematicalInequalities):
     def problem_vasile_p21086(self):
         return c3s((a**2+64*b*c)/(b+c)**2) - 18, [a,b,c], []
 
-    @mark(mark.skip)
     def problem_vasile_p21087(self):
         return c3s((a**2*(b+c)+k*a*b*c)/(b**2+k*b*c+c**2)) - c3s(a), [a,b,c,k+1], []
 
-    @mark(mark.skip)
     def problem_vasile_p21088(self):
         return c3s((a**3+(k+1)*a*b*c)/(b**2+k*b*c+c**2)) - c3s(a), [a,b,c,k+Rational(3,2)], []
 
@@ -1194,15 +1183,12 @@ class MathematicalInequalitiesVol2(MathematicalInequalities):
     def problem_vasile_p21092(self):
         return c3s((b**2+c**2-a**2)/(2*a**2+(b+c)**2)) - Rational(1,2), [a,b,c], []
 
-    @mark(mark.skip)
     def problem_vasile_p21093(self):
         return 3/k - c3s((3*a**2-2*b*c)/(k*a**2+(b-c)**2)), [a,b,c,k], []
 
-    @mark(mark.skip)
     def problem_vasile_p21094_p1(self):
         return c3s(a/(a**2+k*b*c)) - 9/c3s(a)/(1+k), [a,b,c,k-3-sqrt(7)], []
 
-    @mark(mark.skip)
     def problem_vasile_p21094_p2(self):
         return c3s(a/(k*a**2+b*c)) - 9/c3s(a)/(1+k), [a,b,c,k-3-sqrt(7)], []
 
@@ -1281,11 +1267,9 @@ class MathematicalInequalitiesVol2(MathematicalInequalities):
     def problem_vasile_p21114(self):
         return 9/c3s(a*b)/2 - c3s(1/(b**2+c**2)), [b+c-a,c+a-b,a+b-c], []
 
-    @mark(mark.skip)
     def problem_vasile_p21115_p1(self):
         return Abs(c3s((a+b)/(a-b))) - 5, [b+c-a,c+a-b,a+b-c], []
 
-    @mark(mark.skip)
     def problem_vasile_p21115_p2(self):
         return Abs(c3s((a**2+b**2)/(a**2-b**2))) - 3, [b+c-a,c+a-b,a+b-c], []
 
@@ -1298,7 +1282,6 @@ class MathematicalInequalitiesVol2(MathematicalInequalities):
     def problem_vasile_p21118(self):
         return c3s((a*(b+c)-2*b*c)/((b+c)*(3*a+b+c))), [a,b,c], []
 
-    @mark(mark.skip)
     def problem_vasile_p21119(self):
         return c3s((a**5-a**2)/(a**5+b**2+c**2)), [a,b,c,c3s(a**2)-3], []
 
@@ -2335,7 +2318,6 @@ class MathematicalInequalitiesVol3(MathematicalInequalities):
     def problem_vasile_p31087_p2(self):
         return c3s(1/a/sqrt(a+8*b)) - sqrt(1/c3p(a)), [a,b,c], []
 
-    @mark(mark.skip)
     def problem_vasile_p31088(self):
         return sqrt(c3s(a)/3) - c3s(a/sqrt(5*a+4*b)), [a,b,c], []
 
@@ -2613,7 +2595,6 @@ class MathematicalInequalitiesVol3(MathematicalInequalities):
     def problem_vasile_p31160(self):
         return c4p(1+2*a/(b+c)) - 9, [a,b,c,d] ,[]
 
-    @mark(mark.skip)
     def problem_vasile_p31161(self):
         return c4p(1+k*a/(b+c)) - (1+k)**2, [a,b,c,d,k], []
 
@@ -3033,7 +3014,6 @@ class MathematicalInequalitiesVol3(MathematicalInequalities):
         return x + y + z - sqrt(4*(a + b + c + sqrt(a*b) + sqrt(b*c) + sqrt(c*a)) + 3*(a*b*c)**Rational(1,3)), [a,b,c,x,y,z],\
             [a/(y*z) + b/(z*x) + c/(x*y) - 1]
 
-    @mark(mark.skip)
     def problem_vasile_p32080_p2(self):
         return x + y + z - (sqrt(a + b) + sqrt(b + c) + sqrt(c + a)), [a,b,c,x,y,z], [a/(y*z) + b/(z*x) + c/(x*y) - 1]
 

--- a/triples/core/linsos/linsos.py
+++ b/triples/core/linsos/linsos.py
@@ -80,7 +80,7 @@ class LinearSOSSolver(ProofNode):
     lift_degree_limit: int
         The maximum degree to lift the polynomial. Defaults to 4.
     wedderburn: bool
-        Use wedderburn decomposition. Defaults to True.
+        Whether to use the wedderburn decomposition. Defaults to True.
     quad_diff_order: int
         The maximum degree of the form (xi - xj)^(2k)*... in the basis. Defaults to 8.
     preordering: str
@@ -110,6 +110,26 @@ class LinearSOSSolver(ProofNode):
         or irrational problems. TODO: Allow tolerance?
     verbose: bool
         Whether to print the information of the linear programming problem. Defaults to False.
+
+    Examples
+    --------
+    LinearSOS uses linear programming to solve inequality problems.
+
+    >>> from sympy.abc import a, b, c
+    >>> sol = LinearSOS(a**5*(a-b)+b**5*(b-c)+c**5*(c-a), [a,b,c])
+    >>> sol.solution # doctest: +SKIP
+    (Σ(a**2*(a**2 - b*c)**2))/6 + (Σ((a - c)**2*(6*a**3*c + 6*a**2*c**2
+     + 3*a**2*(a - b)**2 + (a - b)**2*(b - c)**2)))/18 + 2*(Σ(a**2*(a - b)**2*(a**2 + a*b)))/3
+
+    The parameter `lift_degree_limit` controls the maximum lift degree to explore.
+
+    >>> sol = LinearSOS(3 - (a+b+c)**2, [a**2-1, b**2-1, c**2-1], [a+b+c+1/a+1/b+1/c],
+    ... lift_degree_limit=6)
+    >>> sol.solution # doctest: +SKIP
+    (a*b*c*(a + b + c + 1/c + 1/b + 1/a)*(Σ(-3*a*b*c**2 + 3*a*b - 2))
+     + 3*(Σ((a**2 + 1)*(b**2 - 1)*(c**2 - 1))))/(Σ(a**2*b**2*c**2 + 1))
+
+    LinearSOS has complexity issues for high-dimensional problems.
     """
     default_configs = {
         "basis_limit": 20000,
@@ -513,8 +533,8 @@ def LinearSOS(
     linprog_options: Dict = LINPROG_OPTIONS,
     linprog_time_limit: float = 300.,
     allow_numer: int = 0,
-    time_limit: float = 3600.,
     verbose: bool = False,
+    time_limit: float = 3600.,
 ) -> Optional[Solution]:
     """
     Main function for linear programming SOS.
@@ -547,7 +567,7 @@ def LinearSOS(
     lift_degree_limit: int
         The maximum degree to lift the polynomial. Defaults to 4.
     wedderburn: bool
-        Use wedderburn decomposition. Defaults to True.
+        Whether to use the wedderburn decomposition. Defaults to True.
     quad_diff_order: int
         The maximum degree of the form (xi - xj)^(2k)*... in the basis. Defaults to 8.
     preordering: str
@@ -576,7 +596,9 @@ def LinearSOS(
         When > 0, the solution can be numerical, this might be useful for large scale problems
         or irrational problems. TODO: Allow tolerance?
     time_limit: float
-        The time limit in seconds for the solver.
+        The time limit (in seconds) for the solver. Defaults to 3600. When the time limit is
+        reached, the solver is killed when it returns to the main loop.
+        However, it might not be killed instantly if it is stuck in an internal function.
     verbose: bool
         Whether to print the information of the linear programming problem. Defaults to False.
 

--- a/triples/core/linsos/linsos.py
+++ b/triples/core/linsos/linsos.py
@@ -203,13 +203,17 @@ class LinearSOSSolver(ProofNode):
         qmodule = configs.get('qmodule', problem.ineq_constraints)
         tangents = list(prepare_tangents(problem, qmodule=qmodule,
             additional_tangents=configs['tangents'],
-            wedderburn=configs['wedderburn']).items())
+            wedderburn=configs['wedderburn'],
+            time_limit=time_limit
+        ).items())
         time_limit()
 
         if configs['augment_tangents']:
             tangents += list(prepare_inexact_tangents(problem,
                 monomial_manager=configs['symmetry'],
-                all_nonnegative=configs['all_nonnegative']).items())
+                all_nonnegative=configs['all_nonnegative'],
+                time_limit=time_limit
+            ).items())
             time_limit()
 
         tangents = clear_polys_by_symmetry(tangents, problem.expr.gens, configs['symmetry'])

--- a/triples/core/linsos/linsos.py
+++ b/triples/core/linsos/linsos.py
@@ -110,26 +110,6 @@ class LinearSOSSolver(ProofNode):
         or irrational problems. TODO: Allow tolerance?
     verbose: bool
         Whether to print the information of the linear programming problem. Defaults to False.
-
-    Examples
-    --------
-    LinearSOS uses linear programming to solve inequality problems.
-
-    >>> from sympy.abc import a, b, c
-    >>> sol = LinearSOS(a**5*(a-b)+b**5*(b-c)+c**5*(c-a), [a,b,c])
-    >>> sol.solution # doctest: +SKIP
-    (Σ(a**2*(a**2 - b*c)**2))/6 + (Σ((a - c)**2*(6*a**3*c + 6*a**2*c**2
-     + 3*a**2*(a - b)**2 + (a - b)**2*(b - c)**2)))/18 + 2*(Σ(a**2*(a - b)**2*(a**2 + a*b)))/3
-
-    The parameter `lift_degree_limit` controls the maximum lift degree to explore.
-
-    >>> sol = LinearSOS(3 - (a+b+c)**2, [a**2-1, b**2-1, c**2-1], [a+b+c+1/a+1/b+1/c],
-    ... lift_degree_limit=6)
-    >>> sol.solution # doctest: +SKIP
-    (a*b*c*(a + b + c + 1/c + 1/b + 1/a)*(Σ(-3*a*b*c**2 + 3*a*b - 2))
-     + 3*(Σ((a**2 + 1)*(b**2 - 1)*(c**2 - 1))))/(Σ(a**2*b**2*c**2 + 1))
-
-    LinearSOS has complexity issues for high-dimensional problems.
     """
     default_configs = {
         "basis_limit": 20000,
@@ -607,6 +587,27 @@ def LinearSOS(
     solution: Optional[Solution]
         The solution of the linear programming SOS. When solution is None, it means that the linear
         programming SOS fails.
+
+    Examples
+    --------
+    LinearSOS uses linear programming to solve inequality problems.
+
+    >>> from triples import LinearSOS
+    >>> from sympy.abc import a, b, c
+    >>> sol = LinearSOS(a**5*(a-b)+b**5*(b-c)+c**5*(c-a), [a,b,c])
+    >>> sol.solution # doctest: +SKIP
+    (Σ(a**2*(a**2 - b*c)**2))/6 + (Σ((a - c)**2*(6*a**3*c + 6*a**2*c**2
+     + 3*a**2*(a - b)**2 + (a - b)**2*(b - c)**2)))/18 + 2*(Σ(a**2*(a - b)**2*(a**2 + a*b)))/3
+
+    The parameter `lift_degree_limit` controls the maximum lift degree to explore.
+
+    >>> sol = LinearSOS(3 - (a+b+c)**2, [a**2-1, b**2-1, c**2-1], [a+b+c+1/a+1/b+1/c],
+    ... lift_degree_limit=6)
+    >>> sol.solution # doctest: +SKIP
+    (a*b*c*(a + b + c + 1/c + 1/b + 1/a)*(Σ(-3*a*b*c**2 + 3*a*b - 2))
+     + 3*(Σ((a**2 + 1)*(b**2 - 1)*(c**2 - 1))))/(Σ(a**2*b**2*c**2 + 1))
+
+    LinearSOS has complexity issues for high-dimensional problems.
     """
     problem = ProofNode.new_problem(expr, ineq_constraints, eq_constraints)
     problem.set_roots(roots)

--- a/triples/core/linsos/tangents.py
+++ b/triples/core/linsos/tangents.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Dict, Optional, TYPE_CHECKING
+from typing import Tuple, List, Dict, Callable, Optional, TYPE_CHECKING
 from itertools import combinations
 
 import numpy as np
@@ -7,7 +7,7 @@ from sympy import MutableDenseMatrix as Matrix
 
 from ...utils import Root, MonomialManager, identify_symmetry
 from ...utils.roots.num_extrema import numeric_optimize_skew_symmetry
-from ...sdp.arithmetic import permute_matrix_rows, solve_nullspace
+from ...sdp.arithmetic import permute_matrix_rows, solve_nullspace, ArithmeticTimeout
 from ...sdp.wedderburn import symmetry_adapted_basis
 
 if TYPE_CHECKING:
@@ -192,6 +192,7 @@ def _get_ineq_constrained_tangents(
                 ns = Matrix.hstack(ns, *new_ns)
 
             vecs = [ns[:, i] for i in range(ns.shape[1])]
+
             for vec in vecs:
                 poly = monomial_manager.invarraylize(vec, symbols, degree)
                 poly = _canonicalize(poly)
@@ -224,7 +225,8 @@ def prepare_tangents(
     qmodule: Optional[Dict[Poly, 'Expr']] = None,
     default_tangents = DEFAULT_TANGENTS,
     additional_tangents: List['Expr'] = [],
-    wedderburn: bool = True
+    wedderburn: bool = True,
+    time_limit: Optional[Callable] = None,
 ) -> Dict[Poly, 'Expr']:
     """
     Prepare tangents for LinearSOS given a list of roots (equality cases). The tangents should
@@ -274,6 +276,8 @@ def prepare_tangents(
 
     TODO: Handle high-order roots.
     """
+    time_limit = ArithmeticTimeout.make_checker(time_limit)
+
     poly = problem.expr
     G = problem.identify_symmetry()
     ineq_constraints = qmodule if qmodule is not None else problem.ineq_constraints
@@ -291,6 +295,8 @@ def prepare_tangents(
 
         if len(symbols) in default_tangents:
             tangents.extend(default_tangents[len(symbols)](*symbols))
+
+    time_limit()
 
     tangents = _filter_nonnumeric_tangents(tangents, symbols)
 
@@ -313,6 +319,7 @@ def prepare_tangents(
             symmetry=symm
         )
         tangents.update(new_tangents)
+        time_limit()
     # print(tangents)
     return tangents
 
@@ -411,7 +418,8 @@ def prepare_inexact_tangents(
     monomial_manager: MonomialManager = None,
     all_nonnegative: bool = False,
     threshold: float = 0.5,
-    max_degree: int = 5
+    max_degree: int = 5,
+    time_limit: Optional[Callable] = None,
 ) -> Dict[Poly, 'Expr']:
     """
     The function `prepare_tangents` has highlighted the importance of handling
@@ -419,6 +427,8 @@ def prepare_inexact_tangents(
     to local minima that are very close to zeros. They can be handled by a
     slight numerical perturbation that makes them numerical zeros.
     """
+    time_limit = ArithmeticTimeout.make_checker(time_limit)
+
     poly = problem.expr
     ineq_constraints = problem.ineq_constraints
     eq_constraints = problem.eq_constraints
@@ -432,6 +442,8 @@ def prepare_inexact_tangents(
     perms = [[1,0] + list(range(2, nvars))] # reflection
     if nvars >= 3:
         perms.append(list(range(1, nvars)) + [0])
+
+    time_limit()
 
     new_roots = []
     try:
@@ -471,6 +483,8 @@ def prepare_inexact_tangents(
                 _canonicalize(monomial_base.invarraylize(p, poly.gens, degree)\
                                  .retract()) for p in vecs])
             break
+            time_limit()
+        time_limit()
 
     new_tangents = {t**2: t.as_expr()**2 for t in new_tangents if t is not None}
     # print('New tangents:\n', list(new_tangents.values()))

--- a/triples/core/linsos/tangents.py
+++ b/triples/core/linsos/tangents.py
@@ -126,19 +126,21 @@ def _canonicalize(p: Poly) -> Optional[Poly]:
 
 
 def _get_ineq_constrained_tangents(
-    ineq: Poly,
-    ineq_expr: 'Expr',
-    roots: List[Root] = [],
-    monomial_manager: MonomialManager = None,
+    ineq_items: List[Tuple[Poly, 'Expr', Optional['PermutationGroup']]],
+    roots: List[Root],
+    monomial_manager: MonomialManager,
+    symbols: Tuple['Symbol', ...],
     num_tangents: int = 5,
     min_degree: int = 3,
     max_degree: int = 8,
-    symmetry: Optional['PermutationGroup'] = None
-) -> Dict[Poly, 'Expr']:
+    time_limit: Optional[Callable] = None,
+) -> List[Dict[Poly, 'Expr']]:
     """
-    Compute a dictionary of items `(ineq*poly**2, ineq_expr*expr**2)` such that
-    `ineq * poly` vanishes at all given roots. As there are infinitely many polynomials
+    For each inequality constraint in ineq_items, compute a dictionary of items
+    `(ineq*poly**2, ineq_expr*expr**2)` such that `ineq * poly` vanishes
+    at all given roots. As there are infinitely many polynomials
     that satisfy this condition, the function heuristically picks a few.
+    All these dictionaries are merged together.
 
     Parameters
     ----------
@@ -152,72 +154,97 @@ def _get_ineq_constrained_tangents(
         The monomial manager object for generating monomials.
     num_tangents : int
         Tangents are generated in a loop until it reaches the expected number of tangents.
+    min_degree : int
+        The loop does not break if min_degree is not met.
     max_degree : int
         Tangents are generated in a loop until it reaches the maximum degree.
-
-    Returns
-    -------
-    Dict[Poly, Expr]
-        A dictionary of items `(ineq*poly**2, ineq_expr*expr**2)`.
-
-    TODO: Handle high-order roots.
     """
-    roots = [r for r in roots if r.eval(ineq) != 0]
+    time_limit = ArithmeticTimeout.make_checker(time_limit)
 
-    symbols = ineq.gens
-    tangents = {}
-    if ineq.is_monomial and sum(_ != 0 for _ in tuple(ineq.LM())) == 1:
-        ineq, ineq_expr = Poly(1, *symbols), Integer(1)
+    # Preprocess each ineq: filter roots and check monomial status
+    processed = []
+    for ineq, ineq_expr, symm in ineq_items:
+        filtered_roots = [r for r in roots if r.eval(ineq) != 0]
+        is_monomial = ineq.is_monomial and sum(_ != 0 for _ in tuple(ineq.LM())) == 1
+        processed.append((ineq, ineq_expr, symm, filtered_roots, is_monomial))
 
-
-    if roots:
-        for degree in range(1, max_degree):
-            seen = set()
-
-            mat = Matrix.hstack(*[r.span(degree) for r in roots])
-            ns = _get_sorted_nullspace(monomial_manager, mat, degree)
-
-            if (symmetry is not None) and ns.shape[1] and (not symmetry.is_trivial):
-                # wedderburn decomposition
-                def action(g):
-                    arr = g.array_form
-                    inds = monomial_manager.dict_monoms(degree)
-                    monoms = monomial_manager.inv_monoms(degree)
-                    return [inds[tuple([m[i] for i in arr])] for m in monoms]
-                sa_basis = symmetry_adapted_basis(symmetry, action)
-                new_ns = []
-                for Q in sa_basis:
-                    # restrict the subspace to each symmetric-adapted component
-                    new_ns.append(_common_subspace(Q, ns))
-                ns = Matrix.hstack(ns, *new_ns)
-
-            vecs = [ns[:, i] for i in range(ns.shape[1])]
-
-            for vec in vecs:
-                poly = monomial_manager.invarraylize(vec, symbols, degree)
-                poly = _canonicalize(poly)
-                if poly is None or poly.is_zero:
-                    continue
-
-                # check whether the primitive form is seen
-                _, poly2 = poly.primitive()
-                if poly2.LC() < 0:
-                    poly2 = -poly2
-                if poly2 in seen:
-                    continue
-                seen.add(poly2)
-
-                tangents[ineq*poly**2] = ineq_expr*poly.as_expr()**2
-
-            if degree >= min_degree and len(tangents) > num_tangents:
+    # Group by (filtered_roots, symmetry) to share nullspace computation
+    groups = []
+    for idx, (ineq, ineq_expr, symm, filtered_roots, is_monomial) in enumerate(processed):
+        found = False
+        for group in groups:
+            ref_idx = group[0][0]
+            _, _, ref_symm, ref_roots, _ = processed[ref_idx]
+            if filtered_roots == ref_roots and symm == ref_symm:
+                group.append((idx, ineq, ineq_expr, filtered_roots, is_monomial))
+                found = True
                 break
+        if not found:
+            groups.append([(idx, ineq, ineq_expr, filtered_roots, is_monomial)])
 
-    if all(not r.is_nontrivial for r in roots):
-        tangents[ineq] = ineq_expr
+    results = [{} for _ in ineq_items]
 
-    # print('Roots of', ineq_expr, ':', roots)
-    # print('Tangents of', ineq_expr, ':', [e for t, e in tangents.items()])
-    return tangents
+    for group_items in groups:
+        # Extract common data from first item in group
+        _, _, _, group_roots, _ = group_items[0]
+        _, _, group_symm, _, _ = processed[group_items[0][0]]
+
+        all_polys = []
+        seen_polys = set()
+
+        if group_roots:
+            for degree in range(1, max_degree):
+                time_limit()
+
+                mat = Matrix.hstack(*[r.span(degree) for r in group_roots])
+                ns = _get_sorted_nullspace(monomial_manager, mat, degree)
+
+                if (group_symm is not None) and ns.shape[1] and (not group_symm.is_trivial):
+                    # wedderburn decomposition
+                    def action(g):
+                        arr = g.array_form
+                        inds = monomial_manager.dict_monoms(degree)
+                        monoms = monomial_manager.inv_monoms(degree)
+                        return [inds[tuple([m[i] for i in arr])] for m in monoms]
+                    sa_basis = symmetry_adapted_basis(group_symm, action)
+                    new_ns = []
+                    for Q in sa_basis:
+                        # restrict the subspace to each symmetric-adapted component
+                        new_ns.append(_common_subspace(Q, ns))
+                    ns = Matrix.hstack(ns, *new_ns)
+
+                vecs = [ns[:, i] for i in range(ns.shape[1])]
+
+                for vec in vecs:
+                    poly = monomial_manager.invarraylize(vec, symbols, degree)
+                    poly = _canonicalize(poly)
+                    if poly is None or poly.is_zero:
+                        continue
+
+                    # check whether the primitive form is seen
+                    _, poly2 = poly.primitive()
+                    if poly2.LC() < 0:
+                        poly2 = -poly2
+                    if poly2 in seen_polys:
+                        continue
+                    seen_polys.add(poly2)
+                    all_polys.append(poly)
+
+                if degree >= min_degree and len(all_polys) > num_tangents:
+                    break
+
+        # Generate tangents for each ineq in the group using shared polys
+        for idx, ineq, ineq_expr, filtered_roots, is_monomial in group_items:
+            use_ineq = Poly(1, *symbols) if is_monomial else ineq
+            use_expr = Integer(1) if is_monomial else ineq_expr
+
+            for poly in all_polys:
+                results[idx][use_ineq * poly**2] = use_expr * poly.as_expr()**2
+
+            if all(not r.is_nontrivial for r in filtered_roots):
+                results[idx][use_ineq] = use_expr
+
+    return results
 
 
 def prepare_tangents(
@@ -306,18 +333,23 @@ def prepare_tangents(
     monomial_manager = MonomialManager(len(symbols))
     ineq_constraints = ineq_constraints.items() if isinstance(ineq_constraints, dict) else ineq_constraints
 
-    symm = None
+    ineq_items = []
     for ineq, ineq_expr in ineq_constraints:
         if wedderburn:
             symm = identify_symmetry(ineq, G)
+        else:
+            symm = None
+        ineq_items.append((ineq, ineq_expr, symm))
 
-        new_tangents = _get_ineq_constrained_tangents(
-            ineq,
-            ineq_expr,
-            roots=roots,
-            monomial_manager=monomial_manager,
-            symmetry=symm
-        )
+    results = _get_ineq_constrained_tangents(
+        ineq_items,
+        roots=roots,
+        monomial_manager=monomial_manager,
+        symbols=symbols,
+        time_limit=time_limit,
+    )
+
+    for new_tangents in results:
         tangents.update(new_tangents)
         time_limit()
     # print(tangents)

--- a/triples/core/linsos/tangents.py
+++ b/triples/core/linsos/tangents.py
@@ -140,7 +140,6 @@ def _get_ineq_constrained_tangents(
     `(ineq*poly**2, ineq_expr*expr**2)` such that `ineq * poly` vanishes
     at all given roots. As there are infinitely many polynomials
     that satisfy this condition, the function heuristically picks a few.
-    All these dictionaries are merged together.
 
     Parameters
     ----------
@@ -161,42 +160,53 @@ def _get_ineq_constrained_tangents(
     """
     time_limit = ArithmeticTimeout.make_checker(time_limit)
 
-    # Preprocess each ineq: filter roots and check monomial status
+    # Preprocess each ineq: filter roots by index and check monomial status
     processed = []
     for ineq, ineq_expr, symm in ineq_items:
-        filtered_roots = [r for r in roots if r.eval(ineq) != 0]
+        root_inds = tuple(i for i, r in enumerate(roots) if r.eval(ineq) != 0)
         is_monomial = ineq.is_monomial and sum(_ != 0 for _ in tuple(ineq.LM())) == 1
-        processed.append((ineq, ineq_expr, symm, filtered_roots, is_monomial))
+        processed.append((ineq, ineq_expr, symm, root_inds, is_monomial))
 
-    # Group by (filtered_roots, symmetry) to share nullspace computation
+    # Group by (root_inds, symmetry) to share nullspace computation
     groups = []
-    for idx, (ineq, ineq_expr, symm, filtered_roots, is_monomial) in enumerate(processed):
+    for idx, (ineq, ineq_expr, symm, root_inds, is_monomial) in enumerate(processed):
         found = False
         for group in groups:
             ref_idx = group[0][0]
-            _, _, ref_symm, ref_roots, _ = processed[ref_idx]
-            if filtered_roots == ref_roots and symm == ref_symm:
-                group.append((idx, ineq, ineq_expr, filtered_roots, is_monomial))
+            _, _, ref_symm, ref_root_inds, _ = processed[ref_idx]
+            if root_inds == ref_root_inds and symm == ref_symm:
+                group.append((idx, ineq, ineq_expr, root_inds, is_monomial))
                 found = True
                 break
         if not found:
-            groups.append([(idx, ineq, ineq_expr, filtered_roots, is_monomial)])
+            groups.append([(idx, ineq, ineq_expr, root_inds, is_monomial)])
 
     results = [{} for _ in ineq_items]
 
+    # Local cache for root spans: (root_index, degree) -> span result
+    span_cache: Dict[Tuple[int, int], Matrix] = {}
+
     for group_items in groups:
         # Extract common data from first item in group
-        _, _, _, group_roots, _ = group_items[0]
+        _, _, _, group_root_inds, _ = group_items[0]
         _, _, group_symm, _, _ = processed[group_items[0][0]]
 
         all_polys = []
         seen_polys = set()
 
-        if group_roots:
+        if group_root_inds:
             for degree in range(1, max_degree):
                 time_limit()
 
-                mat = Matrix.hstack(*[r.span(degree) for r in group_roots])
+                # Gather spans for all roots in this group, using cache
+                group_spans = []
+                for ri in group_root_inds:
+                    key = (ri, degree)
+                    if key not in span_cache:
+                        span_cache[key] = roots[ri].span(degree)
+                    group_spans.append(span_cache[key])
+
+                mat = Matrix.hstack(*group_spans)
                 ns = _get_sorted_nullspace(monomial_manager, mat, degree)
 
                 if (group_symm is not None) and ns.shape[1] and (not group_symm.is_trivial):
@@ -233,16 +243,20 @@ def _get_ineq_constrained_tangents(
                 if degree >= min_degree and len(all_polys) > num_tangents:
                     break
 
+        time_limit()
+
         # Generate tangents for each ineq in the group using shared polys
-        for idx, ineq, ineq_expr, filtered_roots, is_monomial in group_items:
+        for idx, ineq, ineq_expr, root_inds, is_monomial in group_items:
             use_ineq = Poly(1, *symbols) if is_monomial else ineq
             use_expr = Integer(1) if is_monomial else ineq_expr
 
             for poly in all_polys:
                 results[idx][use_ineq * poly**2] = use_expr * poly.as_expr()**2
 
-            if all(not r.is_nontrivial for r in filtered_roots):
+            if all(not roots[ri].is_nontrivial for ri in root_inds):
                 results[idx][use_ineq] = use_expr
+
+            time_limit()
 
     return results
 

--- a/triples/core/node.py
+++ b/triples/core/node.py
@@ -43,6 +43,9 @@ class ProofNode:
     children: List['ProofNode']
     _complexity: Optional[ProblemComplexity] = None
     _complexity_models: Optional[Union[Dict, bool]] = None
+
+    skip_enter_verbose = -1
+
     def __init__(self,
         problem: InequalityProblem, configs: Optional[Dict[str, Any]]=None,
     ):
@@ -197,6 +200,8 @@ class TransformNode(ProofNode):
 
 
 class SolveProblem(ProofNode):
+    skip_enter_verbose = 1
+
     def explore(self, configs):
         if self.state == 0:
             from .preprocess.modeling import ReformulateAlgebraic
@@ -280,13 +285,14 @@ class ProofTree:
         node = self.select()
         cfg = self.get_configs(node)
 
-        tree_verbose = self.get_configs(self)["verbose"]
-        if tree_verbose:
-            path = [node]
-            MAX_PATH_LEN = 5
-            while path[-1] in self.parents and len(path) < MAX_PATH_LEN:
-                path.append(self.parents[path[-1]])
-            print(f'Exploring ... {" -> ".join([_.__class__.__name__ for _ in path[::-1]])}')
+        if node.state >= node.skip_enter_verbose:
+            tree_verbose = self.get_configs(self)["verbose"]
+            if tree_verbose:
+                path = [node]
+                MAX_PATH_LEN = 5
+                while path[-1] in self.parents and len(path) < MAX_PATH_LEN:
+                    path.append(self.parents[path[-1]])
+                print(f'Exploring ... {" >> ".join([_.__class__.__name__ for _ in path[::-1]])}')
 
         if cfg.get("callback_before_explore"):
             cfg["callback_before_explore"](self, node, cfg)
@@ -302,6 +308,7 @@ class ProofTree:
             else:
                 # kill this node
                 node.finished = True
+
                 if cfg.get("raise_exception", False):
                     raise e
                 if cfg.get("verbose", False):

--- a/triples/core/preprocess/algebraic.py
+++ b/triples/core/preprocess/algebraic.py
@@ -17,6 +17,9 @@ class CancelDenominator(ProofNode):
     default_configs = {
         "irrational_expr": False,
     }
+
+    skip_enter_verbose = 1
+
     def explore(self, configs):
         problem = self.problem
         poly, ineq_constraints, eq_constraints = problem.expr, problem.ineq_constraints, problem.eq_constraints

--- a/triples/core/preprocess/elimination.py
+++ b/triples/core/preprocess/elimination.py
@@ -620,7 +620,8 @@ def resultant_elimination(
 
     if eliminate_binomial_constraints:
         found = True
-        while found and len(problem.gens):
+        ngens = len(problem.gens)
+        while found and ngens:
             found = False
             symmetry = problem.identify_symmetry()
             orbits = symmetry.orbits()
@@ -634,8 +635,14 @@ def resultant_elimination(
                         eliminated_vars.append(problem.gens[ind])
                         problem = attempt[0]
                         restorations.append(attempt[1])
-                        found = True
-                        break
+
+                        if len(problem.gens) < ngens:
+                            ngens = len(problem.gens)
+                            found = True
+                            break
+                        else:
+                            found = False
+                            break
 
     if eliminated_vars and verbose:
         print("Resultant Elimination:", eliminated_vars)

--- a/triples/core/preprocess/elimination.py
+++ b/triples/core/preprocess/elimination.py
@@ -358,14 +358,42 @@ def eliminate_var_by_constraint(
 
     from .signs import sign_sos
     signs = problem.get_symbol_signs()
+    solver = lambda x: sign_sos(x, signs)
 
     gens = problem.gens
+    gen_index = (gen_index + len(gens))%len(gens)
     _p2expr = lambda p: p2expr(p.as_poly(gens), symmetry)
     srcs = [(0, {-problem.expr: 0}), (1, ineqs), (2, eqs)]
     dst = [{}, {}, {}]
 
+    has_trivial_cons = False
+
     new_expr = problem.expr
     restoration = lambda x: x
+
+    #############################################
+    # For fast check whether it is valid on the
+    # marginalized problem, which avoids computing
+    # a large resultant directly
+    #############################################
+    point = [[2,3,5][i%3] for i in range(len(gens))]
+    reordered_gens = tuple(gens[:gen_index]) + tuple(gens[gen_index+1:]) + (gens[gen_index],)
+    for i, g in enumerate(reordered_gens):
+        sgn = signs[g][0]
+        if sgn is None or sgn <= 0:
+            point[i] = -point[i]
+        elif sgn is not None and sgn == 0:
+            point[i] = 0
+
+    def _eval(f: Poly, point):
+        f = f.reorder(*reordered_gens)
+        f = f.eval(tuple(point)[:len(gens) - 2])
+        const, f = f.primitive()
+        if const < 0:
+            f = -f
+        return f
+    #############################################
+
     for tp, src in srcs:
         for F, value in src.items():
             if F.degree(gen_index) <= 0:
@@ -375,8 +403,59 @@ def eliminate_var_by_constraint(
             if tp != 0 and F == constraint:
                 continue
 
+
+            def _certificate_coeffs(U, V, res, p2expr=_p2expr, solver=solver):
+                """
+                Automatically selects the sign and tries to establish
+                `U*F + V*constraint == res`
+                """
+                u_proof = p2expr(U)
+                if tp <= 1:
+                    u_proof = solver(u_proof)
+                    if u_proof is None:
+                        U, V, res = -U, -V, -res
+                        u_proof = solver(p2expr(U))
+                        if u_proof is None:
+                            # the sign of U is not determined
+                            return None
+
+
+                v_proof = p2expr(V)
+                if not is_eq: # constraint is ineq
+                    v_proof = solver(v_proof)
+                    if v_proof is None:
+                        if tp <= 1:
+                            # U >= 0 but we cannot prove V >= 0
+                            return None
+                        else:
+                            U, V, res = -U, -V, -res
+                            u_proof = -u_proof
+                            v_proof = solver(p2expr(V))
+                            if v_proof is None:
+                                # the sign of V is not determined
+                                return None
+                return U, V, res, u_proof, v_proof
+
+
+            #############################################
+            # Fast check whether it is valid on the
+            # marginalized problem, which avoids computing
+            # a large resultant directly
+            #############################################
+            if len(gens) >= 3 and (not (is_eq and tp == 2)):
+                F2 = _eval(F, point)
+                constraint2 = _eval(constraint, point)
+                U2, V2, res2 = resultant_bezout(F2, constraint2, gens[gen_index], reduced=True)
+                cert = _certificate_coeffs(U2, V2, res2, p2expr=lambda x: x.as_expr())
+                # print(f"Fast check U2 = {U2}; V2 = {V2};\ncert = {cert}")
+                if cert is None:
+                    # failed to prove U2, V2 >= 0
+                    return None
+            #############################################
+
+
             # U*F + V*constraint == res
-            U, V, res = resultant_bezout(F, constraint, gens[gen_index])
+            U, V, res = resultant_bezout(F, constraint, gens[gen_index], reduced=True)
 
             if tp == 0 and U.is_zero:
                 # it should be handled differently because
@@ -390,32 +469,12 @@ def eliminate_var_by_constraint(
                         return problem, lambda x: x
                 return None
 
-            u_proof = _p2expr(U)
-            if tp <= 1:
-                u_proof = sign_sos(u_proof, signs)
-                if u_proof is None:
-                    U, V, res = -U, -V, -res
-                    u_proof = sign_sos(_p2expr(U), signs)
-                    if u_proof is None:
-                        # the sign of U is not determined
-                        return None
-
-
-            v_proof = _p2expr(V)
-            if not is_eq: # constraint is ineq
-                v_proof = sign_sos(v_proof, signs)
-                if v_proof is None:
-                    if tp <= 1:
-                        # U >= 0 but we cannot prove V >= 0
-                        return None
-                else:
-                    U, V, res = -U, -V, -res
-                    u_proof = -u_proof
-                    v_proof = sign_sos(_p2expr(V), signs)
-                    if v_proof is None:
-                        # the sign of V is not determined
-                        return None
-
+            cert = _certificate_coeffs(U, V, res)
+            # print(f'U = {U};\nV = {V};\nres = {res};\ncert = {cert}')
+            if cert is None:
+                # failed to prove U, V >= 0
+                return None
+            U, V, res, u_proof, v_proof = cert
 
             # now that we have U*F + V*constraint == res
             # and also U, V >= 0
@@ -432,12 +491,50 @@ def eliminate_var_by_constraint(
             else:
                 # res == U*F + V*constraint >= 0
                 dst_tp = 2 if is_eq and tp == 2 else 1
-                dst[dst_tp][res] = u_proof*value + v_proof*constraint_expr
+
+                if sign_sos(res.as_expr(), signs) is None:
+                    # if not None, then res >= 0 is trivial and should not
+                    # be pushed into constraints
+                    dst[dst_tp][res] = u_proof*value + v_proof*constraint_expr
+                else:
+                    has_trivial_cons = True
 
     new_problem = problem.copy_new(new_expr, dst[1], dst[2])
     if remove_redundancy:
         new_problem = new_problem.remove_redundancy()
+
+    if has_trivial_cons:
+        new_problem = _inject_problem_signs(new_problem, signs)
+
     return new_problem, restoration
+
+
+def _inject_problem_signs(problem: "InequalityProblem", signs):
+    """
+    Check whether the problem recovers the signs. If not,
+    inject the signs into the problem.
+    """
+    new_signs = problem.get_symbol_signs()
+    need_update = False
+    new_ineqs, new_eqs = {}, {}
+    for s in problem.gens:
+        if new_signs[s][0] is None and signs[s][0] is not None:
+            need_update = True
+            sgn, val = signs[s]
+            poly = Poly(s, problem.gens)
+            if sgn == 0:
+                new_eqs[poly] = val
+            else:
+                if sgn < 0:
+                    poly = -poly
+                new_ineqs[poly] = val
+
+    if need_update:
+        new_ineqs.update(problem.ineq_constraints)
+        new_eqs.update(problem.eq_constraints)
+        problem = problem.copy_new(
+            problem.expr, new_ineqs, new_eqs)
+    return problem
 
 
 def is_binomial_in(poly: Poly, gen_index: int) -> bool:
@@ -511,6 +608,11 @@ def resultant_elimination(
             problem = attempt[0]
             restorations.append(attempt[1])
             eliminated_vars.append(hom)
+
+    if all(_.total_degree() <= 1 for _ in problem.eq_constraints)\
+        and all(_.total_degree() <= 1 for _ in problem.ineq_constraints):
+        # linear programming -> needs no transformation
+        eliminate_binomial_constraints = False
 
     if eliminate_binomial_constraints:
         found = True

--- a/triples/core/preprocess/elimination.py
+++ b/triples/core/preprocess/elimination.py
@@ -609,9 +609,9 @@ def resultant_elimination(
             restorations.append(attempt[1])
             eliminated_vars.append(hom)
 
-    if all(_.total_degree() <= 1 for _ in problem.eq_constraints)\
-        and all(_.total_degree() <= 1 for _ in problem.ineq_constraints):
-        # linear programming -> needs no transformation
+    if all(_.is_monomial for _ in problem.eq_constraints)\
+        and all(_.is_monomial for _ in problem.ineq_constraints):
+        # needs no transformation
         eliminate_binomial_constraints = False
 
     if eliminate_binomial_constraints:

--- a/triples/core/preprocess/elimination.py
+++ b/triples/core/preprocess/elimination.py
@@ -1,12 +1,19 @@
-from typing import Tuple, List, Set, Optional, TYPE_CHECKING
+from typing import Tuple, List, Set, Optional, Callable, TYPE_CHECKING
 
 from sympy import Poly, Symbol, Integer, Mul, QQ, ZZ
 from sympy import MutableDenseMatrix as Matrix
 from sympy.polys.matrices.sdm import SDM
 
+from ..solution import Solution
+from ...utils import (
+    CyclicSum, verify_symmetry, poly_reduce_by_symmetry,
+    resultant_bezout
+)
+
 if TYPE_CHECKING:
     from sympy import Expr
     from ..problem import InequalityProblem
+
 
 def _identify_matrix_symmetry(S: Matrix) -> List[List[int]]:
     """
@@ -308,3 +315,229 @@ def eliminate_power_constraints(
                 new_gens[:mat.shape[0]], exprs, inv_basis.diagonal()[:mat.shape[0]])})
 
     return problem, composed
+
+
+
+#########################################################
+#
+#                       Resultant
+#
+#########################################################
+
+
+def p2expr(p: Poly, symmetry = None) -> "Expr":
+    """Convert a polynomial to expr wisely by leveraging the symmetry."""
+    if (symmetry is not None) and verify_symmetry(p, symmetry):
+        p = poly_reduce_by_symmetry(p, symmetry)
+        return CyclicSum(p.as_expr(), p.gens, symmetry)
+    return p.as_expr()
+
+
+def eliminate_var_by_constraint(
+    problem: "InequalityProblem",
+    constraint: Poly,
+    gen_index: int,
+    remove_redundancy: bool = True,
+    symmetry = None,
+) -> Optional[Tuple["InequalityProblem", Callable]]:
+    """
+    Eliminate a variable using a constraint by the method
+    of resultant.
+
+    For each expression `F` in the problem, it computes
+        `U*F + V*constraint == Resultant(F, constraint, gen)`
+    to try eliminating the variable `gen`.
+    """
+
+    ineqs, eqs = problem.ineq_constraints, problem.eq_constraints
+    is_eq = constraint in eqs
+    if (not is_eq) and (constraint not in ineqs):
+        return None
+
+    constraint_expr = eqs[constraint] if is_eq else ineqs[constraint]
+
+    from .signs import sign_sos
+    signs = problem.get_symbol_signs()
+
+    gens = problem.gens
+    _p2expr = lambda p: p2expr(p.as_poly(gens), symmetry)
+    srcs = [(0, {-problem.expr: 0}), (1, ineqs), (2, eqs)]
+    dst = [{}, {}, {}]
+
+    new_expr = problem.expr
+    restoration = lambda x: x
+    for tp, src in srcs:
+        for F, value in src.items():
+            if F.degree(gen_index) <= 0:
+                dst[tp][F] = value
+                continue
+
+            if tp != 0 and F == constraint:
+                continue
+
+            # U*F + V*constraint == res
+            U, V, res = resultant_bezout(F, constraint, gens[gen_index])
+
+            if tp == 0 and U.is_zero:
+                # it should be handled differently because
+                # U*F vanishes
+                lc, rem = F.div(constraint)
+                if rem.is_zero:
+                    # F is a multiple of constraint
+                    lc_expr = lc.as_expr()
+                    if is_eq or (len(lc_expr.free_symbols) == 0 and lc_expr >= 0):
+                        problem.solution = lc_expr * value
+                        return problem, lambda x: x
+                return None
+
+            u_proof = _p2expr(U)
+            if tp <= 1:
+                u_proof = sign_sos(u_proof, signs)
+                if u_proof is None:
+                    U, V, res = -U, -V, -res
+                    u_proof = sign_sos(_p2expr(U), signs)
+                    if u_proof is None:
+                        # the sign of U is not determined
+                        return None
+
+
+            v_proof = _p2expr(V)
+            if not is_eq: # constraint is ineq
+                v_proof = sign_sos(v_proof, signs)
+                if v_proof is None:
+                    if tp <= 1:
+                        # U >= 0 but we cannot prove V >= 0
+                        return None
+                else:
+                    U, V, res = -U, -V, -res
+                    u_proof = -u_proof
+                    v_proof = sign_sos(_p2expr(V), signs)
+                    if v_proof is None:
+                        # the sign of V is not determined
+                        return None
+
+
+            # now that we have U*F + V*constraint == res
+            # and also U, V >= 0
+            res = res.as_poly(gens)
+            if tp == 0:
+                # expr = -F = (-res + V*constraint)/U
+                # hence we shall prove -res >= 0 to imply expr >= 0
+                new_expr = -res
+                u0_proof, v0_proof = u_proof, v_proof
+                def restoration(x):
+                    if x is None: return None
+                    return (x + v0_proof*constraint_expr)/u0_proof
+
+            else:
+                # res == U*F + V*constraint >= 0
+                dst_tp = 2 if is_eq and tp == 2 else 1
+                dst[dst_tp][res] = u_proof*value + v_proof*constraint_expr
+
+    new_problem = problem.copy_new(new_expr, dst[1], dst[2])
+    if remove_redundancy:
+        new_problem = new_problem.remove_redundancy()
+    return new_problem, restoration
+
+
+def is_binomial_in(poly: Poly, gen_index: int) -> bool:
+    """
+    Check if the polynomial is binomial in the variable
+    at the given index.
+
+    Examples
+    --------
+    >>> from sympy.abc import a, b, c, d, e
+    >>> p = ((a**2+a*b**2+3*c**2*(d + 1)-3)*e).as_poly(a,b,c,d,e)
+    >>> [is_binomial_in(p, i) for i in range(5)]
+    [False, True, True, True, False]
+    """
+    a, b = -1, -1
+    for m in poly.monoms():
+        d = m[gen_index]
+        if a == -1:
+            a = d
+        elif d == a:
+            pass
+        elif b == -1:
+            b = d
+        elif d == b:
+            pass
+        else:
+            return False
+    return (a != -1) and (b != -1)
+
+
+def _try_resultant_elimination_in(
+    problem: "InequalityProblem",
+    gen_index: int,
+    **kwargs,
+) -> Optional[Tuple["InequalityProblem", Callable]]:
+    srcs = [problem.eq_constraints, problem.ineq_constraints]
+    for src in srcs:
+        for con in src:
+            if is_binomial_in(con, gen_index):
+                attempt = eliminate_var_by_constraint(
+                    problem, con, gen_index, **kwargs)
+                if attempt is not None:
+                    return attempt
+    return None
+
+
+def resultant_elimination(
+    problem: "InequalityProblem",
+    homogenize: bool = True,
+    eliminate_binomial_constraints: bool = True,
+    verbose: int = 0,
+) -> Tuple["InequalityProblem", Callable]:
+    """
+    Heuristic elimination of variables using the method of resultant.
+    """
+    ineqs, eqs = problem.ineq_constraints, problem.eq_constraints
+    if (not ineqs) and (not eqs):
+        return problem, lambda x: x
+
+    restorations = []
+    eliminated_vars = []
+
+    if homogenize and not problem.is_homogeneous:
+        problem_hom, hom = problem.homogenize()
+        symmetry = problem_hom.identify_symmetry()
+        attempt = _try_resultant_elimination_in(
+            problem_hom, -1, symmetry=symmetry)
+        if attempt is not None:
+            restorations.append(
+                lambda x: Solution.dehomogenize(x, hom))
+            problem = attempt[0]
+            restorations.append(attempt[1])
+            eliminated_vars.append(hom)
+
+    if eliminate_binomial_constraints:
+        found = True
+        while found and len(problem.gens):
+            found = False
+            symmetry = problem.identify_symmetry()
+            orbits = symmetry.orbits()
+            for orbit in orbits:
+                if len(orbit) == 1:
+                    # it is standalone and has no symmetry
+                    ind = next(iter(orbit))
+                    attempt = _try_resultant_elimination_in(
+                        problem, ind, symmetry=symmetry)
+                    if attempt is not None:
+                        eliminated_vars.append(problem.gens[ind])
+                        problem = attempt[0]
+                        restorations.append(attempt[1])
+                        found = True
+                        break
+
+    if eliminated_vars and verbose:
+        print("Resultant Elimination:", eliminated_vars)
+
+    def restoration(sol):
+        if sol is None:
+            return None
+        for rs in restorations[::-1]:
+            sol = rs(sol)
+        return sol
+    return problem, restoration

--- a/triples/core/preprocess/elimination.py
+++ b/triples/core/preprocess/elimination.py
@@ -568,14 +568,18 @@ def is_binomial_in(poly: Poly, gen_index: int) -> bool:
 def _try_resultant_elimination_in(
     problem: "InequalityProblem",
     gen_index: int,
+    symmetry = None,
     **kwargs,
 ) -> Optional[Tuple["InequalityProblem", Callable]]:
     srcs = [problem.eq_constraints, problem.ineq_constraints]
     for src in srcs:
         for con in src:
             if is_binomial_in(con, gen_index):
+                if symmetry is not None and not verify_symmetry(con, symmetry):
+                    # breaks symmetry, skip it
+                    continue
                 attempt = eliminate_var_by_constraint(
-                    problem, con, gen_index, **kwargs)
+                    problem, con, gen_index, symmetry=symmetry, **kwargs)
                 if attempt is not None:
                     return attempt
     return None

--- a/triples/core/preprocess/modeling.py
+++ b/triples/core/preprocess/modeling.py
@@ -405,6 +405,8 @@ class ReformulateAlgebraic(ProofNode):
         "assumptions": False,
     }
 
+    skip_enter_verbose = 1
+
     modeling_helper = None
     def explore(self, configs):
         if self.state != 0:

--- a/triples/core/preprocess/polynomial.py
+++ b/triples/core/preprocess/polynomial.py
@@ -115,4 +115,3 @@ class SolvePolynomial(TransformNode):
         if self.state != 0 and len(self.children) == 0:
             # check one more time if there are no children
             self.finished = True
-

--- a/triples/core/preprocess/polynomial.py
+++ b/triples/core/preprocess/polynomial.py
@@ -6,7 +6,8 @@ from .elimination import eliminate_power_constraints
 from ..node import TransformNode
 from ...utils import (
     CyclicSum,
-    identify_symmetry_from_lists, verify_symmetry, poly_reduce_by_symmetry
+    identify_symmetry_from_lists, verify_symmetry, poly_reduce_by_symmetry,
+    resultant_bezout
 )
 
 if TYPE_CHECKING:
@@ -81,7 +82,8 @@ class SolvePolynomial(TransformNode):
                     pass
 
         if configs["homogenize"]:
-            problem, _restoration = reduce_over_quotient_ring(problem)
+            # problem, _restoration = reduce_over_quotient_ring(problem)
+            problem, _restoration = resultant_elimination(problem)
         else:
             _restoration = lambda x: x
 
@@ -113,6 +115,107 @@ class SolvePolynomial(TransformNode):
 #                Bidegree Homogenization
 #
 #########################################################
+
+
+def eliminate_constraint(
+    problem: "InequalityProblem",
+    constraint: Poly,
+    gen_index: int,
+    remove_redundancy: bool = True,
+) -> Optional[Tuple["InequalityProblem", Callable]]:
+
+    ineqs, eqs = problem.ineq_constraints, problem.eq_constraints
+    is_eq = constraint in eqs
+    if (not is_eq) and (constraint not in ineqs):
+        return None
+
+    constraint_expr = eqs[constraint] if is_eq else ineqs[constraint]
+
+    from .signs import sign_sos
+    signs = problem.get_symbol_signs()
+    # symm = problem.identify_symmetry()
+
+    gens = problem.gens
+    srcs = [(0, {-problem.expr: 0}), (1, ineqs), (2, eqs)]
+    dst = [{}, {}, {}]
+
+    new_expr = problem.expr
+    restoration = lambda x: x
+    for tp, src in srcs:
+        for F, value in src.items():
+            if F.degree(gen_index) <= 0:
+                dst[tp][F] = value
+                continue
+
+            if tp != 0 and F == constraint:
+                continue
+
+            # U*F + V*constraint == res
+            U, V, res = resultant_bezout(F, constraint, gens[gen_index])
+
+            if tp == 0 and U.is_zero:
+                # it should be handled differently because
+                # U*F vanishes
+                lc, rem = F.div(constraint)
+                if rem.is_zero:
+                    # F is a multiple of constraint
+                    lc_expr = lc.as_expr()
+                    if is_eq or (len(lc_expr.free_symbols) == 0 and lc_expr >= 0):
+                        problem.solution = lc_expr * value
+                        return problem, lambda x: x
+
+                return None
+
+            if tp <= 1:
+                u_proof = sign_sos(U.as_expr(), signs)
+                if u_proof is None:
+                    U, V, res = -U, -V, -res
+                    u_proof = sign_sos(U.as_expr(), signs)
+                    if u_proof is None:
+                        # the sign of U is not determined
+                        return None
+            else:
+                u_proof = U.as_expr()#poly_reduce_by_symmetry(U, symm)
+
+            if not is_eq: # constraint is ineq
+                v_proof = sign_sos(V.as_expr(), signs)
+                if v_proof is None:
+                    if tp <= 1:
+                        # U >= 0 but we cannot prove V >= 0
+                        return None
+                else:
+                    U, V, res = -U, -V, -res
+                    u_proof = -u_proof
+                    v_proof = sign_sos(V.as_expr(), signs)
+                    if v_proof is None:
+                        # the sign of V is not determined
+                        return None
+            else:
+                v_proof = V.as_expr()#poly_reduce_by_symmetry(V, symm)
+
+
+            # now that we have U*F + V*constraint == res
+            # and also U, V >= 0
+            res = res.as_poly(gens)
+            if tp == 0:
+                # expr = -F = (-res + V*constraint)/U
+                # hence we shall prove -res >= 0 to imply expr >= 0
+                new_expr = -res
+                u0_proof, v0_proof = u_proof, v_proof
+                def restoration(x):
+                    if x is None: return None
+                    return (x + v0_proof*constraint_expr)/u0_proof
+
+            else:
+                # res == U*F + V*constraint >= 0
+                dst_tp = 2 if is_eq and tp == 2 else 1
+                dst[dst_tp][res] = u_proof*value + v_proof*constraint_expr
+
+    new_problem = problem.copy_new(new_expr, dst[1], dst[2])
+    if remove_redundancy:
+        new_problem = new_problem.remove_redundancy()
+    return new_problem, restoration
+
 
 def _is_bidegree(p: Poly) -> Optional[Tuple[Poly, Poly, int]]:
     """Check whether a multivariate polynomial has two different degrees.
@@ -316,14 +419,11 @@ def reduce_over_quotient_ring(problem: "InequalityProblem"):
     1. Eliminate linear equality constraints, e.g. a+2b=3
     2. Eliminate linear inequality constraints, e.g. b+c-a, c+a-b, a+b-c>=0
     """
-    poly, ineq_constraints, eq_constraints = problem.expr, problem.ineq_constraints, problem.eq_constraints
     restorations = []
     ################################################################
     #           Homogenize the polynomial and constraints
     ################################################################
-    is_hom = poly.is_homogeneous and all(e.is_homogeneous for e in ineq_constraints)\
-        and all(e.is_homogeneous for e in eq_constraints)
-    if is_hom:
+    if problem.is_homogeneous:
         # nothing to do
         return problem, lambda x: x
 
@@ -343,4 +443,79 @@ def reduce_over_quotient_ring(problem: "InequalityProblem"):
             sol = rs(sol)
         return sol
 
+    return problem, restoration
+
+
+def is_bidegree_in(poly: Poly, gen_index: int) -> bool:
+    a, b = -1, -1
+    for m in poly.monoms():
+        d = m[gen_index]
+        if a == -1:
+            a = d
+        elif d == a:
+            pass
+        elif b == -1:
+            b = d
+        elif d == b:
+            pass
+        else:
+            return False
+    return (a != -1) and (b != -1)
+
+
+def _try_resultant_elimination_in(
+    problem: "InequalityProblem",
+    gen_index: int,
+    **kwargs,
+) -> Optional[Tuple["InequalityProblem", Callable]]:
+    srcs = [problem.eq_constraints, problem.ineq_constraints]
+    for src in srcs:
+        for con in src:
+            if is_bidegree_in(con, gen_index):
+                attempt = eliminate_constraint(problem, con, gen_index, **kwargs)
+                if attempt is not None:
+                    return attempt
+    return None
+
+
+def resultant_elimination(problem: "InequalityProblem") -> Tuple["InequalityProblem", Callable]:
+    """
+    Heuristic elimination of variables using the method of resultant.
+    """
+    ineqs, eqs = problem.ineq_constraints, problem.eq_constraints
+    if (not ineqs) and (not eqs):
+        return problem, lambda x: x
+
+    restorations = []
+
+    if not problem.is_homogeneous:
+        problem_hom, hom = problem.homogenize()
+
+        attempt = _try_resultant_elimination_in(problem_hom, -1)
+        if attempt is not None:
+            restorations.append(lambda x: x.xreplace({hom: 1}) if x is not None else x)
+            problem = attempt[0]
+            restorations.append(attempt[1])
+
+    found = True
+    while found and len(problem.gens):
+        found = False
+        symmetry = problem.identify_symmetry()
+        orbits = symmetry.orbits()
+        for orbit in orbits:
+            if len(orbit) == 1:
+                # it is standalone and has no symmetry
+                attempt = _try_resultant_elimination_in(problem, next(iter(orbit)))
+                if attempt is not None:
+                    problem = attempt[0]
+                    restorations.append(attempt[1])
+                    found = True
+                    break
+
+    def restoration(sol):
+        if sol is None:
+            return None
+        for rs in restorations[::-1]:
+            sol = rs(sol)
+        return sol
     return problem, restoration

--- a/triples/core/preprocess/polynomial.py
+++ b/triples/core/preprocess/polynomial.py
@@ -28,6 +28,7 @@ class SolvePolynomial(TransformNode):
         "remove_redundancy": True,
         "eliminate_power_constraints": True,
         "irrational_expr": False,
+        "verbose": False,
     }
     def get_polynomial_solvers(self, configs):
         solvers = configs.get('solvers', None)
@@ -84,7 +85,8 @@ class SolvePolynomial(TransformNode):
 
         if configs["homogenize"]:
             # problem, _restoration = reduce_over_quotient_ring(problem)
-            problem, _restoration = resultant_elimination(problem)
+            problem, _restoration = resultant_elimination(
+                problem, verbose=configs["verbose"])
         else:
             _restoration = lambda x: x
 
@@ -93,6 +95,13 @@ class SolvePolynomial(TransformNode):
             self.solution = problem.expr.LC() * sqf**2
             self.finished = True
             return
+
+        if configs["verbose"]:
+            print(f"Processed problem at id {id(problem)}:\n"
+                f"Vars        = {len(problem.gens)}\n"
+                f"Degree      = {problem.expr.total_degree()}\n"
+                f"Constraints = {len(problem.ineq_constraints)} ineqs +"
+                f" {len(problem.eq_constraints)} eqs")
 
         solvers = self.get_polynomial_solvers(configs)
         self.children = [solver(problem) for solver in solvers]
@@ -143,9 +152,9 @@ def eliminate_constraint(
 
     from .signs import sign_sos
     signs = problem.get_symbol_signs()
-    # symm = problem.identify_symmetry()
 
     gens = problem.gens
+    _p2expr = lambda p: p2expr(p.as_poly(gens), symmetry)
     srcs = [(0, {-problem.expr: 0}), (1, ineqs), (2, eqs)]
     dst = [{}, {}, {}]
 
@@ -173,24 +182,22 @@ def eliminate_constraint(
                     if is_eq or (len(lc_expr.free_symbols) == 0 and lc_expr >= 0):
                         problem.solution = lc_expr * value
                         return problem, lambda x: x
-
                 return None
 
-            U = p2expr(U.as_poly(gens), symmetry)
-            V = p2expr(V.as_poly(gens), symmetry)
+            u_proof = _p2expr(U)
             if tp <= 1:
-                u_proof = sign_sos(U, signs)
+                u_proof = sign_sos(u_proof, signs)
                 if u_proof is None:
                     U, V, res = -U, -V, -res
-                    u_proof = sign_sos(U, signs)
+                    u_proof = sign_sos(_p2expr(U), signs)
                     if u_proof is None:
                         # the sign of U is not determined
                         return None
-            else:
-                u_proof = U
 
+
+            v_proof = _p2expr(V)
             if not is_eq: # constraint is ineq
-                v_proof = sign_sos(V, signs)
+                v_proof = sign_sos(v_proof, signs)
                 if v_proof is None:
                     if tp <= 1:
                         # U >= 0 but we cannot prove V >= 0
@@ -198,12 +205,10 @@ def eliminate_constraint(
                 else:
                     U, V, res = -U, -V, -res
                     u_proof = -u_proof
-                    v_proof = sign_sos(V, signs)
+                    v_proof = sign_sos(_p2expr(V), signs)
                     if v_proof is None:
                         # the sign of V is not determined
                         return None
-            else:
-                v_proof = V
 
 
             # now that we have U*F + V*constraint == res
@@ -486,7 +491,8 @@ def _try_resultant_elimination_in(
 
 
 def resultant_elimination(
-    problem: "InequalityProblem"
+    problem: "InequalityProblem",
+    verbose: int = 0,
 ) -> Tuple["InequalityProblem", Callable]:
     """
     Heuristic elimination of variables using the method of resultant.
@@ -496,6 +502,7 @@ def resultant_elimination(
         return problem, lambda x: x
 
     restorations = []
+    eliminated_vars = []
 
     if not problem.is_homogeneous:
         problem_hom, hom = problem.homogenize()
@@ -507,6 +514,7 @@ def resultant_elimination(
                 lambda x: Solution.dehomogenize(x, hom) if x is not None else x)
             problem = attempt[0]
             restorations.append(attempt[1])
+            eliminated_vars.append(hom)
 
     found = True
     while found and len(problem.gens):
@@ -516,13 +524,18 @@ def resultant_elimination(
         for orbit in orbits:
             if len(orbit) == 1:
                 # it is standalone and has no symmetry
+                ind = next(iter(orbit))
                 attempt = _try_resultant_elimination_in(
-                    problem, next(iter(orbit)), symmetry=symmetry)
+                    problem, ind, symmetry=symmetry)
                 if attempt is not None:
+                    eliminated_vars.append(problem.gens[ind])
                     problem = attempt[0]
                     restorations.append(attempt[1])
                     found = True
                     break
+
+    if eliminated_vars and verbose:
+        print("Resultant Elimination:", eliminated_vars)
 
     def restoration(sol):
         if sol is None:

--- a/triples/core/preprocess/polynomial.py
+++ b/triples/core/preprocess/polynomial.py
@@ -1,32 +1,20 @@
-from typing import List, Dict, Tuple, Callable, Optional, TYPE_CHECKING
-
-from sympy import Poly
-
-from .elimination import eliminate_power_constraints
+from .elimination import eliminate_power_constraints, resultant_elimination
 from ..node import TransformNode
-from ..solution import Solution
-from ...utils import (
-    CyclicSum,
-    identify_symmetry_from_lists, verify_symmetry, poly_reduce_by_symmetry,
-    resultant_bezout
-)
-
-if TYPE_CHECKING:
-    from sympy import Expr
-    from ..problem import InequalityProblem
 
 
 class SolvePolynomial(TransformNode):
     """
-    Solve a dense polynomial inequality. The target expression and its constraints
-    are all converted and stored as sympy (dense) Poly class. However, the process
-    of converting expressions to dense polynomials is inefficient for very large inputs.
+    Solve a dense polynomial inequality. The target expression
+    and its constraints are all converted and stored as sympy (dense)
+    Poly class. However, the process of converting expressions to dense
+    polynomials is inefficient for very large inputs.
     """
     default_configs = {
         "sqf": False,
         "homogenize": True,
         "remove_redundancy": True,
         "eliminate_power_constraints": True,
+        "eliminate_binomial_constraints": True,
         "irrational_expr": False,
         "verbose": False,
     }
@@ -61,14 +49,17 @@ class SolvePolynomial(TransformNode):
 
         sqf = 1
         if configs["sqf"]:
-            problem, sqf = problem.sqr_free(problem_sqf=True, ineqs_sqf=False, eqs_sqf=False)
+            problem, sqf = problem.sqr_free(
+                problem_sqf=True, ineqs_sqf=False, eqs_sqf=False)
 
         problem = problem.remove_redundancy()
 
         power_restore = lambda x: x
         if configs["eliminate_power_constraints"]:
-            new_problem, new_power_restore = eliminate_power_constraints(problem,
-                irrational_expr=configs["irrational_expr"])
+            new_problem, new_power_restore = eliminate_power_constraints(
+                problem,
+                irrational_expr=configs["irrational_expr"]
+            )
             if new_problem is problem:
                 # nothing changed
                 pass
@@ -83,12 +74,18 @@ class SolvePolynomial(TransformNode):
                     # and we had better preserve both
                     pass
 
-        if configs["homogenize"]:
-            # problem, _restoration = reduce_over_quotient_ring(problem)
-            problem, _restoration = resultant_elimination(
-                problem, verbose=configs["verbose"])
-        else:
-            _restoration = lambda x: x
+        problem, res_restore = resultant_elimination(
+            problem,
+            **{
+                key: configs[key]
+                for key in [
+                    "homogenize",
+                    "eliminate_binomial_constraints",
+                    "verbose",
+                ]
+            }
+        )
+
 
         if problem.expr.total_degree() <= 0 and problem.expr.LC() >= 0:
             # nonnegative constant to prove
@@ -111,7 +108,7 @@ class SolvePolynomial(TransformNode):
         def composed_restoration(x):
             if x is None:
                 return None
-            return sqf**2 * power_restore(_restoration(x))
+            return sqf**2 * power_restore(res_restore(x))
 
         self.restorations = dict.fromkeys(self.children, composed_restoration)
 
@@ -119,428 +116,3 @@ class SolvePolynomial(TransformNode):
             # check one more time if there are no children
             self.finished = True
 
-
-#########################################################
-#
-#                Bidegree Homogenization
-#
-#########################################################
-
-
-def p2expr(p: Poly, symmetry = None) -> "Expr":
-    """Convert a polynomial to expr wisely by leveraging the symmetry."""
-    if (symmetry is not None) and verify_symmetry(p, symmetry):
-        p = poly_reduce_by_symmetry(p, symmetry)
-        return CyclicSum(p.as_expr(), p.gens, symmetry)
-    return p.as_expr()
-
-
-def eliminate_constraint(
-    problem: "InequalityProblem",
-    constraint: Poly,
-    gen_index: int,
-    remove_redundancy: bool = True,
-    symmetry = None,
-) -> Optional[Tuple["InequalityProblem", Callable]]:
-
-    ineqs, eqs = problem.ineq_constraints, problem.eq_constraints
-    is_eq = constraint in eqs
-    if (not is_eq) and (constraint not in ineqs):
-        return None
-
-    constraint_expr = eqs[constraint] if is_eq else ineqs[constraint]
-
-    from .signs import sign_sos
-    signs = problem.get_symbol_signs()
-
-    gens = problem.gens
-    _p2expr = lambda p: p2expr(p.as_poly(gens), symmetry)
-    srcs = [(0, {-problem.expr: 0}), (1, ineqs), (2, eqs)]
-    dst = [{}, {}, {}]
-
-    new_expr = problem.expr
-    restoration = lambda x: x
-    for tp, src in srcs:
-        for F, value in src.items():
-            if F.degree(gen_index) <= 0:
-                dst[tp][F] = value
-                continue
-
-            if tp != 0 and F == constraint:
-                continue
-
-            # U*F + V*constraint == res
-            U, V, res = resultant_bezout(F, constraint, gens[gen_index])
-
-            if tp == 0 and U.is_zero:
-                # it should be handled differently because
-                # U*F vanishes
-                lc, rem = F.div(constraint)
-                if rem.is_zero:
-                    # F is a multiple of constraint
-                    lc_expr = lc.as_expr()
-                    if is_eq or (len(lc_expr.free_symbols) == 0 and lc_expr >= 0):
-                        problem.solution = lc_expr * value
-                        return problem, lambda x: x
-                return None
-
-            u_proof = _p2expr(U)
-            if tp <= 1:
-                u_proof = sign_sos(u_proof, signs)
-                if u_proof is None:
-                    U, V, res = -U, -V, -res
-                    u_proof = sign_sos(_p2expr(U), signs)
-                    if u_proof is None:
-                        # the sign of U is not determined
-                        return None
-
-
-            v_proof = _p2expr(V)
-            if not is_eq: # constraint is ineq
-                v_proof = sign_sos(v_proof, signs)
-                if v_proof is None:
-                    if tp <= 1:
-                        # U >= 0 but we cannot prove V >= 0
-                        return None
-                else:
-                    U, V, res = -U, -V, -res
-                    u_proof = -u_proof
-                    v_proof = sign_sos(_p2expr(V), signs)
-                    if v_proof is None:
-                        # the sign of V is not determined
-                        return None
-
-
-            # now that we have U*F + V*constraint == res
-            # and also U, V >= 0
-            res = res.as_poly(gens)
-            if tp == 0:
-                # expr = -F = (-res + V*constraint)/U
-                # hence we shall prove -res >= 0 to imply expr >= 0
-                new_expr = -res
-                u0_proof, v0_proof = u_proof, v_proof
-                def restoration(x):
-                    if x is None: return None
-                    return (x + v0_proof*constraint_expr)/u0_proof
-
-            else:
-                # res == U*F + V*constraint >= 0
-                dst_tp = 2 if is_eq and tp == 2 else 1
-                dst[dst_tp][res] = u_proof*value + v_proof*constraint_expr
-
-    new_problem = problem.copy_new(new_expr, dst[1], dst[2])
-    if remove_redundancy:
-        new_problem = new_problem.remove_redundancy()
-    return new_problem, restoration
-
-
-def _is_bidegree(p: Poly) -> Optional[Tuple[Poly, Poly, int]]:
-    """Check whether a multivariate polynomial has two different degrees.
-    Returns l1, l2, sgn such that p = sgn * (l2 - l1). Also,
-    l1, l2 are homogeneous, deg(l1) < deg(l2) and l1.LC() > 0. Returns
-    None if p does not have the property.
-
-    Examples
-    ---------
-    >>> from sympy.abc import a, b, c
-    >>> _is_bidegree((a**2 + b**2 + c**2).as_poly(a,b,c)) is None
-    True
-    >>> _is_bidegree((2 - 3*(a+b+c) - a*b*c).as_poly(a,b,c)) is None
-    True
-    >>> _is_bidegree((3*(a+b+c) - a*b*c).as_poly(a,b,c))
-    (Poly(3*a + 3*b + 3*c, a, b, c, domain='ZZ'), Poly(a*b*c, a, b, c, domain='ZZ'), -1)
-    >>> _is_bidegree((-3*(a+b+c) + a*b*c).as_poly(a,b,c))
-    (Poly(3*a + 3*b + 3*c, a, b, c, domain='ZZ'), Poly(a*b*c, a, b, c, domain='ZZ'), 1)
-    """
-    terms = {}
-    for m, c in p.terms():
-        d = sum(m)
-        if d not in terms:
-            if len(terms) == 2:
-                return None
-            terms[d] = [(m, c)]
-        else:
-            terms[d].append((m, c))
-    if len(terms) != 2:
-        return None
-    d1, l1 = terms.popitem()
-    d2, l2 = terms.popitem()
-    if d1 > d2:
-        d1, d2 = d2, d1
-        l1, l2 = l2, l1
-    # d1 < d2
-    l1 = Poly(dict(l1), p.gens, domain=p.domain)
-    l2 = Poly(dict(l2), p.gens, domain=p.domain)
-    if l1.LC() < 0:
-        l1 = -l1
-        sgn = 1
-    else:
-        l2 = -l2
-        sgn = -1
-    return l1, l2, sgn
-
-def _align_degree(p: Poly, p1: Poly, p2: Poly, accept_odd_degree: bool = False) -> Optional[Tuple[Poly, int, Poly]]:
-    """
-    Homogenize p given p1 == p2 and deg(p1) < deg(p2).
-    Returns q, d, x such that q = p1**d * p + x(p2 - p1) where q, x are polynomials
-    and q is homogeneous. Returns None if it fails.
-
-    Parameters
-    ----------
-    p: Poly
-        The polynomial to be homogenized.
-    p1: Poly
-        The first polynomial in the alignment.
-    p2: Poly
-        The second polynomial in the alignment.
-    accept_odd_degree: bool
-        If False, d is forced to be even.
-
-    Examples
-    --------
-    >>> from sympy.abc import a, b, c
-    >>> from sympy import Poly
-    >>> p, p1, p2 = Poly(a**2+b**2+c**2 - 3, (a,b,c)), Poly(3, (a,b,c)), Poly(a+b+c, (a,b,c))
-    >>> q, d, x = _align_degree(p, p1, p2); (q, d, x) # doctest: +NORMALIZE_WHITESPACE
-    (Poly(6*a**2 - 6*a*b - 6*a*c + 6*b**2 - 6*b*c + 6*c**2, a, b, c, domain='ZZ'),
-    2,
-    Poly(-3*a - 3*b - 3*c - 9, a, b, c, domain='ZZ'))
-    >>> (q - (p1**d * p + x*(p2 - p1)))
-    Poly(0, a, b, c, domain='ZZ')
-    """
-    ddiff = p2.total_degree() - p1.total_degree()
-    if ddiff == 0:
-        return None
-    terms = {}
-    for m, c in p.terms():
-        d = sum(m)
-        if d not in terms:
-            terms[d] = [(m, c)]
-        else:
-            terms[d].append((m, c))
-    # p = sum(d * polys[d] for d in terms)
-    keys = sorted(terms.keys())
-    for i in range(len(keys)-1):
-        if (keys[i+1]-keys[i])%ddiff != 0:
-            return None
-    muldeg = (keys[-1] - keys[0])//ddiff
-    if muldeg == 0:
-        # nothing to do
-        return p, 0, Poly({}, p.gens, domain=p.domain)
-    if (not accept_odd_degree) and muldeg % 2 != 0:
-        # d is not even, might multiply a negative term
-        return None
-    polys = [Poly(dict(terms[d]), p.gens, domain=p.domain) for d in keys]
-    q = Poly({}, p.gens, domain=p.domain)
-    for d, poly in zip(keys, polys):
-        codeg = (keys[-1] - d)//ddiff
-        # poly -> poly * p2**codeg * p1**muldeg
-        q += poly * p2**codeg * p1**(muldeg - codeg)
-        # x += poly * (p2**codeg - p1**codeg)/(p2 - p1) * p1**(muldeg - codeg)
-    divrem = (q - p1**muldeg*p).div(p2 - p1)
-    if not divrem[1].is_zero:
-        return None
-    # print(p, '- (hom) ->', q, muldeg, divrem[0])
-    return q, muldeg, divrem[0]
-
-def _bidegree_recover_expr(lst: List[Dict[Poly, Tuple[Poly, int, Poly]]], p1: Poly, sgn_expr: "Expr") -> "Expr":
-    """
-    Utility function for bidegree homogenization.
-    Recover the original expressions from homogenization info, each represented
-    by a tuple (mul_deg, expr, quo). After recovery, it would be:
-
-        `p1.as_expr()**mul_deg * expr + sgn_expr * quo.as_expr()`
-
-    The modification is done in-place. Returns only the expression
-    form of `p1`.
-    """
-    symmetry = identify_symmetry_from_lists([list(d.keys()) for d in lst])
-    if symmetry.is_trivial:
-        symmetry = None
-
-    p1_expr = p2expr(p1, symmetry)
-    for d in lst:
-        for p, (mul_deg, expr, quo) in d.items():
-            d[p] = p1_expr**mul_deg * expr + p2expr(quo, symmetry)*sgn_expr
-    return p1_expr
-
-def _bidegree_attempt(problem: "InequalityProblem", eq: Poly) -> Optional[Tuple["InequalityProblem", Callable]]:
-    """
-    Test whether the constraint `eq` can be use to homogenize the original problem.
-
-    If yes, returns a new problem and a function to recover the solution.
-    """
-    poly, ineq_constraints, eq_constraints = problem.expr, problem.ineq_constraints, problem.eq_constraints
-
-    bideg = _is_bidegree(eq)
-    if bideg is None:
-        return None
-    p1, p2, sgn = bideg
-
-    accept_odd = True if (p1.total_degree() == 0 and p1.LC() > 0) else False
-    # print(f'Bidegree: {eq} == 0  <=>  {p1} == {p2}')
-
-    # handle them universally
-    dicts = [{poly: 0}, ineq_constraints, eq_constraints]
-    new_dicts = [{}, {}, {}]
-
-    for dict_i, src in enumerate(dicts):
-        dst = new_dicts[dict_i]
-        for key, expr in src.items():
-            if dict_i == 2 and key == eq:
-                continue
-            alignment = _align_degree(key, p1, p2, accept_odd_degree=accept_odd)
-            if alignment is None:
-                return None
-            # to avoid wasting time, we only store the homogenization info here
-            new_poly, mul_deg, quo = alignment
-            dst[new_poly] = (mul_deg, expr, quo)
-
-    # All polynomials are homogenized,
-    # now we restore the homogenization info (tuples) to exprs.
-    mul_deg = next(iter(new_dicts[0].values()))[0]
-    eq_expr = eq_constraints[eq]
-    p1_expr = _bidegree_recover_expr(new_dicts, p1, sgn * eq_expr)
-
-    new_poly, expr_shift = next(iter(new_dicts[0].items()))
-    def _align_degree_restore(x):
-        """Recover z such that `(p1_expr**mul_deg * z + expr_shift) == x`"""
-        return (x - expr_shift) / p1_expr**mul_deg
-    new_problem = problem.new(new_poly, new_dicts[1], new_dicts[2])
-    new_problem.roots = problem.roots
-    return new_problem, _align_degree_restore
-
-def bidegree_homogenization(problem: "InequalityProblem") -> Tuple["InequalityProblem", Callable]:
-    for eq in problem.eq_constraints:
-        attempt = _bidegree_attempt(problem, eq)
-        if attempt is not None:
-            return attempt
-    return problem, lambda x: x
-
-
-def reduce_over_quotient_ring(problem: "InequalityProblem"):
-    """
-    Perform quotient ring reduction of the problem, including operations like
-    homogenization.
-
-    Given equality constraint f(x) = g(x) where f,g are nonzero homogeneous polynomials
-    and deg(f) = deg(g), we obtain 1 = (f(x)/g(x)) and can be used for homogenization.
-
-    TODO:
-    1. Eliminate linear equality constraints, e.g. a+2b=3
-    2. Eliminate linear inequality constraints, e.g. b+c-a, c+a-b, a+b-c>=0
-    """
-    restorations = []
-    ################################################################
-    #           Homogenize the polynomial and constraints
-    ################################################################
-    if problem.is_homogeneous:
-        # nothing to do
-        return problem, lambda x: x
-
-    ################################################################
-    #         Homogenize using bidegree constraints
-    ################################################################
-
-    problem, restore = bidegree_homogenization(problem)
-    restorations.append(restore)
-
-    if len(restorations) == 0:
-        restorations.append(lambda x: x)
-    def restoration(sol):
-        if sol is None:
-            return None
-        for rs in restorations[::-1]:
-            sol = rs(sol)
-        return sol
-
-    return problem, restoration
-
-
-def is_bidegree_in(poly: Poly, gen_index: int) -> bool:
-    a, b = -1, -1
-    for m in poly.monoms():
-        d = m[gen_index]
-        if a == -1:
-            a = d
-        elif d == a:
-            pass
-        elif b == -1:
-            b = d
-        elif d == b:
-            pass
-        else:
-            return False
-    return (a != -1) and (b != -1)
-
-
-def _try_resultant_elimination_in(
-    problem: "InequalityProblem",
-    gen_index: int,
-    **kwargs,
-) -> Optional[Tuple["InequalityProblem", Callable]]:
-    srcs = [problem.eq_constraints, problem.ineq_constraints]
-    for src in srcs:
-        for con in src:
-            if is_bidegree_in(con, gen_index):
-                attempt = eliminate_constraint(
-                    problem, con, gen_index, **kwargs)
-                if attempt is not None:
-                    return attempt
-    return None
-
-
-def resultant_elimination(
-    problem: "InequalityProblem",
-    verbose: int = 0,
-) -> Tuple["InequalityProblem", Callable]:
-    """
-    Heuristic elimination of variables using the method of resultant.
-    """
-    ineqs, eqs = problem.ineq_constraints, problem.eq_constraints
-    if (not ineqs) and (not eqs):
-        return problem, lambda x: x
-
-    restorations = []
-    eliminated_vars = []
-
-    if not problem.is_homogeneous:
-        problem_hom, hom = problem.homogenize()
-        symmetry = problem_hom.identify_symmetry()
-        attempt = _try_resultant_elimination_in(
-            problem_hom, -1, symmetry=symmetry)
-        if attempt is not None:
-            restorations.append(
-                lambda x: Solution.dehomogenize(x, hom) if x is not None else x)
-            problem = attempt[0]
-            restorations.append(attempt[1])
-            eliminated_vars.append(hom)
-
-    found = True
-    while found and len(problem.gens):
-        found = False
-        symmetry = problem.identify_symmetry()
-        orbits = symmetry.orbits()
-        for orbit in orbits:
-            if len(orbit) == 1:
-                # it is standalone and has no symmetry
-                ind = next(iter(orbit))
-                attempt = _try_resultant_elimination_in(
-                    problem, ind, symmetry=symmetry)
-                if attempt is not None:
-                    eliminated_vars.append(problem.gens[ind])
-                    problem = attempt[0]
-                    restorations.append(attempt[1])
-                    found = True
-                    break
-
-    if eliminated_vars and verbose:
-        print("Resultant Elimination:", eliminated_vars)
-
-    def restoration(sol):
-        if sol is None:
-            return None
-        for rs in restorations[::-1]:
-            sol = rs(sol)
-        return sol
-    return problem, restoration

--- a/triples/core/preprocess/polynomial.py
+++ b/triples/core/preprocess/polynomial.py
@@ -4,6 +4,7 @@ from sympy import Poly
 
 from .elimination import eliminate_power_constraints
 from ..node import TransformNode
+from ..solution import Solution
 from ...utils import (
     CyclicSum,
     identify_symmetry_from_lists, verify_symmetry, poly_reduce_by_symmetry,
@@ -117,11 +118,20 @@ class SolvePolynomial(TransformNode):
 #########################################################
 
 
+def p2expr(p: Poly, symmetry = None) -> "Expr":
+    """Convert a polynomial to expr wisely by leveraging the symmetry."""
+    if (symmetry is not None) and verify_symmetry(p, symmetry):
+        p = poly_reduce_by_symmetry(p, symmetry)
+        return CyclicSum(p.as_expr(), p.gens, symmetry)
+    return p.as_expr()
+
+
 def eliminate_constraint(
     problem: "InequalityProblem",
     constraint: Poly,
     gen_index: int,
     remove_redundancy: bool = True,
+    symmetry = None,
 ) -> Optional[Tuple["InequalityProblem", Callable]]:
 
     ineqs, eqs = problem.ineq_constraints, problem.eq_constraints
@@ -166,19 +176,21 @@ def eliminate_constraint(
 
                 return None
 
+            U = p2expr(U.as_poly(gens), symmetry)
+            V = p2expr(V.as_poly(gens), symmetry)
             if tp <= 1:
-                u_proof = sign_sos(U.as_expr(), signs)
+                u_proof = sign_sos(U, signs)
                 if u_proof is None:
                     U, V, res = -U, -V, -res
-                    u_proof = sign_sos(U.as_expr(), signs)
+                    u_proof = sign_sos(U, signs)
                     if u_proof is None:
                         # the sign of U is not determined
                         return None
             else:
-                u_proof = U.as_expr()#poly_reduce_by_symmetry(U, symm)
+                u_proof = U
 
             if not is_eq: # constraint is ineq
-                v_proof = sign_sos(V.as_expr(), signs)
+                v_proof = sign_sos(V, signs)
                 if v_proof is None:
                     if tp <= 1:
                         # U >= 0 but we cannot prove V >= 0
@@ -186,12 +198,12 @@ def eliminate_constraint(
                 else:
                     U, V, res = -U, -V, -res
                     u_proof = -u_proof
-                    v_proof = sign_sos(V.as_expr(), signs)
+                    v_proof = sign_sos(V, signs)
                     if v_proof is None:
                         # the sign of V is not determined
                         return None
             else:
-                v_proof = V.as_expr()#poly_reduce_by_symmetry(V, symm)
+                v_proof = V
 
 
             # now that we have U*F + V*constraint == res
@@ -341,16 +353,10 @@ def _bidegree_recover_expr(lst: List[Dict[Poly, Tuple[Poly, int, Poly]]], p1: Po
     if symmetry.is_trivial:
         symmetry = None
 
-    def p2expr(p: Poly) -> "Expr":
-        # convert a polynomial to expr wisely by exploting the symmetry
-        if (symmetry is not None) and verify_symmetry(p, symmetry):
-            p = poly_reduce_by_symmetry(p, symmetry)
-            return CyclicSum(p.as_expr(), p.gens, symmetry)
-        return p.as_expr()
-    p1_expr = p2expr(p1)
+    p1_expr = p2expr(p1, symmetry)
     for d in lst:
         for p, (mul_deg, expr, quo) in d.items():
-            d[p] = p1_expr**mul_deg * expr + p2expr(quo)*sgn_expr
+            d[p] = p1_expr**mul_deg * expr + p2expr(quo, symmetry)*sgn_expr
     return p1_expr
 
 def _bidegree_attempt(problem: "InequalityProblem", eq: Poly) -> Optional[Tuple["InequalityProblem", Callable]]:
@@ -472,13 +478,16 @@ def _try_resultant_elimination_in(
     for src in srcs:
         for con in src:
             if is_bidegree_in(con, gen_index):
-                attempt = eliminate_constraint(problem, con, gen_index, **kwargs)
+                attempt = eliminate_constraint(
+                    problem, con, gen_index, **kwargs)
                 if attempt is not None:
                     return attempt
     return None
 
 
-def resultant_elimination(problem: "InequalityProblem") -> Tuple["InequalityProblem", Callable]:
+def resultant_elimination(
+    problem: "InequalityProblem"
+) -> Tuple["InequalityProblem", Callable]:
     """
     Heuristic elimination of variables using the method of resultant.
     """
@@ -490,10 +499,12 @@ def resultant_elimination(problem: "InequalityProblem") -> Tuple["InequalityProb
 
     if not problem.is_homogeneous:
         problem_hom, hom = problem.homogenize()
-
-        attempt = _try_resultant_elimination_in(problem_hom, -1)
+        symmetry = problem_hom.identify_symmetry()
+        attempt = _try_resultant_elimination_in(
+            problem_hom, -1, symmetry=symmetry)
         if attempt is not None:
-            restorations.append(lambda x: x.xreplace({hom: 1}) if x is not None else x)
+            restorations.append(
+                lambda x: Solution.dehomogenize(x, hom) if x is not None else x)
             problem = attempt[0]
             restorations.append(attempt[1])
 
@@ -505,7 +516,8 @@ def resultant_elimination(problem: "InequalityProblem") -> Tuple["InequalityProb
         for orbit in orbits:
             if len(orbit) == 1:
                 # it is standalone and has no symmetry
-                attempt = _try_resultant_elimination_in(problem, next(iter(orbit)))
+                attempt = _try_resultant_elimination_in(
+                    problem, next(iter(orbit)), symmetry=symmetry)
                 if attempt is not None:
                     problem = attempt[0]
                     restorations.append(attempt[1])

--- a/triples/core/preprocess/qcqp.py
+++ b/triples/core/preprocess/qcqp.py
@@ -292,7 +292,8 @@ class QCQPSolver(ProofNode):
 
         y = None
         try:
-            sdp.print_graph(short=2)
+            if configs["verbose"]:
+                sdp.print_graph(short=2)
             y = sdp.solve(
                 verbose=configs["verbose"],
                 solver=configs["solver"],

--- a/triples/core/preprocess/qcqp.py
+++ b/triples/core/preprocess/qcqp.py
@@ -15,6 +15,7 @@ from ...sdp import SDPProblem
 if TYPE_CHECKING:
     from sympy import Poly
 
+
 class QCQP(InequalityProblem):
     """
     Quadratic Constrained Quadratic Program (QCQP). Representing
@@ -192,13 +193,22 @@ class QCQPSolver(ProofNode):
                 return
             problem, restoration = result
 
-
             self.wrapped_problem = problem
             self.restoration = restoration
             self.state = 1
-            return
+
+            # continue
+            # return
 
         if self.state == 1:
+            if configs["verbose"]:
+                relaxation = "SDP+RLT+McCormick" if configs["mccormick"] else "SDP+RLT"
+                print(f"Solving as a QCQP using {relaxation}......\n"
+                      f"Shape       = {self.wrapped_problem.P0.shape}\n"
+                      f"Vars        = {len(self.wrapped_problem.gens)}\n"
+                      f"Constraints = {len(self.wrapped_problem.P_ineqs)} ineqs +"
+                      f" {len(self.wrapped_problem.P_eqs)} eqs")
+
             self.state += 1
 
             solution = self.solve_dual(configs, mccormick=configs["mccormick"])
@@ -282,6 +292,7 @@ class QCQPSolver(ProofNode):
 
         y = None
         try:
+            sdp.print_graph(short=2)
             y = sdp.solve(
                 verbose=configs["verbose"],
                 solver=configs["solver"],
@@ -303,9 +314,15 @@ class QCQPSolver(ProofNode):
         eqs = problem.eq_constraints.values()
 
 
+        def uneval_mul(args):
+            if any(v == 0 for v in args):
+                return 0
+            args = [v for v in args if v != 1]
+            return Mul(*args, evaluate=False)
+
         args = [d * row**2 for d, row in zip(D, U * x) if d != 0 and row != 0]\
-            + [(-lam) * val for lam, val in zip(y[:len(ineqs)], ineqs) if lam != 0 and val != 0]\
-            + [(-mu) * val for mu, val in zip(y[len(ineqs):len(ineqs)+len(eqs)], eqs) if mu != 0 and val != 0]
+            + [uneval_mul([-lam, val]) for lam, val in zip(y[:len(ineqs)], ineqs)]\
+            + [uneval_mul([-mu, val]) for mu, val in zip(y[len(ineqs):len(ineqs)+len(eqs)], eqs)]
 
         if mccormick:
             cons = [v for m, v in zip(problem.P_ineqs, problem.ineq_constraints.values())
@@ -313,9 +330,8 @@ class QCQPSolver(ProofNode):
             r = len(cons)
             inds = [i*r + j for i in range(r) for j in range(i+1, r)]
             args.extend([
-                Mul(-lam, cons[i%r], cons[i//r], evaluate=False) for i, lam in zip(inds, y[len(ineqs)+len(eqs):])
-                    if lam != 0 and cons[i%r] != 0 and cons[i//r] != 0
+                uneval_mul([-lam, cons[i%r], cons[i//r]]) for i, lam in zip(inds, y[len(ineqs)+len(eqs):])
             ])
 
-        sol = Add(*args, evaluate=False)
+        sol = Add(*[a for a in args if a != 0], evaluate=False)
         return sol

--- a/triples/core/preprocess/signs.py
+++ b/triples/core/preprocess/signs.py
@@ -106,6 +106,8 @@ def _prove_by_recur(expr: Expr, signs: SIGNS_TYPE) -> Optional[Tuple[Expr, bool]
     `new_expr` is not `expr`. The second argument tracks whether the expr
     has changed.
     """
+    from ...utils.expressions.cyclic import _replace_symbols
+
     if isinstance(expr, Rational):
         if expr >= 0:
             return expr, False
@@ -156,10 +158,21 @@ def _prove_by_recur(expr: Expr, signs: SIGNS_TYPE) -> Optional[Tuple[Expr, bool]
         # all permutations. E.g.
         # `CyclicProduct((a-b),(a,b,c,d),AlternatingGroup(4))`
         # is nonnegative after expanding. However, it is undetermined termwise.
-        sol = _prove_by_recur(expr.doit(deep=False), signs)
-        if sol is not None:
-            return sol[0], True
-        return None
+
+        sub_exprs = []
+        for translation in CyclicExpr._generate_all_translations(
+            expr.args[1], expr.args[2]):
+            trans = _replace_symbols(expr.args[0], translation)
+            sub_result = _prove_by_recur(trans, signs)
+            if sub_result is None:
+                return None
+            sub_exprs.append((sub_result[0], trans))
+
+        if all(v1 == v2 for v1, v2 in sub_exprs):
+            # nothing changed
+            return expr, True
+        sol = expr.base_func(*[v1 for v1, v2 in sub_exprs])
+        return sol, True
 
     if len(expr.free_symbols) == 0:
         # e.g. (sqrt(2) - 1)

--- a/triples/core/preprocess/signs.py
+++ b/triples/core/preprocess/signs.py
@@ -205,6 +205,7 @@ def sign_sos(expr: Union[Expr, Poly], signs: SIGNS_TYPE, factor: bool = False) -
 
     Note that the function bases on heuristics,
     and may fail on expressions that are nonnegative.
+
     >>> sign_sos(a**12 + b**12 + c**12 - 3*a**4*b**4*c**4, signs) is None
     True
     """

--- a/triples/core/problem.py
+++ b/triples/core/problem.py
@@ -773,7 +773,10 @@ class InequalityProblem(Generic[T]):
         self.roots = roots
         return self.roots
 
-    def transform(self, transform: Dict[Symbol, Expr], inv_transform: Dict[Symbol, Expr]) -> Tuple['InequalityProblem', Callable]:
+    def transform(self,
+        transform: Dict[Symbol, Expr],
+        inv_transform: Dict[Symbol, Expr]
+    ) -> Tuple['InequalityProblem', Callable]:
         """
 
 
@@ -788,15 +791,15 @@ class InequalityProblem(Generic[T]):
         >>> new_pro, restore = problem.transform({a:y+z,b:z+x,c:x+y}, {x:(b+c-a)/2,y:(c+a-b)/2, z:(a+b-c)/2})
         >>> new_pro.expr.expand(), new_pro.ineq_constraints # doctest: +NORMALIZE_WHITESPACE
         (2*x**3*z - 2*x**2*y*z + 2*x*y**3 - 2*x*y**2*z - 2*x*y*z**2 + 2*y*z**3,
-         {2*x: F(a), 2*y: F(b), 2*z: F(c)})
+         {2*x: F(y + z), 2*y: F(x + z), 2*z: F(x + y)})
 
         After we find a solution (sympy Expr) to the transformed problem, use `restore` to
         transform it back to the original problem.
-        >>> sol = (F(a)*F(c)*(x-y)**2 + F(b)*F(a)*(y-z)**2 + F(c)*F(b)*(z-x)**2)/2
-        >>> (sol.xreplace({F(a): 2*x, F(b): 2*y, F(c): 2*z}) - new_pro.expr).expand()
+        >>> sol = (-x + z)**2*F(x + y)*F(x + z)/2 + (x - y)**2*F(x + y)*F(y + z)/2 + (y - z)**2*F(x + z)*F(y + z)/2
+        >>> (sol.xreplace({F(y + z): 2*x, F(x + z): 2*y, F(x + y): 2*z}) - new_pro.expr).expand()
         0
         >>> restore(sol) # doctest: +SKIP
-        (-a + b)**2*F(a)*F(c)/2 + (a - c)**2*F(b)*F(c)/2 + (-b + c)**2*F(a)*F(b)/2
+        (-a + b)**2*F(a)*F(b)/2 + (a - c)**2*F(a)*F(c)/2 + (-b + c)**2*F(b)*F(c)/2
         >>> (restore(sol).xreplace({F(a):b+c-a, F(b):c+a-b, F(c):a+b-c}) - problem.expr).expand()
         0
 
@@ -814,6 +817,7 @@ class InequalityProblem(Generic[T]):
             symbols = tuple([_ for _ in self.expr.gens if (_ not in transform)]) + new_symbols
         for src, dst in zip(src_dicts, dst_dicts):
             for p, e in src.items():
+                e = e.xreplace(transform)
                 if isinstance(p, Expr):
                     p = p.xreplace(transform)
                 elif isinstance(p, Poly):
@@ -835,7 +839,8 @@ class InequalityProblem(Generic[T]):
             if x is None:
                 return None
             denom = next(iter(dst_dicts[0].values())).xreplace(inv_transform)
-            return x.xreplace(inv_transform) / denom
+            numer = x.xreplace(inv_transform)
+            return numer / denom
         return problem, restore
 
     def marginalize(self, transform: Dict[Symbol, Expr], diff: Optional[Dict[Symbol, Expr]]=None) -> Tuple['InequalityProblem', Callable]:

--- a/triples/core/problem.py
+++ b/triples/core/problem.py
@@ -19,7 +19,8 @@ from .dispatch import (
 )
 from ..utils import optimize_poly, Root, RootList
 from ..utils.monomials import (
-    verify_closure, _identify_symmetry_from_blackbox
+    verify_closure, _identify_symmetry_from_blackbox,
+    identify_symmetry_from_lists
 )
 
 if TYPE_CHECKING:
@@ -662,6 +663,10 @@ class InequalityProblem(Generic[T]):
         >>> pro.gens
         (a, b, c)
         """
+        if self.is_polynomial:
+            return identify_symmetry_from_lists(
+                [[self.expr], list(self.ineq_constraints), list(self.eq_constraints)]
+            )
         gens = self.gens
         reorder_funcs = self.reduce(lambda x: (x, self._dtype_make_reorder_func(x, gens)), dict)
         ls = [[self.expr], list(self.ineq_constraints), list(self.eq_constraints)]

--- a/triples/core/problem.py
+++ b/triples/core/problem.py
@@ -6,6 +6,7 @@ from sympy import (
     Expr, Symbol, Poly, Integer, Function, Mul, Add, Pow,
     fraction
 )
+from sympy.combinatorics.named_groups import SymmetricGroup
 from sympy.combinatorics.perm_groups import Permutation, PermutationGroup
 from sympy.core.symbol import uniquely_named_symbol
 from sympy.core.sympify import sympify, CantSympify
@@ -19,7 +20,7 @@ from .dispatch import (
 )
 from ..utils import optimize_poly, Root, RootList
 from ..utils.monomials import (
-    verify_closure, _identify_symmetry_from_blackbox,
+    _identify_symmetry_from_action,
     identify_symmetry_from_lists
 )
 
@@ -657,24 +658,26 @@ class InequalityProblem(Generic[T]):
         ----------
         >>> from sympy.abc import a, b, c
         >>> pro = InequalityProblem(a**2*b+b**2*c+c**2*a-3, [a-1, b-1, c-1])
-        >>> pro.identify_symmetry()
-        PermutationGroup([
-            (0 1 2)])
+        >>> pro.identify_symmetry().is_cyclic
+        True
         >>> pro.gens
         (a, b, c)
         """
+        ls = [[self.expr], list(self.ineq_constraints), list(self.eq_constraints)]
+
         if self.is_polynomial:
-            return identify_symmetry_from_lists(
-                [[self.expr], list(self.ineq_constraints), list(self.eq_constraints)]
-            )
+            return identify_symmetry_from_lists(ls)
+
         gens = self.gens
         reorder_funcs = self.reduce(lambda x: (x, self._dtype_make_reorder_func(x, gens)), dict)
-        ls = [[self.expr], list(self.ineq_constraints), list(self.eq_constraints)]
-        def verify_func(perm: Permutation) -> bool:
-            # TODO: we can use int-index for reorder_funcs and ls
-            reorder = lambda x: reorder_funcs[x](perm)
-            return all(verify_closure(l, reorder) for l in ls)
-        return _identify_symmetry_from_blackbox(verify_func, len(gens))
+        def action(x, perm):
+            f = reorder_funcs.get(x)
+            if f is None:
+                f = self._dtype_make_reorder_func(x, gens)
+            return f(perm)
+        return _identify_symmetry_from_action(
+            ls, SymmetricGroup(len(gens)), action
+        )
 
     def wrap_constraints(self, symmetry: Optional[PermutationGroup]=None) -> Tuple['InequalityProblem', Callable]:
         """

--- a/triples/core/sdpsos/sdpsos.py
+++ b/triples/core/sdpsos/sdpsos.py
@@ -227,7 +227,7 @@ class SDPSOSSolver(ProofNode):
     lift_degree_limit: int
         The maximum lift degree to explore. Default is 2.
     wedderburn: bool
-        Use wedderburn decomposition. Defaults to True.
+        Whether to use the wedderburn decomposition. Defaults to True.
     dof_limit: int
         The maximum degree of freedom of the SDP. When it exceeds `dof_limit`,
         the node will be pruned. This prevents crash in external SDP solvers. Default is 7000.
@@ -596,7 +596,7 @@ def SDPSOS(
     lift_degree_limit: int
         The maximum lift degree to explore. Default is 2.
     wedderburn: bool
-        Use wedderburn decomposition. Defaults to True.
+        Whether to use the wedderburn decomposition. Defaults to True.
     dof_limit: int
         The maximum degree of freedom of the SDP. When it exceeds `dof_limit`,
         the node will be pruned. This prevents crash in external SDP solvers. Default is 7000.
@@ -605,6 +605,8 @@ def SDPSOS(
     allow_numer: int
         Whether to allow inexact numerical solution. This is useful when it fails to obtain an
         exact solution by rationalization.
+    solve_kwargs: Dict[str, Any]
+        Extra keyword arguments to pass to the SDP solver.
     ineq_constraints_with_trivial: bool
         Whether to add the trivial inequality constraint 1 >= 0. This is used to generate the
         quadratic module. Default is True.
@@ -616,7 +618,49 @@ def SDPSOS(
         `unstable_eig_threshold`, then it considers the problem as numerically unstable
         and stops further search. Default is -0.1.
     verbose: bool
-        Whether to print the progress. Default is False.
+        Whether to print the progress. If verbose >= 2, it also prints the
+        SDP solver progress. Default is False.
+    time_limit: float
+        The time limit (in seconds) for the solver. Defaults to 3600. When the time limit is
+        reached, the solver is killed when it returns to the main loop.
+        However, it might not be killed instantly if it is stuck in an internal function.
+
+    Examples
+    --------
+    SDPSOS solves inequalities by semidefinite programming (SDP).
+
+    >>> from sympy.abc import a, b, c, d, e, x, y, z
+    >>> sol = SDPSOS(a**3*(a-b)+b**3*(b-c)+c**3*(c-a))
+    >>> sol.solution # doctest: +SKIP
+    (Σ((a - b)**2*(a + b)**2))/8 + (Σ((2*a*b - a*c - b*c)**2))/60 + (Σ((a**2 - a*b - b**2 + b*c)**2))/12
+    + (Σ((-5*a**2 + 2*a*b - 4*a*c - 5*b**2 + 2*b*c + 10*c**2)**2))/360
+    + (Σ((a**2 - a*b - a*c + b**2 - b*c + c**2)**2))/18
+
+    Not all nonnegative forms are SOS of polynomials. The parameter `lift_degree_limit`
+    controls the maximum lift degree to explore.
+
+    >>> sol = SDPSOS((x**2 + y**2 - 3*z**2)*x**2*y**2 + z**6, lift_degree_limit=0)
+    >>> sol is None # because Motzkin's form is not SOS
+    True
+    >>> sol = SDPSOS((x**2 + y**2 - 3*z**2)*x**2*y**2 + z**6, lift_degree_limit=2)
+    >>> sol is not None
+    True
+    >>> sol.solution.doit().together() # doctest: +SKIP
+    (x**2*y**2*(-x + y)**2*(x + y)**2 + x**2*y**2*(x - y)**2*(x + y)**2
+    + 14*x**2*y**2*(x**2 + y**2 - 2*z**2)**2 + 4*z**2*(-x + y)**2*(x*y + z**2)**2
+    + 4*z**2*(x - y)**2*(x*y + z**2)**2 + 8*z**2*(x + y)**2*(x*y - z**2)**2
+    + 8*(x*y - z**2)**2*(x*y + z**2)**2)/(4*(2*z**2 + (-x + y)**2 + (x - y)**2 + 2*(x + y)**2))
+
+
+    ### Specifying Roots
+
+    Currently SDPSOS first identifies the equality cases to apply facial reduction
+    and then solves the problem. However, in some cases, this could be slow or cause
+    numerical instability. To skip the process, pass in `roots = []` (an empty list).
+
+    >>> sol = SDPSOS((a+b+c+d+e)**2-4*(a*b+b*c+c*d+d*e+e*a), [a,b,c,d,e], roots=[])
+    >>> sol.solution # doctest: +SKIP
+    (Σ(a*(a - b + c + d - e)**2) + 4*(Σ(a*b*d)))/(Σ(a))
     """
     problem = ProofNode.new_problem(expr, ineq_constraints, eq_constraints)
     problem.set_roots(roots)

--- a/triples/core/sdpsos/sdpsos.py
+++ b/triples/core/sdpsos/sdpsos.py
@@ -300,7 +300,8 @@ class SDPSOSSolver(ProofNode):
 
             if configs["verbose"]:
                 print(f"Lift Degree = {lift_degree}")
-                print(f"Qmodule = {qmodule}\nIdeal   = {list(eq_constraints.keys())}")
+                print(f"Qmodule = {[p.as_expr() for p in qmodule]}\n"
+                      f"Ideal   = {[p.as_expr() for p in eq_constraints]}")
 
             poly_qmodule_tuples = None
             if poly_qmodule:

--- a/triples/core/sdpsos/sdpsos.py
+++ b/triples/core/sdpsos/sdpsos.py
@@ -629,6 +629,7 @@ def SDPSOS(
     --------
     SDPSOS solves inequalities by semidefinite programming (SDP).
 
+    >>> from triples import SDPSOS
     >>> from sympy.abc import a, b, c, d, e, x, y, z
     >>> sol = SDPSOS(a**3*(a-b)+b**3*(b-c)+c**3*(c-a))
     >>> sol.solution # doctest: +SKIP

--- a/triples/core/solution.py
+++ b/triples/core/solution.py
@@ -446,6 +446,8 @@ class Solution(SolutionBase[T]):
         """
         if homogenizer is None:
             return self
+        if self is None:
+            return self
 
         expr = self
         if isinstance(self, Solution):

--- a/triples/core/solution.py
+++ b/triples/core/solution.py
@@ -1,23 +1,22 @@
 from collections import defaultdict
-import re
-from typing import Tuple, Dict, Union, Optional, TypeVar, Generic, TYPE_CHECKING
+from re import sub as re_sub
+from typing import Tuple, Dict, Union, Optional, TypeVar, Generic
 from warnings import warn
 
 import sympy as sp
 from sympy.core.singleton import S
-from sympy import Poly, Symbol, Float, Equality, Add, Mul
+from sympy import (
+    Poly, Expr, Symbol, Integer, Rational, Float,
+    Equality, Add, Mul, Pow
+)
 from sympy.printing.precedence import precedence_traditional
 from sympy.printing.str import StrPrinter
 from sympy.combinatorics import PermutationGroup, Permutation, CyclicGroup
 from sympy.core.relational import Equality
 
 from .problem import InequalityProblem
-from ..utils.expressions.cyclic import CyclicProduct, CyclicExpr, rewrite_symmetry
+from ..utils.expressions.cyclic import CyclicSum, CyclicProduct, CyclicExpr, rewrite_symmetry
 from ..utils.expressions.psatz import SOSlist, PSatz
-
-if TYPE_CHECKING:
-    from sympy import Expr
-
 
 T = TypeVar('T')
 
@@ -55,9 +54,9 @@ class Solution(SolutionBase[T]):
     method = ''
     def __init__(self,
         problem: Optional[Union[InequalityProblem[T], T]]=None,
-        solution: Optional['Expr']=None,
-        ineq_constraints: Optional[Dict[T, 'Expr']]=None,
-        eq_constraints: Optional[Dict[T, 'Expr']]=None,
+        solution: Optional[Expr]=None,
+        ineq_constraints: Optional[Dict[T, Expr]]=None,
+        eq_constraints: Optional[Dict[T, Expr]]=None,
         is_equal: Optional[bool]=None
     ):
 
@@ -83,11 +82,11 @@ class Solution(SolutionBase[T]):
         return self.problem.expr
 
     @property
-    def ineq_constraints(self) -> Dict[T, 'Expr']:
+    def ineq_constraints(self) -> Dict[T, Expr]:
         return self.problem.ineq_constraints
 
     @property
-    def eq_constraints(self) -> Dict[T, 'Expr']:
+    def eq_constraints(self) -> Dict[T, Expr]:
         return self.problem.eq_constraints
 
     @expr.setter
@@ -96,12 +95,12 @@ class Solution(SolutionBase[T]):
         self.problem.expr = value
 
     @ineq_constraints.setter
-    def ineq_constraints(self, value: Dict[T, 'Expr']):
+    def ineq_constraints(self, value: Dict[T, Expr]):
         """Bypass immutability: directly overwrite the problem inequality constraints; use with care."""
         self.problem.ineq_constraints = value
 
     @eq_constraints.setter
-    def eq_constraints(self, value: Dict[T, 'Expr']):
+    def eq_constraints(self, value: Dict[T, Expr]):
         """Bypass immutability: directly overwrite the problem equality constraints; use with care."""
         self.problem.eq_constraints = value
 
@@ -294,7 +293,7 @@ class Solution(SolutionBase[T]):
             if mode == 'txt':
                 def _convert_superscript(s):
                     pow_trans = str.maketrans('0123456789', '⁰¹²³⁴⁵⁶⁷⁸⁹')
-                    return re.sub(r'\^(\d+)', lambda m: m.group(1).translate(pow_trans), s)
+                    return re_sub(r'\^(\d+)', lambda m: m.group(1).translate(pow_trans), s)
                 to_str = lambda x: _convert_superscript(_to_str(x).replace('*',''))
             else:
                 to_str = lambda x: _to_str(x)
@@ -435,7 +434,7 @@ class Solution(SolutionBase[T]):
         self.solution = self.solution.evalf(*args, **kwargs)
         return self
 
-    def as_expr(self, *args, **kwargs) -> 'Expr':
+    def as_expr(self, *args, **kwargs) -> Expr:
         """
         Return the solution as an expression. It is equivalent to .solution.
         """
@@ -594,7 +593,7 @@ def _arg_sqr_core(arg):
 
 
 
-def _print_str(expr: 'Expr', cyclic_sum_name = 'Σ', cyclic_product_name = '∏',
+def _print_str(expr: Expr, cyclic_sum_name = 'Σ', cyclic_product_name = '∏',
                with_cyclic_parens = False, settings=None):
     """Advanced printing to handle cyclic expressions."""
     settings = {} if settings is None else settings
@@ -612,8 +611,103 @@ def _print_str(expr: 'Expr', cyclic_sum_name = 'Σ', cyclic_product_name = '∏'
     setattr(printer, '_print_CyclicProduct', lambda expr: _print_CyclicProduct(expr))
     return printer.doprint(expr)
 
-def _print_latex(expr: 'Expr', settings=None):
+def _print_latex(expr: Expr, settings=None):
     # if 'long_frac_ratio' not in settings:
     #     settings['long_frac_ratio'] = 2
     settings = {} if settings is None else settings
     return sp.latex(expr, **settings)
+
+
+class _rewriting_exception(Exception): ...
+
+def extract_undetermined_exprs(expr: Expr, F, extra_checker=None) -> Optional[Expr]:
+    """
+    Extract sign-undetermined subexpressions from the given expression
+    and rewrite them with the given function.
+
+    Parameters
+    ----------
+    expr : Expr
+        The input expression.
+    F : Function
+        The function or callable to apply to the undetermined expressions.
+    extra_checker : Callable[[Expr], Optional[Union[bool, Expr]]] | dict | set
+        Optional callable to check if a subexpression is to be parsed.
+        Defaults to None.
+
+    Returns
+    -------
+    Expr
+        The rewritten expression.
+
+    Examples
+    --------
+    >>> from sympy.abc import a,b,c
+    >>> from sympy import Function
+    >>> F = Function('F')
+    >>> extract_undetermined_exprs((a + (b-c)**2*(a**2 + 3))/(b**3 + a), F)
+    ((a**2 + 3)*(b - c)**2 + F(a))/(b**2*F(b) + F(a))
+    """
+    if extra_checker is not None:
+        if isinstance(extra_checker, (set, dict)):
+            _container = extra_checker
+            extra_checker = lambda x: x in _container
+        if not callable(extra_checker):
+            raise TypeError("extra_checker must be a callable or a dict/set.")
+
+    def is_pow2(x):
+        if isinstance(x, Pow):
+            if isinstance(x.exp, Rational) and (x.exp.p % 2 == 0 or x.exp.q % 2 == 0):
+                return True
+        elif len(x.free_symbols) == 0 and x >= 0:
+            return True
+        return False
+
+    def dfs(x):
+        if extra_checker is not None:
+            z = extra_checker(x)
+            if z is not None and (z is not False):
+                return F(x) if z is True else z
+        if isinstance(x, Expr):
+            if len(x.free_symbols) == 0:
+                # constants might be sp.Add, etc., e.g. 1+sqrt(2)
+                # however, using .is_constant() is very slow
+                if x < 0:
+                    raise _rewriting_exception
+                elif x >= 0:
+                    return x
+            if isinstance(x, Symbol):
+                return F(x)
+            elif isinstance(x, (Add, Mul)):
+                return x.func(*(dfs(_) for _ in x.args))
+            elif isinstance(x, Pow):
+                base, exp = x.as_base_exp()
+                if isinstance(exp, Integer):
+                    if exp % 2 == 0:
+                        return x
+                    elif exp == -1:
+                        return 1 / dfs(base)
+                    elif exp > 0:
+                        return dfs(base)*Pow(base, exp - 1, evaluate=False)
+                    else:
+                        return Pow(base, exp + 1, evaluate=False) / dfs(base)
+                elif isinstance(base, Rational):
+                    if exp.p % 2 == 0:
+                        return x
+                return dfs(base)**exp
+            elif isinstance(x, (CyclicSum, CyclicProduct)):
+                base = x.args[0]
+
+                if is_pow2(base): # easy case where we do not need to expand
+                    return x
+                elif isinstance(base, Mul) and all(is_pow2(_) for _ in base.args):
+                    return x
+                # ensure each arg is nonnegative by expanding
+                each_arg = [dfs(_) for _ in x.doit(deep=False).args]
+                assert len(each_arg) >= 0
+                return x.func(dfs(base), *x.args[1:])
+        return x
+    try:
+        return dfs(expr)
+    except _rewriting_exception:
+        return None

--- a/triples/core/structsos/__init__.py
+++ b/triples/core/structsos/__init__.py
@@ -1,8 +1,7 @@
 from .structsos import StructuralSOS, StructuralSOSSolver, _structural_sos
 from .univariate import prove_univariate
-from .solution import SolutionStructural
 
 __all__ = [
     'StructuralSOS', 'StructuralSOSSolver', '_structural_sos',
-    'prove_univariate', 'SolutionStructural'
+    'prove_univariate'
 ]

--- a/triples/core/structsos/constrained/acute.py
+++ b/triples/core/structsos/constrained/acute.py
@@ -4,8 +4,8 @@ from sympy.polys.polyerrors import CoercionFailed
 from ..solution import SolutionStructural
 from ..ternary.utils import CommonExpr
 from ..ternary import (
-    sos_struct_acyclic_quadratic, sos_struct_quartic,
-    sos_struct_cubic, sos_struct_sextic
+    structsos_acyclic_quadratic, structsos_quartic,
+    structsos_cubic, structsos_sextic
 )
 from ..ternary.dense_symmetric import sym_axis, _homogenize_sym_proof
 from ..utils import (
@@ -117,7 +117,7 @@ def _constrained_acute_cubic(coeff: Coeff, F):
         return None if sol is None else sol / CyclicSum(a)
 
     if c300 >= 0:
-        return sos_struct_cubic(coeff)
+        return structsos_cubic(coeff)
     x, y = (c210/-c300), (c111/-c300)
 
     def _solve_trivial(t):
@@ -156,7 +156,7 @@ def _constrained_acute_cubic(coeff: Coeff, F):
         ker2 = CyclicSum((a**2+b**2-c**2)*(c**2+a**2-b**2)*(b-c)**2) + 1/(t - 1)**2/4*CyclicSum((b+c-(2*t-2)*a)*(a-b)*(a-c))**2
         rem = (original * multiplier - ker2).doit().as_poly(a,b,c)
         # print(t, rem)
-        rem_sol = sos_struct_sextic(Coeff(rem))
+        rem_sol = structsos_sextic(Coeff(rem))
         if rem_sol is not None:
             return (rem_sol + ker)/multiplier
 
@@ -274,7 +274,7 @@ def _constrained_acute_quartic(coeff: Coeff, F):
             quad = Coeff({
                 (2,0,0): va2, (1,1,0): vab, (1,0,1): vac, (0,2,0): vb2, (0,1,1): vbc, (0,0,2): vc2
             }, is_rational=coeff.is_rational)
-            sol = sos_struct_acyclic_quadratic(quad)
+            sol = structsos_acyclic_quadratic(quad)
             if sol is not None:
                 return CyclicSum(F(a)*sol)
 
@@ -314,7 +314,7 @@ def _constrained_acute_quartic(coeff: Coeff, F):
         new_coeff = Coeff(
             coeff.as_poly(a,b,c) - x*CyclicSum((b**2+c**2-a**2)*(a-b)*(a-c)).as_poly(a,b,c)
         )
-        sol = sos_struct_quartic(new_coeff)
+        sol = structsos_quartic(new_coeff)
         if sol is not None:
             return sol + 2*x*CyclicSum(F(a)*(2*a+b+c)*(a-b)**2*(a-c)**2)/(CyclicSum(a*(b+c-2*a)**2)+CyclicSum(a*(b-c)**2))
 

--- a/triples/core/structsos/constrained/acute.py
+++ b/triples/core/structsos/constrained/acute.py
@@ -1,7 +1,6 @@
 from sympy import Poly, Function, Integer, Add, sqrt
 from sympy.polys.polyerrors import CoercionFailed
 
-from ..solution import SolutionStructural
 from ..ternary.utils import CommonExpr
 from ..ternary import (
     structsos_acyclic_quadratic, structsos_quartic,
@@ -12,6 +11,7 @@ from ..utils import (
     Coeff, uniquely_named_symbol, rationalize_func
 )
 from ..univariate import prove_univariate
+from ...solution import extract_undetermined_exprs
 
 def constrained_acute(poly, ineq_constraints, eq_constraints):
     gens = poly.gens
@@ -51,7 +51,7 @@ def constrained_acute(poly, ineq_constraints, eq_constraints):
             return None
 
     extra_checker = lambda x: x if isinstance(x, F) else None
-    solution = SolutionStructural._extract_nonnegative_exprs(solution, func_name=Gname, extra_checker=extra_checker)
+    solution = extract_undetermined_exprs(solution, G, extra_checker=extra_checker)
 
     if solution is None:
         return None

--- a/triples/core/structsos/constrained/acute.py
+++ b/triples/core/structsos/constrained/acute.py
@@ -13,7 +13,11 @@ from ..utils import (
 from ..univariate import prove_univariate
 from ...solution import extract_undetermined_exprs
 
-def constrained_acute(poly, ineq_constraints, eq_constraints):
+def constrained_acute(problem):
+    poly = problem.expr
+    ineq_constraints = problem.ineq_constraints
+    eq_constraints = problem.eq_constraints
+
     gens = poly.gens
     if len(gens) != 3:
         return None
@@ -57,14 +61,14 @@ def constrained_acute(poly, ineq_constraints, eq_constraints):
         return None
 
     replacement = {F(a): cons[0], F(b): cons[1], F(c): cons[2]}
-    for k, v in ineq_constraints.items():
-        if len(k.free_symbols) == 1 and k.is_monomial and k.LC() >= 0:
-            replacement[G(k.free_symbols.pop())] = v/k.LC()
+    signs = problem.get_symbol_signs()
+    is_pos = lambda x: (x is not None) and x >= 0
+    replacement.update({G(x): v for x, (sgn, v) in signs.items() if is_pos(sgn)})
+
     solution = solution.xreplace(replacement)
     if solution.has(F) or solution.has(G):
         return None
     return solution
-
 
 
 def _constrained_acute_quadratic(coeff: Coeff, F):

--- a/triples/core/structsos/constrained/solver.py
+++ b/triples/core/structsos/constrained/solver.py
@@ -1,12 +1,10 @@
-from typing import Dict, Optional, Tuple, Callable, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
-
-from .linear import elimination_linear
 from .acute import constrained_acute
 
 if TYPE_CHECKING:
-    from sympy import Poly, Expr
-
+    from sympy import Expr
+    from ...problem import InequalityProblem
 
 
 _SOLVERS = [
@@ -14,27 +12,27 @@ _SOLVERS = [
 ]
 
 def structural_sos_constrained(
-    poly: "Poly", ineq_constraints: Dict["Poly", "Expr"] = {}, eq_constraints: Dict["Poly", "Expr"] = {}
+    problem: "InequalityProblem"
 ) -> Optional["Expr"]:
     """
     Solve general constrained polynomial inequalities by synthetic heuristics.
     """
-    if len(ineq_constraints) == 0:
+    if len(problem.ineq_constraints) == 0:
         return None
 
     for solver in _SOLVERS:
-        solution = solver(poly, ineq_constraints, eq_constraints)
+        solution = solver(problem)
         if solution is not None:
             return solution
 
 
-def structural_sos_constraints_elimination(
-    poly: "Poly", ineq_constraints: Dict["Poly", "Expr"], eq_constraints: Dict["Poly", "Expr"]
-) -> Tuple["Poly", Dict["Poly", "Expr"], Dict["Poly", "Expr"], Callable]:
-    restore = lambda x: x
-    funcs = [
-        elimination_linear
-    ]
-    for func in funcs:
-        poly, ineq_constraints, eq_constraints, restore = func(poly, ineq_constraints, eq_constraints, restore)
-    return poly, ineq_constraints, eq_constraints, restore
+# def structural_sos_constraints_elimination(
+#     poly: "Poly", ineq_constraints: Dict["Poly", "Expr"], eq_constraints: Dict["Poly", "Expr"]
+# ) -> Tuple["Poly", Dict["Poly", "Expr"], Dict["Poly", "Expr"], Callable]:
+#     restore = lambda x: x
+#     funcs = [
+#         elimination_linear
+#     ]
+#     for func in funcs:
+#         poly, ineq_constraints, eq_constraints, restore = func(poly, ineq_constraints, eq_constraints, restore)
+#     return poly, ineq_constraints, eq_constraints, restore

--- a/triples/core/structsos/nvars/__init__.py
+++ b/triples/core/structsos/nvars/__init__.py
@@ -1,9 +1,9 @@
-from .linear import sos_struct_nvars_linear
-from .quadratic import sos_struct_nvars_quadratic
+from .linear import structsos_nvars_linear
+from .quadratic import structsos_nvars_quadratic
 from .solver import structural_sos_nvars
 
 __all__ = [
-    'sos_struct_nvars_linear',
-    'sos_struct_nvars_quadratic',
+    'structsos_nvars_linear',
+    'structsos_nvars_quadratic',
     'structural_sos_nvars'
 ]

--- a/triples/core/structsos/nvars/linear.py
+++ b/triples/core/structsos/nvars/linear.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ....utils import Coeff
 
-def sos_struct_nvars_linear(coeff: "Coeff", **kwargs):
+def structsos_nvars_linear(coeff: "Coeff", **kwargs):
     """
     Solve a linear inequality. Supports non-homogeneous polynomials also.
 

--- a/triples/core/structsos/nvars/quadratic.py
+++ b/triples/core/structsos/nvars/quadratic.py
@@ -193,7 +193,7 @@ def _isotopic_congruence(S: Matrix, vec: List["Expr"]) -> Optional["Expr"]:
     return Add(*cross, *fluct)
 
 
-def sos_struct_nvars_quadratic(coeff: "Coeff", **kwargs):
+def structsos_nvars_quadratic(coeff: "Coeff", **kwargs):
     """
     Solve a quadratic inequality on real numbers. Coeff
     must be homogeneous.
@@ -201,13 +201,13 @@ def sos_struct_nvars_quadratic(coeff: "Coeff", **kwargs):
     mat = make_mat_from_coeff(coeff)
     if mat is None:
         return None
-    solution = sos_struct_nvars_quadratic_real(coeff, mat)
+    solution = structsos_nvars_quadratic_real(coeff, mat)
     if solution is not None:
         return solution
-    return sos_struct_nvars_quadratic_copositive(coeff, mat)
+    return structsos_nvars_quadratic_copositive(coeff, mat)
 
 
-def sos_struct_nvars_quadratic_real(
+def structsos_nvars_quadratic_real(
     coeff: "Coeff", mat: Optional[Matrix]=None, **kwargs
 ):
     """
@@ -233,7 +233,7 @@ def sos_struct_nvars_quadratic_real(
     return _isotopic_congruence(mat, coeff.gens)
 
 
-def sos_struct_nvars_quadratic_copositive(
+def structsos_nvars_quadratic_copositive(
     coeff: "Coeff", mat: Optional[Matrix]=None, **kwargs
 ):
     """TODO: Implement copositive cases, e.g., Motzkin-Straus theorem."""

--- a/triples/core/structsos/nvars/quartic.py
+++ b/triples/core/structsos/nvars/quartic.py
@@ -5,15 +5,15 @@ from ..utils import Coeff, rationalize_func
 from ....sdp import congruence
 from ....utils import verify_symmetry
 
-def sos_struct_nvars_quartic_symmetric(poly, real=True):
+def structsos_nvars_quartic_symmetric(poly, real=True):
     """
     Solve a homogeneous quartic symmetric polynomial inequality on real numbers for nvars >= 4.
     """
     if poly.total_degree() == 4 and verify_symmetry(poly, "sym"):
-        return _sos_struct_nvars_quartic_symmetric_sdp(Coeff(poly))
+        return _structsos_nvars_quartic_symmetric_sdp(Coeff(poly))
 
 
-def _sos_struct_nvars_quartic_symmetric_sdp(coeff: Coeff):
+def _structsos_nvars_quartic_symmetric_sdp(coeff: Coeff):
     """
     If a symmetric quartic polynomial is SOS, then it can be written in the form of
     ```

--- a/triples/core/structsos/nvars/solver.py
+++ b/triples/core/structsos/nvars/solver.py
@@ -5,7 +5,7 @@ from sympy.core.symbol import uniquely_named_symbol
 
 from .quartic import structsos_nvars_quartic_symmetric
 from ..sparse import structsos_common, structsos_degree_specified_solver
-from ..solution import SolutionStructural
+from ...solution import extract_undetermined_exprs
 from ....utils import Coeff
 
 if TYPE_CHECKING:
@@ -83,7 +83,7 @@ def structural_sos_nvars(
     ####################################################################
     func_name = uniquely_named_symbol('G', poly.gens + tuple(ineq_constraints.values()))
     func = Function(func_name)
-    solution = SolutionStructural._extract_nonnegative_exprs(solution, func_name=func_name)
+    solution = extract_undetermined_exprs(solution, func)
     if solution is None:
         return None
 

--- a/triples/core/structsos/nvars/solver.py
+++ b/triples/core/structsos/nvars/solver.py
@@ -3,8 +3,8 @@ from typing import Union, Dict, Optional, TYPE_CHECKING
 from sympy import Function
 from sympy.core.symbol import uniquely_named_symbol
 
-from .quartic import sos_struct_nvars_quartic_symmetric
-from ..sparse import sos_struct_common, sos_struct_degree_specified_solver
+from .quartic import structsos_nvars_quartic_symmetric
+from ..sparse import structsos_common, structsos_degree_specified_solver
 from ..solution import SolutionStructural
 from ....utils import Coeff
 
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from sympy import Poly, Expr
 
 SOLVERS_SYMMETRIC = {
-    4: sos_struct_nvars_quartic_symmetric,
+    4: structsos_nvars_quartic_symmetric,
 }
 
 def _structural_sos_nvars_symmetric(
@@ -26,8 +26,8 @@ def _structural_sos_nvars_symmetric(
     if not isinstance(coeff, Coeff):
         coeff = Coeff(coeff)
 
-    return sos_struct_common(coeff,
-        sos_struct_degree_specified_solver(SOLVERS_SYMMETRIC, homogeneous=True),
+    return structsos_common(coeff,
+        structsos_degree_specified_solver(SOLVERS_SYMMETRIC, homogeneous=True),
         real=real
     )
 
@@ -37,8 +37,8 @@ def _structural_sos_nvars_general(
 ) -> Optional["Expr"]:
     if not isinstance(coeff, Coeff):
         coeff = Coeff(coeff)
-    return sos_struct_common(coeff,
-        sos_struct_degree_specified_solver({}, homogeneous=True),
+    return structsos_common(coeff,
+        structsos_degree_specified_solver({}, homogeneous=True),
         real=real
     )
 

--- a/triples/core/structsos/nvars/solver.py
+++ b/triples/core/structsos/nvars/solver.py
@@ -10,6 +10,7 @@ from ....utils import Coeff
 
 if TYPE_CHECKING:
     from sympy import Poly, Expr
+    from ...problem import InequalityProblem
 
 SOLVERS_SYMMETRIC = {
     4: structsos_nvars_quartic_symmetric,
@@ -44,15 +45,25 @@ def _structural_sos_nvars_general(
 
 
 def structural_sos_nvars(
-    poly: "Poly",
-    ineq_constraints: Dict["Poly", "Expr"] = {},
-    eq_constraints: Dict["Poly", "Expr"] = {}
+    problem: "InequalityProblem"
 ) -> Optional["Expr"]:
     """
     Main function of structural SOS for n-var homogeneous polynomials.
     """
+    poly: "Poly" = problem.expr
+    ineq_constraints = problem.ineq_constraints
+    # eq_constraints = problem.eq_constraints
+
     if not poly.is_homogeneous: # should not happen
         raise ValueError("structural_sos_nvars only supports homogeneous polynomials.")
+
+    signs = problem.get_symbol_signs()
+    is_pos = lambda x: (x is not None) and x >= 0
+    r_plus = all(is_pos(signs.get(x, (-1, -1))[0]) for x in poly.gens)
+
+    if (not r_plus) and poly.total_degree() % 2 == 1:
+        # TODO: try to disprove the problem
+        return None
 
     coeff = Coeff(poly)
     solution = None
@@ -76,10 +87,7 @@ def structural_sos_nvars(
     if solution is None:
         return None
 
-    replacement = {}
-    for k, v in ineq_constraints.items():
-        if len(k.free_symbols) == 1 and k.is_monomial and k.LC() >= 0:
-            replacement[func(k.free_symbols.pop())] = v/k.LC()
+    replacement = {func(x): v for x, (sgn, v) in signs.items() if is_pos(sgn)}
     solution = solution.xreplace(replacement)
 
     if solution.has(func):

--- a/triples/core/structsos/pivoting/bivariate.py
+++ b/triples/core/structsos/pivoting/bivariate.py
@@ -1,9 +1,17 @@
-import sympy as sp
+from typing import Optional, TYPE_CHECKING
+
+from sympy import Poly, Add, Mul, signsimp, together
+from sympy.core import S as Singleton
 from sympy.core.symbol import uniquely_named_symbol
 
 from ..univariate import prove_univariate
 
-def structural_sos_2vars(poly, ineq_constraints, eq_constraints):
+if TYPE_CHECKING:
+    from sympy import Expr
+    from ...problem import InequalityProblem
+
+
+def structural_sos_2vars(problem: "InequalityProblem") -> Optional["Expr"]:
     """
     Solve bivariate homogeneous polynomial inequality. This is equivalent
     to univariate case after dehomogenization.
@@ -12,6 +20,10 @@ def structural_sos_2vars(poly, ineq_constraints, eq_constraints):
     is a convex cone with vertex at the origin on the XY plane. The boundary
     of the cone is linear.
     """
+    poly: "Poly" = problem.expr
+    ineq_constraints = problem.ineq_constraints
+    eq_constraints = problem.eq_constraints
+
     sgn, factors = poly.factor_list()
 
     sols = []
@@ -30,7 +42,7 @@ def structural_sos_2vars(poly, ineq_constraints, eq_constraints):
     if sgn < 0:
         return None
 
-    return sgn * sp.Mul(*sols)
+    return sgn * Mul(*sols)
 
 
 class HalfspaceIntersection2D():
@@ -130,25 +142,25 @@ def _structsos_bivariate_linear_ineq(poly, ineq_constraints, eq_constraints):
     d = poly.homogeneous_order()
 
     def _hom_sos(sos_list, d, numer, denom):
-        numer = sp.signsimp(numer)
-        denom = sp.signsimp(denom)
+        numer = signsimp(numer)
+        denom = signsimp(denom)
         def map_poly(p):
             d2 = p.total_degree()
             all_coeffs = [p.coeff_monomial((d2-i, )) for i in range(d2+1)]
-            expr = sp.Add(*(c*numer**(d2-i)*denom**i for i, c in enumerate(all_coeffs))).expand()
-            expr = sp.signsimp(expr.together())
+            expr = Add(*(c*numer**(d2-i)*denom**i for i, c in enumerate(all_coeffs))).expand()
+            expr = signsimp(expr.together())
             expr = expr**2 * denom**((d//2-d2)*2)
             return expr
         coeffs = [c for c, p in sos_list]
         polys = [map_poly(p) for c, p in sos_list]
-        return sp.Add(*(c*p for c, p in zip(coeffs, polys)))
+        return Add(*(c*p for c, p in zip(coeffs, polys)))
 
     bound = hs.as_bounds()
     if len(bound) == 0:
         if d % 2 != 0:
             return None
         all_coeffs = [poly.coeff_monomial((d-i, i)) for i in range(d+1)]
-        sol = prove_univariate(sp.Poly(all_coeffs, a), (-sp.oo, sp.oo))
+        sol = prove_univariate(Poly(all_coeffs, a), (-Singleton.Infinity, Singleton.Infinity))
         if sol is None:
             return None
         sol = (sol.xreplace({a: a/b}) * b**d).together()
@@ -160,10 +172,10 @@ def _structsos_bivariate_linear_ineq(poly, ineq_constraints, eq_constraints):
         (u, v), expr = bound[0]
         y = uniquely_named_symbol('y', (a, b, *expr.free_symbols))
         poly2 = poly.subs({a: (u - v*y)/(u**2 + v**2), b: (v + u*y)/(u**2 + v**2)}).as_poly(y)
-        sol = prove_univariate(poly2, (-sp.oo, sp.oo), return_type='list')
+        sol = prove_univariate(poly2, (-Singleton.Infinity, Singleton.Infinity), return_type='list')
         if sol is None:
             return None
-        ubva, uavb = sp.signsimp(sp.together(u*b - v*a)), sp.signsimp(sp.together(u*a + v*b))
+        ubva, uavb = signsimp(together(u*b - v*a)), signsimp(together(u*a + v*b))
         if d % 2 == 0:
             sol = _hom_sos(sol[0][1], d, ubva, uavb)
         else:
@@ -177,13 +189,13 @@ def _structsos_bivariate_linear_ineq(poly, ineq_constraints, eq_constraints):
         (w, z), expr2 = bound[1]
         y = uniquely_named_symbol('y', (a, b, *expr1.free_symbols, *expr2.free_symbols))
         poly2 = poly.subs({a: (v*y - z)/(v*w - u*z), b: (u*y - w)/(u*z - v*w)}).as_poly(y)
-        sol = prove_univariate(poly2, (0, sp.oo), return_type='list')
+        sol = prove_univariate(poly2, (0, Singleton.Infinity), return_type='list')
         if sol is None:
             return None
-        wazb, uavb = sp.signsimp(sp.together(w*a + z*b)), sp.signsimp(sp.together(u*a + v*b))
+        wazb, uavb = signsimp(together(w*a + z*b)), signsimp(together(u*a + v*b))
 
-        # p1 = sp.Add(*(c*p.as_expr()**2 for c, p in zip(*sol[0][1:])))
-        # p2 = sp.Add(*(c*p.as_expr()**2 for c, p in zip(*sol[1][1:])))
+        # p1 = Add(*(c*p.as_expr()**2 for c, p in zip(*sol[0][1:])))
+        # p2 = Add(*(c*p.as_expr()**2 for c, p in zip(*sol[1][1:])))
         # if d % 2 == 1:
         #     sol = (expr1 * p1 + expr2 * p2).subs(y, wazb/uavb).together() * uavb**(d-1)
         # elif d >= 2:

--- a/triples/core/structsos/pivoting/bivariate.py
+++ b/triples/core/structsos/pivoting/bivariate.py
@@ -19,10 +19,10 @@ def structural_sos_2vars(poly, ineq_constraints, eq_constraints):
         if multiplicity % 2 == 0:
             sols.append(factor.as_expr() ** multiplicity)
             continue
-        sol = _sos_struct_bivariate_linear_ineq(factor, ineq_constraints, eq_constraints)
+        sol = _structsos_bivariate_linear_ineq(factor, ineq_constraints, eq_constraints)
         if sol is None:
             sgn = -sgn
-            sol = _sos_struct_bivariate_linear_ineq(-factor, ineq_constraints, eq_constraints)
+            sol = _structsos_bivariate_linear_ineq(-factor, ineq_constraints, eq_constraints)
         if sol is None:
             return None
         sols.append(sol ** multiplicity)
@@ -114,7 +114,7 @@ class HalfspaceIntersection2D():
         return list(zip(self.normals, self.exprs))
 
 
-def _sos_struct_bivariate_linear_ineq(poly, ineq_constraints, eq_constraints):
+def _structsos_bivariate_linear_ineq(poly, ineq_constraints, eq_constraints):
     hs = HalfspaceIntersection2D()
 
     for ineq, e in ineq_constraints.items():

--- a/triples/core/structsos/quaternary/cubic.py
+++ b/triples/core/structsos/quaternary/cubic.py
@@ -91,8 +91,8 @@ def _quaternary_cubic_partial_symmetric(coeff: "Coeff", real = False):
 
     c100, c000, c200, c110, c111 = [coeff(_) for _ in [(1,0,0,2), (0,0,0,3), (2,0,0,1), (1,1,0,1), (1,1,1,0)]]
     if c111 == 0:
-        from ..nvars.quadratic import sos_struct_quadratic
-        return sos_struct_quadratic(coeff)
+        from ..nvars.quadratic import structsos_quadratic
+        return structsos_quadratic(coeff)
     elif c111 < 0 or c000 < 0:
         return None
     # normalize

--- a/triples/core/structsos/quaternary/dense_symmetric.py
+++ b/triples/core/structsos/quaternary/dense_symmetric.py
@@ -3,7 +3,7 @@ from typing import Tuple, Optional, TYPE_CHECKING
 from sympy import Poly, Add
 from sympy.combinatorics import PermutationGroup, Permutation
 
-from .utils import CyclicSum, sos_struct_reorder_symmetry
+from .utils import CyclicSum, structsos_reorder_symmetry
 from ..univariate import prove_univariate
 from ....utils import poly_reduce_by_symmetry, arraylize_sp, invarraylize
 
@@ -274,7 +274,7 @@ def _quaternary_dense_symmetric_vanish2_liftfree(coeff: "Coeff", sym=None):
 #
 #####################################################################
 
-@sos_struct_reorder_symmetry(groups=(2, 2))
+@structsos_reorder_symmetry(groups=(2, 2))
 def quaternary_dense_dihedral(coeff: "Coeff"):
     return _quaternary_dense_dihedral_by_level(coeff)
 

--- a/triples/core/structsos/quaternary/quartic_symmetric.py
+++ b/triples/core/structsos/quaternary/quartic_symmetric.py
@@ -89,7 +89,7 @@ def _quaternary_quartic_symmetric_sdp(coeff):
     `F(1,1,1,1) = 0`, then it is sum of squares.
 
     Sum-of-squares symmetric quartic forms are handled
-    generally in `_sos_struct_nvars_quartic_symmetric_sdp`.
+    generally in `_structsos_nvars_quartic_symmetric_sdp`.
 
     Examples
     --------
@@ -107,8 +107,8 @@ def _quaternary_quartic_symmetric_sdp(coeff):
 
     => s(26a4+(236-244*sqrt(2))a3b+(373-198*sqrt(2))a2b2+(1444-1036*sqrt(2))a2bc+(297-202*sqrt(2))abcd)
     """
-    from ..nvars.quartic import _sos_struct_nvars_quartic_symmetric_sdp
-    return _sos_struct_nvars_quartic_symmetric_sdp(coeff)
+    from ..nvars.quartic import _structsos_nvars_quartic_symmetric_sdp
+    return _structsos_nvars_quartic_symmetric_sdp(coeff)
 
 
 def _compute_44_sym_real_full_mat(coeff: Coeff, m11, m33, m, r):

--- a/triples/core/structsos/quaternary/solver.py
+++ b/triples/core/structsos/quaternary/solver.py
@@ -12,7 +12,7 @@ from .dense_symmetric import quaternary_dense_symmetric, quaternary_dense_dihedr
 
 from ..utils import Coeff, PolynomialNonpositiveError, PolynomialUnsolvableError
 from ..sparse import structsos_common, structsos_degree_specified_solver
-from ..solution import SolutionStructural
+from ...solution import extract_undetermined_exprs
 
 if TYPE_CHECKING:
     from sympy import Poly, Expr
@@ -186,7 +186,7 @@ def structural_sos_4vars(
     ####################################################################
     func_name = uniquely_named_symbol('G', poly.gens + tuple(ineq_constraints.values()))
     func = Function(func_name)
-    solution = SolutionStructural._extract_nonnegative_exprs(solution, func_name=func_name)
+    solution = extract_undetermined_exprs(solution, func)
     if solution is None:
         return None
 

--- a/triples/core/structsos/quaternary/solver.py
+++ b/triples/core/structsos/quaternary/solver.py
@@ -16,6 +16,7 @@ from ..solution import SolutionStructural
 
 if TYPE_CHECKING:
     from sympy import Poly, Expr
+    from ...problem import InequalityProblem
 
 
 SOLVERS_CYCLIC = {
@@ -131,17 +132,28 @@ def _structural_sos_4vars_dihedral(
 
 
 def structural_sos_4vars(
-    poly: "Poly",
-    ineq_constraints: Dict["Poly", "Expr"] = {},
-    eq_constraints: Dict["Poly", "Expr"] = {}
+    problem: "InequalityProblem"
 ) -> Optional["Expr"]:
     """
     Main function of structural SOS for 4-var homogeneous polynomials.
     """
+    poly: "Poly" = problem.expr
+    ineq_constraints = problem.ineq_constraints
+    # eq_constraints = problem.eq_constraints
+
     if len(poly.gens) != 4: # should not happen
         raise ValueError("structural_sos_4vars only supports 4-var polynomials.")
     if not poly.is_homogeneous: # should not happen
         raise ValueError("structural_sos_4vars only supports homogeneous polynomials.")
+
+    # check whether the variables are in the nonnegative orthant
+    signs = problem.get_symbol_signs()
+    is_pos = lambda x: (x is not None) and x >= 0
+    r_plus = all(is_pos(signs.get(x, (-1, -1))[0]) for x in poly.gens)
+
+    if (not r_plus) and poly.total_degree() % 2 == 1:
+        # TODO: try to disprove the problem
+        return None
 
     coeff = Coeff(poly)
     solution = None
@@ -178,10 +190,7 @@ def structural_sos_4vars(
     if solution is None:
         return None
 
-    replacement = {}
-    for k, v in ineq_constraints.items():
-        if len(k.free_symbols) == 1 and k.is_monomial and k.LC() >= 0:
-            replacement[func(k.free_symbols.pop())] = v/k.LC()
+    replacement = {func(x): v for x, (sgn, v) in signs.items() if is_pos(sgn)}
     solution = solution.xreplace(replacement)
 
     if solution.has(func):

--- a/triples/core/structsos/quaternary/solver.py
+++ b/triples/core/structsos/quaternary/solver.py
@@ -11,7 +11,7 @@ from .quintic import quaternary_quintic_symmetric
 from .dense_symmetric import quaternary_dense_symmetric, quaternary_dense_dihedral
 
 from ..utils import Coeff, PolynomialNonpositiveError, PolynomialUnsolvableError
-from ..sparse import sos_struct_common, sos_struct_degree_specified_solver
+from ..sparse import structsos_common, structsos_degree_specified_solver
 from ..solution import SolutionStructural
 
 if TYPE_CHECKING:
@@ -43,8 +43,8 @@ def _structural_sos_4vars_symmetric(
     if not isinstance(coeff, Coeff):
         coeff = Coeff(coeff)
 
-    return sos_struct_common(coeff,
-        sos_struct_degree_specified_solver(SOLVERS_SYMMETRIC, homogeneous=True),
+    return structsos_common(coeff,
+        structsos_degree_specified_solver(SOLVERS_SYMMETRIC, homogeneous=True),
         quaternary_dense_symmetric,
         real=real
     )
@@ -60,8 +60,8 @@ def _structural_sos_4vars_cyclic(
     if not isinstance(coeff, Coeff):
         coeff = Coeff(coeff)
 
-    return sos_struct_common(coeff,
-        sos_struct_degree_specified_solver(SOLVERS_CYCLIC, homogeneous=True),
+    return structsos_common(coeff,
+        structsos_degree_specified_solver(SOLVERS_CYCLIC, homogeneous=True),
         real=real
     )
 
@@ -77,8 +77,8 @@ def _structural_sos_4vars_partial_symmetric(
     """
     if not isinstance(coeff, Coeff):
         coeff = Coeff(coeff)
-    return sos_struct_common(coeff,
-        sos_struct_degree_specified_solver(SOLVERS_SYMMETRIC_NONHOM, homogeneous=True),
+    return structsos_common(coeff,
+        structsos_degree_specified_solver(SOLVERS_SYMMETRIC_NONHOM, homogeneous=True),
         real=real
     )
 
@@ -95,8 +95,8 @@ def _structural_sos_4vars_dihedral(
     if not isinstance(coeff, Coeff):
         coeff = Coeff(coeff)
     if coeff.total_degree() <= 2:
-        from ..nvars.quadratic import sos_struct_nvars_quadratic
-        sol = sos_struct_nvars_quadratic(coeff)
+        from ..nvars.quadratic import structsos_nvars_quadratic
+        sol = structsos_nvars_quadratic(coeff)
         if sol is not None:
             return sol
 

--- a/triples/core/structsos/quaternary/utils.py
+++ b/triples/core/structsos/quaternary/utils.py
@@ -1,5 +1,5 @@
 from ..utils import (
-    Coeff, sos_struct_reorder_symmetry,
+    Coeff, structsos_reorder_symmetry,
     radsimp, sum_y_exprs, rationalize_func, quadratic_weighting, zip_longest, intervals, congruence,
     StructuralSOSError, PolynomialNonpositiveError, PolynomialUnsolvableError
 )
@@ -10,7 +10,7 @@ from ....utils import (
 )
 
 (
-    Coeff, sos_struct_reorder_symmetry,
+    Coeff, structsos_reorder_symmetry,
     radsimp, sum_y_exprs, rationalize_func, quadratic_weighting, zip_longest, intervals, congruence,
     StructuralSOSError, PolynomialNonpositiveError, PolynomialUnsolvableError
 )

--- a/triples/core/structsos/solution.py
+++ b/triples/core/structsos/solution.py
@@ -1,6 +1,11 @@
+from warnings import warn
+
+warn("SolutionStructural is deprecated, please use Solution instead.",
+     stacklevel=2, category=DeprecationWarning)
+
 from typing import Optional, Callable
 
-import sympy as sp
+from sympy import Expr, Symbol, Add, Mul, Pow, Integer, Rational, Function
 
 from ..solution import Solution
 from ...utils import CyclicSum, CyclicProduct
@@ -18,7 +23,7 @@ class SolutionStructural(Solution):
             self._is_equal = bool(self.as_eq().simplify())
 
     @classmethod
-    def _extract_nonnegative_exprs(cls, expr: sp.Expr, func_name: str = "_G", extra_checker: Optional[Callable] = None):
+    def _extract_nonnegative_exprs(cls, expr: Expr, func_name: str = "_G", extra_checker: Optional[Callable] = None):
         """
         Raw output of StructuralSOS might assume nonnegativity of some symbols,
         we extract these symbols and replace them with _F(x) for further processing.
@@ -26,62 +31,62 @@ class SolutionStructural(Solution):
         """
         # extract symbol constraints from dict
         # mapping = dict((s.as_expr(), v) for s, v in ineq_constraints.items() if \
-        #             isinstance(s, sp.Symbol) or (isinstance(s, sp.Poly) and s.is_monomial and len(s.free_symbols) == 1 and s.LC() > 0))
+        #             isinstance(s, Symbol) or (isinstance(s, Poly) and s.is_monomial and len(s.free_symbols) == 1 and s.LC() > 0))
         # mapping.update(dict((s.as_expr(), v) for s, v in eq_constraints.items() if s.is_monomial and len(s.free_symbols) == 1 and s.LC() > 0))
 
         # TODO: Handle symbols that represent zero?
-        func = sp.Function(func_name)
+        func = Function(func_name)
         if extra_checker is None:
             extra_checker = lambda x: None
         def dfs(arg):
             checked = extra_checker(arg)
             if checked is not None:
                 return checked
-            if isinstance(arg, sp.Expr):
+            if isinstance(arg, Expr):
                 if len(arg.free_symbols) == 0:
-                    # constants might be sp.Add, etc., e.g. 1+sqrt(2)
+                    # constants might be Add, etc., e.g. 1+sqrt(2)
                     # however, using .is_constant() is very slow
                     if arg < 0:
                         raise _rewriting_exception
-                elif isinstance(arg, sp.Symbol):
+                elif isinstance(arg, Symbol):
                     return func(arg)
                     # v = mapping.get(arg)
                     # if v is not None:
                     #     return v
                     # raise _rewriting_exception
-                elif isinstance(arg, (sp.Add, sp.Mul)):
+                elif isinstance(arg, (Add, Mul)):
                     return arg.func(*(dfs(_) for _ in arg.args))
-                elif isinstance(arg, sp.Pow):
+                elif isinstance(arg, Pow):
                     base, exp = arg.as_base_exp()
-                    if isinstance(exp, sp.Integer):
+                    if isinstance(exp, Integer):
                         if exp % 2 == 0:
                             return arg
                         elif exp == -1:
                             return 1 / dfs(base)
                         elif exp > 0:
-                            return dfs(base)*sp.Pow(base, exp - 1, evaluate=False)
+                            return dfs(base)*Pow(base, exp - 1, evaluate=False)
                         else:
-                            return sp.Pow(base, exp + 1, evaluate=False) / dfs(base)
-                    elif isinstance(base, sp.Rational):
+                            return Pow(base, exp + 1, evaluate=False) / dfs(base)
+                    elif isinstance(base, Rational):
                         if exp.p % 2 == 0:
                             return arg
                     return dfs(base)**exp
                 elif isinstance(arg, (CyclicSum, CyclicProduct)):
                     base = arg.args[0]
                     def is_pow2(x):
-                        if isinstance(x, sp.Pow):
-                            if isinstance(x.exp, sp.Rational) and x.exp.p % 2 == 0:
+                        if isinstance(x, Pow):
+                            if isinstance(x.exp, Rational) and x.exp.p % 2 == 0:
                                 return True
-                        #     elif isinstance(x.base, sp.Symbol) and mapping.get(x.base) is not None:
+                        #     elif isinstance(x.base, Symbol) and mapping.get(x.base) is not None:
                         #         return True
-                        # elif isinstance(x, sp.Symbol) and mapping.get(x) is not None:
+                        # elif isinstance(x, Symbol) and mapping.get(x) is not None:
                         #     return True
                         elif len(x.free_symbols) == 0 and x >= 0:
                             return True
                         return False
                     if is_pow2(base): # easy case where we do not need to expand
                         return arg
-                    elif isinstance(base, sp.Mul) and all(is_pow2(_) for _ in base.args):
+                    elif isinstance(base, Mul) and all(is_pow2(_) for _ in base.args):
                         return arg
                     # ensure each arg is nonnegative by expanding
                     each_arg = [dfs(_) for _ in arg.doit(deep=False).args]

--- a/triples/core/structsos/sparse.py
+++ b/triples/core/structsos/sparse.py
@@ -8,9 +8,14 @@ from ...utils import CyclicProduct
 def _null_solver(*args, **kwargs):
     return None
 
-def structsos_extract_factors(poly: Union[Poly, Coeff], solver: Callable, real: bool = True, **kwargs):
+def structsos_extract_factors(
+    poly: Union[Poly, Coeff],
+    solver: Callable,
+    real: int = 1,
+    **kwargs
+):
     """
-    Wrap a solver to handle factorizable polynomials in advance.
+    Wrap a solver to handle special polynomials in advance.
 
     Cases.
     + If the polynomial is a*b*c * f(a,b,c), it first solves f(a,b,c) and then multiplies the result by a*b*c.
@@ -39,7 +44,9 @@ def structsos_extract_factors(poly: Union[Poly, Coeff], solver: Callable, real: 
     i, new_coeff = coeff.cancel_k()
     if i > 1:
         new_coeff = coeff_to_poly(new_coeff)
-        solution = solver(new_coeff, real = False if (i % 2 == 0) else real, **kwargs)
+        solution = solver(new_coeff,
+                          real = min(int(real), 1) if (i % 2 == 0) else real,
+                          **kwargs)
         if solution is not None:
             solution = solution.xreplace({s: s**i for s in symbols})
             return solution
@@ -79,7 +86,10 @@ def structsos_common(poly: Union[Poly, Coeff], *solvers, **kwargs):
 
 
 
-def structsos_degree_specified_solver(solvers: Dict[int, Callable], homogeneous: bool = False) -> Callable:
+def structsos_degree_specified_solver(
+    solvers: Dict[int, Callable],
+    homogeneous: bool = False
+)-> Callable:
     """
     A method wrapper for structural SOS with degree specified solvers.
 
@@ -91,6 +101,8 @@ def structsos_degree_specified_solver(solvers: Dict[int, Callable], homogeneous:
             degree = poly.total_degree()
         else:
             degree = poly.total_degree()
+        if degree % 2 == 1 and int(kwargs.get("real", 0)) >= 2:
+            return None
         solver = solvers.get(degree, None)
         if solver is None:
             from .nvars import structsos_nvars_linear, structsos_nvars_quadratic

--- a/triples/core/structsos/sparse.py
+++ b/triples/core/structsos/sparse.py
@@ -8,7 +8,7 @@ from ...utils import CyclicProduct
 def _null_solver(*args, **kwargs):
     return None
 
-def sos_struct_extract_factors(poly: Union[Poly, Coeff], solver: Callable, real: bool = True, **kwargs):
+def structsos_extract_factors(poly: Union[Poly, Coeff], solver: Callable, real: bool = True, **kwargs):
     """
     Wrap a solver to handle factorizable polynomials in advance.
 
@@ -48,7 +48,7 @@ def sos_struct_extract_factors(poly: Union[Poly, Coeff], solver: Callable, real:
     return solver(poly, **kwargs)
 
 
-def sos_struct_common(poly: Union[Poly, Coeff], *solvers, **kwargs):
+def structsos_common(poly: Union[Poly, Coeff], *solvers, **kwargs):
     """
     A method wrapper for multiple solvers.
     """
@@ -75,30 +75,30 @@ def sos_struct_common(poly: Union[Poly, Coeff], *solvers, **kwargs):
 
     # cancel abc
 
-    return sos_struct_extract_factors(poly, _wrapped_solver, **kwargs)
+    return structsos_extract_factors(poly, _wrapped_solver, **kwargs)
 
 
 
-def sos_struct_degree_specified_solver(solvers: Dict[int, Callable], homogeneous: bool = False) -> Callable:
+def structsos_degree_specified_solver(solvers: Dict[int, Callable], homogeneous: bool = False) -> Callable:
     """
     A method wrapper for structural SOS with degree specified solvers.
 
     When `degree <= 2` and the solver is not provided, it uses the default solvers
     from `triples.core.structsos.nvars` for general linear and quadratic solvers.
     """
-    def _sos_struct_degree_specified_solver(poly: Union[Poly, Coeff], *args, **kwargs):
+    def _structsos_degree_specified_solver(poly: Union[Poly, Coeff], *args, **kwargs):
         if homogeneous and isinstance(poly, Coeff):
             degree = poly.total_degree()
         else:
             degree = poly.total_degree()
         solver = solvers.get(degree, None)
         if solver is None:
-            from .nvars import sos_struct_nvars_linear, sos_struct_nvars_quadratic
+            from .nvars import structsos_nvars_linear, structsos_nvars_quadratic
             if degree == 1:
-                solver = sos_struct_nvars_linear
+                solver = structsos_nvars_linear
             elif degree == 2:
-                solver = sos_struct_nvars_quadratic
+                solver = structsos_nvars_quadratic
             else:
                 solver = _null_solver
         return solver(poly, *args, **kwargs)
-    return _sos_struct_degree_specified_solver
+    return _structsos_degree_specified_solver

--- a/triples/core/structsos/structsos.py
+++ b/triples/core/structsos/structsos.py
@@ -1,9 +1,8 @@
 from typing import List, Dict, Union, Optional, TYPE_CHECKING
 
-from sympy import Integer, construct_domain
+from sympy import construct_domain
 from sympy.polys.polyerrors import BasePolynomialError
 
-from .utils import clear_free_symbols
 from .constrained import structural_sos_constrained
 from .pivoting    import structural_sos_2vars
 from .ternary     import structural_sos_3vars
@@ -16,7 +15,6 @@ from ..solution import Solution
 
 if TYPE_CHECKING:
     from sympy import Poly, Expr
-    from .solution import SolutionStructural
     from ..problem import InequalityProblem
 
 class StructuralSOSSolver(ProofNode):
@@ -47,7 +45,7 @@ def StructuralSOS(
     *,
     verbose: Union[bool, int] = False,
     raise_exception: bool = False,
-) -> Optional["SolutionStructural"]:
+) -> Optional["Solution"]:
     """
     A rule-based expert system to solve polynomial inequalities in specific structures.
     Most algorithms run in O(1) or linear time.
@@ -86,12 +84,15 @@ def _structural_sos(problem: "InequalityProblem") -> "Expr":
     Internal function of StructuralSOS, returns a sympy expression only.
     The polynomial must be homogeneous. TODO: remove the homogeneous requirement?
     """
+    problem = problem.remove_redundancy()
+
     poly: "Poly" = problem.expr
     ineq_constraints = problem.ineq_constraints
     eq_constraints = problem.eq_constraints
 
     if poly.is_zero:
-        return Integer(0)
+        return poly.as_expr()
+
     d = poly.total_degree()
     nvars = len(poly.gens)
     if poly.is_monomial:
@@ -99,8 +100,6 @@ def _structural_sos(problem: "InequalityProblem") -> "Expr":
             # since the poly is homogeneous, it must be a monomial
             return poly.as_expr()
         return None
-
-    poly, ineq_constraints, eq_constraints = clear_free_symbols(poly, ineq_constraints, eq_constraints)
 
     if poly.domain.is_EX or poly.domain.is_EXRAW:
         # cast the polynomial to an extended domain

--- a/triples/core/structsos/structsos.py
+++ b/triples/core/structsos/structsos.py
@@ -162,6 +162,6 @@ def _structural_sos(problem: "InequalityProblem") -> "Expr":
         solution = structural_sos_nvars(problem)
 
     if solution is None:
-        solution = structural_sos_constrained(poly, ineq_constraints, eq_constraints)
+        solution = structural_sos_constrained(problem)
 
     return solution

--- a/triples/core/structsos/structsos.py
+++ b/triples/core/structsos/structsos.py
@@ -17,13 +17,14 @@ from ..solution import Solution
 if TYPE_CHECKING:
     from sympy import Poly, Expr
     from .solution import SolutionStructural
+    from ..problem import InequalityProblem
 
 class StructuralSOSSolver(ProofNode):
     def explore(self, configs):
         if self.state == 0:
             problem, _homogenizer = self.problem.homogenize()
 
-            solution = _structural_sos(problem.expr, problem.ineq_constraints, problem.eq_constraints)
+            solution = _structural_sos(problem)
 
             if solution is not None:
                 if _homogenizer is not None:
@@ -80,11 +81,15 @@ def StructuralSOS(
     return problem.sum_of_squares(configs)
 
 
-def _structural_sos(poly: "Poly", ineq_constraints: Dict["Poly", "Expr"] = {}, eq_constraints: Dict["Poly", "Expr"] = {}) -> "Expr":
+def _structural_sos(problem: "InequalityProblem") -> "Expr":
     """
     Internal function of StructuralSOS, returns a sympy expression only.
     The polynomial must be homogeneous. TODO: remove the homogeneous requirement?
     """
+    poly: "Poly" = problem.expr
+    ineq_constraints = problem.ineq_constraints
+    eq_constraints = problem.eq_constraints
+
     if poly.is_zero:
         return Integer(0)
     d = poly.total_degree()
@@ -113,14 +118,14 @@ def _structural_sos(poly: "Poly", ineq_constraints: Dict["Poly", "Expr"] = {}, e
     solution = None
     if nvars == 2:
         # homogeneous bivariate
-        solution = structural_sos_2vars(poly, ineq_constraints, eq_constraints)
+        solution = structural_sos_2vars(problem)
     elif nvars == 3:
-        solution = structural_sos_3vars(poly, ineq_constraints, eq_constraints)
+        solution = structural_sos_3vars(problem)
     elif nvars == 4:
-        solution = structural_sos_4vars(poly, ineq_constraints, eq_constraints)
+        solution = structural_sos_4vars(problem)
 
     if solution is None and nvars > 3:
-        solution = structural_sos_nvars(poly, ineq_constraints, eq_constraints)
+        solution = structural_sos_nvars(problem)
 
     if solution is None:
         solution = structural_sos_constrained(poly, ineq_constraints, eq_constraints)

--- a/triples/core/structsos/structsos.py
+++ b/triples/core/structsos/structsos.py
@@ -68,6 +68,41 @@ def StructuralSOS(
     -------
     solution: Solution
 
+    Examples
+    --------
+    StructuralSOS uses an expert system to solve inequalities in specific structures. Many
+    classical Olympiad-level ternary symmetric or cyclic inequalities are supported.
+
+    >>> from triples import StructuralSOS, CyclicSum
+    >>> from sympy.abc import a, b, c
+    >>> sol = StructuralSOS(a**4*(a-b)*(a-c)+b**4*(b-c)*(b-a)+c**4*(c-a)*(c-b)
+    ... -5*(a-b)**2*(b-c)**2*(c-a)**2, [a,b,c])
+    >>> sol.solution # doctest:+SKIP
+    4*((Σ(a**2*(a - b)*(a - c)))**2/4 + (Σ(a**2*(b - c)**2*(a**2 - 2*a*b - 2*a*c + b**2 + 2*b*c + c**2)**2))/8
+    + (Σ(a*b*(a - b)**2*(a**2 - 2*a*b + 2*a*c + b**2 + 2*b*c - 3*c**2)**2))/4)/(Σ(a**2))
+
+    StructuralSOS uses very fast (but incomplete) algorithms, and extends to high-degree
+    or high-dimensional problems in some cases.
+
+    >>> sol = StructuralSOS(a**30*(a-b)*(a-c)+b**30*(b-c)*(b-a)+c**30*(c-a)*(c-b), [a,b,c])
+    >>> sol is not None
+    True
+    >>> sol.time # doctest:+SKIP
+    0.191594
+
+    Sometimes StructuralSOS better handles problems with ill-conditioned or irrational
+    coefficients than other numerical algorithms.
+
+    >>> from sympy import sqrt
+    >>> sol = StructuralSOS(CyclicSum(a**3-a**2*b + (sqrt(13+16*sqrt(2))-1)/2*a*b*(b-a),
+    ... (a,b,c)), [a,b,c])
+    >>> sol.solution # doctest:+SKIP
+    (2*(∏(a))*(Σ((a - b)**2)) + (Σ(a*(14*b**2 + b*(-a + c)*(-3*sqrt(13 + 16*sqrt(2))
+    + 7 + sqrt(2)*sqrt(13 + 16*sqrt(2)) + 7*sqrt(2)) - 14*c**2 + c*(a - b)*(
+    -sqrt(2)*sqrt(13 + 16*sqrt(2)) + 7 + 7*sqrt(2) + 3*sqrt(13 + 16*sqrt(2))))**2))/98)/(2*(Σ(a*b)))
+
+    However, StructuralSOS is not a complete solver and it does not solve general inequality
+    problems. It only provides a quick check to see whether a problem can be easily solved.
     """
     from ..node import ProofTree
     problem = ProofNode.new_problem(expr, ineq_constraints, eq_constraints)

--- a/triples/core/structsos/structsos.py
+++ b/triples/core/structsos/structsos.py
@@ -122,8 +122,8 @@ def _structural_sos(problem: "InequalityProblem") -> "Expr":
     problem = problem.remove_redundancy()
 
     poly: "Poly" = problem.expr
-    ineq_constraints = problem.ineq_constraints
-    eq_constraints = problem.eq_constraints
+    # ineq_constraints = problem.ineq_constraints
+    # eq_constraints = problem.eq_constraints
 
     if poly.is_zero:
         return poly.as_expr()

--- a/triples/core/structsos/ternary/__init__.py
+++ b/triples/core/structsos/ternary/__init__.py
@@ -1,35 +1,35 @@
-from .sparse  import sos_struct_sparse, sos_struct_heuristic
-from .dense_symmetric import sos_struct_dense_symmetric, sos_struct_liftfree_for_six
-from .quadratic import sos_struct_quadratic, sos_struct_acyclic_quadratic
-from .cubic   import sos_struct_cubic, sos_struct_acyclic_cubic
-from .quartic import sos_struct_quartic, sos_struct_acyclic_quartic
-from .quintic import sos_struct_quintic
-from .sextic  import sos_struct_sextic
-from .septic  import sos_struct_septic
-from .octic   import sos_struct_octic
-from .nonic   import sos_struct_nonic
-from .acyclic import sos_struct_acyclic_sparse
+from .sparse  import structsos_sparse, structsos_heuristic
+from .dense_symmetric import structsos_dense_symmetric, structsos_liftfree_for_six
+from .quadratic import structsos_quadratic, structsos_acyclic_quadratic
+from .cubic   import structsos_cubic, structsos_acyclic_cubic
+from .quartic import structsos_quartic, structsos_acyclic_quartic
+from .quintic import structsos_quintic
+from .sextic  import structsos_sextic
+from .septic  import structsos_septic
+from .octic   import structsos_octic
+from .nonic   import structsos_nonic
+from .acyclic import structsos_acyclic_sparse
 
 from .solver import structural_sos_3vars, _structural_sos_3vars_cyclic, _structural_sos_3vars_acyclic
 
 
 __all__ = [
-    'sos_struct_sparse',
-    'sos_struct_heuristic',
-    'sos_struct_dense_symmetric',
-    'sos_struct_liftfree_for_six',
-    'sos_struct_quadratic',
-    'sos_struct_acyclic_quadratic',
-    'sos_struct_cubic',
-    'sos_struct_acyclic_cubic',
-    'sos_struct_quartic',
-    'sos_struct_acyclic_quartic',
-    'sos_struct_quintic',
-    'sos_struct_sextic',
-    'sos_struct_septic',
-    'sos_struct_octic',
-    'sos_struct_nonic',
-    'sos_struct_acyclic_sparse',
+    'structsos_sparse',
+    'structsos_heuristic',
+    'structsos_dense_symmetric',
+    'structsos_liftfree_for_six',
+    'structsos_quadratic',
+    'structsos_acyclic_quadratic',
+    'structsos_cubic',
+    'structsos_acyclic_cubic',
+    'structsos_quartic',
+    'structsos_acyclic_quartic',
+    'structsos_quintic',
+    'structsos_sextic',
+    'structsos_septic',
+    'structsos_octic',
+    'structsos_nonic',
+    'structsos_acyclic_sparse',
     'structural_sos_3vars',
     '_structural_sos_3vars_cyclic',
     '_structural_sos_3vars_acyclic'

--- a/triples/core/structsos/ternary/acyclic.py
+++ b/triples/core/structsos/ternary/acyclic.py
@@ -1,6 +1,6 @@
 
 
-def sos_struct_acyclic_sparse(coeff, real = True):
+def structsos_acyclic_sparse(coeff, real = True):
     """
     Solve acyclic 3-var polynomial inequalities.
     """

--- a/triples/core/structsos/ternary/cubic.py
+++ b/triples/core/structsos/ternary/cubic.py
@@ -9,9 +9,7 @@ from .utils import (
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .utils import (
-        Coeff
-    )
+    from .utils import Coeff
 
 def structsos_cubic(coeff, real = True):
     """

--- a/triples/core/structsos/ternary/cubic.py
+++ b/triples/core/structsos/ternary/cubic.py
@@ -4,7 +4,7 @@ from sympy import oo as Infinity
 from .utils import (
     CommonExpr,
     sum_y_exprs, rationalize_func, quadratic_weighting,
-    sos_struct_reorder_symmetry
+    structsos_reorder_symmetry
 )
 from typing import TYPE_CHECKING
 
@@ -13,28 +13,28 @@ if TYPE_CHECKING:
         Coeff
     )
 
-def sos_struct_cubic(coeff, real = True):
+def structsos_cubic(coeff, real = True):
     """
     Solve cyclic cubic polynomials.
 
     This function supports irrational coefficients.
     """
     if coeff((2,1,0)) == coeff((1,2,0)):
-        return _sos_struct_cubic_symmetric(coeff)
+        return _structsos_cubic_symmetric(coeff)
     if coeff((3,0,0)) == 0:
-        return _sos_struct_cubic_degenerate(coeff)
+        return _structsos_cubic_degenerate(coeff)
 
     if not coeff.is_rational:
-        return _sos_struct_cubic_nontrivial_irrational(coeff)
+        return _structsos_cubic_nontrivial_irrational(coeff)
 
-    solution = _sos_struct_cubic_parabola(coeff)
+    solution = _structsos_cubic_parabola(coeff)
     if solution is not None:
         return solution
 
-    return _sos_struct_cubic_nontrivial(coeff)
+    return _structsos_cubic_nontrivial(coeff)
 
 
-def _sos_struct_cubic_symmetric(coeff: "Coeff"):
+def _structsos_cubic_symmetric(coeff: "Coeff"):
     """
     Cubic symmetric inequality can be handled with Schur.
     """
@@ -73,7 +73,7 @@ def _sos_struct_cubic_symmetric(coeff: "Coeff"):
     return None
 
 
-def _sos_struct_cubic_degenerate(coeff: "Coeff"):
+def _structsos_cubic_degenerate(coeff: "Coeff"):
     a, b, c = coeff.gens
     CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
 
@@ -89,7 +89,7 @@ def _sos_struct_cubic_degenerate(coeff: "Coeff"):
              + rem * CyclicProduct(a)
 
 
-def _sos_struct_cubic_parabola(coeff: "Coeff"):
+def _structsos_cubic_parabola(coeff: "Coeff"):
     """
     Although we can always multiply s(a) to convert the problem to a quartic one,
     sometimes the cubic inequality does not need to higher the degree.
@@ -140,7 +140,7 @@ def _sos_struct_cubic_parabola(coeff: "Coeff"):
     return None
 
 
-def _sos_struct_cubic_nontrivial(coeff: "Coeff"):
+def _structsos_cubic_nontrivial(coeff: "Coeff"):
     """
     Solve nontrivial cyclic cubic polynomial by multiplying s(a).
 
@@ -215,7 +215,7 @@ def _sos_struct_cubic_nontrivial(coeff: "Coeff"):
     return sum_y_exprs(y, exprs) / CyclicSum(a)
 
 
-def _sos_struct_cubic_nontrivial_irrational(coeff: "Coeff"):
+def _structsos_cubic_nontrivial_irrational(coeff: "Coeff"):
     """
     Use ultimate theorem for cubic to handle general cases, including irrational coefficients.
 
@@ -292,7 +292,7 @@ def _sos_struct_cubic_nontrivial_irrational(coeff: "Coeff"):
 #
 #####################################################################
 
-def sos_struct_acyclic_cubic(coeff, real = True):
+def structsos_acyclic_cubic(coeff, real = True):
     """
     Solve acyclic cubic polynomials.
 
@@ -302,17 +302,17 @@ def sos_struct_acyclic_cubic(coeff, real = True):
     the two gives four intersections, a contradiction to degree 3. Tightest cubic
     polynomials can have one zero in the interior and three zeros on the borders.
     """
-    solution = _sos_struct_acyclic_cubic_symmetric(coeff)
+    solution = _structsos_acyclic_cubic_symmetric(coeff)
     if solution is not None:
         return solution
 
-    solution = _sos_struct_acyclic_cubic_hexagon(coeff)
+    solution = _structsos_acyclic_cubic_hexagon(coeff)
     if solution is not None:
         return solution
 
 
 
-def _sos_struct_acyclic_cubic_hexagon(coeff: "Coeff"):
+def _structsos_acyclic_cubic_hexagon(coeff: "Coeff"):
     """
     Solve acyclic cubics in the form of
     ?a^2b+?ab^2+?ac^2+?bc^2+?a^2c+?b^2c >= ??abc.
@@ -361,8 +361,8 @@ def _sos_struct_acyclic_cubic_hexagon(coeff: "Coeff"):
         return sum(exprs) + (center - sum(zs))*(a*b*c)
 
 
-@sos_struct_reorder_symmetry(groups=(2, 1))
-def _sos_struct_acyclic_cubic_symmetric(coeff: "Coeff"):
+@structsos_reorder_symmetry(groups=(2, 1))
+def _structsos_acyclic_cubic_symmetric(coeff: "Coeff"):
     """
     Solve acyclic cubic polynomials that are symmetric with respect to two variables.
 

--- a/triples/core/structsos/ternary/dense_symmetric.py
+++ b/triples/core/structsos/ternary/dense_symmetric.py
@@ -9,7 +9,7 @@ from sympy.external.gmpy import sqrt as isqrt
 from sympy.utilities import subsets
 
 from .utils import (
-    sos_struct_handle_uncentered, sos_struct_reorder_symmetry,
+    structsos_handle_uncentered, structsos_reorder_symmetry,
 )
 from ..univariate import prove_univariate
 from ....utils import verify_symmetry, poly_reduce_by_symmetry
@@ -57,30 +57,30 @@ def _linear_invert(u, v, d: int = 0) -> Optional[Tuple[int, 'Expr', 'Expr']]:
     return n, u2, v2
 
 
-def sos_struct_dense_symmetric(coeff, real=True):
+def structsos_dense_symmetric(coeff, real=True):
     """
     Solve dense 3-var symmetric inequalities.
     Triggered only when the degree is at least 8 and the polynomial is symmetric.
     """
     if coeff.total_degree() < 8 or not coeff.is_symmetric():
         return None
-    return _sos_struct_dense_symmetric(coeff, real)
+    return _structsos_dense_symmetric(coeff, real)
 
 
-def _sos_struct_dense_symmetric(coeff, real=True):
+def _structsos_dense_symmetric(coeff, real=True):
     """
     Solve dense 3-var symmetric inequalities. This function
     does not check the symmetry of the input polynomial, so it
     should only be called when the symmetry is guaranteed.
     """
     d = coeff.total_degree()
-    methods = [_sos_struct_trivial_additive]
+    methods = [_structsos_trivial_additive]
     if d < 8:
         from .solver import _structural_sos_3vars_cyclic
         methods.append(_structural_sos_3vars_cyclic)
     else:
-        methods.append(sos_struct_liftfree_for_six)
-        methods.append(_sos_struct_lift_for_six)
+        methods.append(structsos_liftfree_for_six)
+        methods.append(_structsos_lift_for_six)
 
     for method in methods:
         solution = method(coeff, real=real)
@@ -88,7 +88,7 @@ def _sos_struct_dense_symmetric(coeff, real=True):
             return solution
 
 
-def _sos_struct_trivial_additive(coeff: 'Coeff', real=True):
+def _structsos_trivial_additive(coeff: 'Coeff', real=True):
     """
     Solve trivial cyclic inequalities with nonnegative coefficients.
     """
@@ -157,8 +157,8 @@ def _homogenize_sym_proof(coeff: 'Coeff', sym_proof, d: int) -> 'Expr':
     return Add(*exprs)
 
 
-@sos_struct_handle_uncentered
-def _sos_struct_lift_for_six(coeff: 'Coeff', real=True):
+@structsos_handle_uncentered
+def _structsos_lift_for_six(coeff: 'Coeff', real=True):
     """
     Solve high-degree (dense) symmetric inequalities by the method
     of lifting the degree for six. Idea: define f(a,1,1) to be the
@@ -199,7 +199,7 @@ def _sos_struct_lift_for_six(coeff: 'Coeff', real=True):
         if all(m % 2 == 0 for _, m in factors):
             # XXX: currently modp factorization is slow
             # unless flint is installed
-            sol = _sos_struct_complex_factorizable(coeff,
+            sol = _structsos_complex_factorizable(coeff,
                     modp=(FLINT_VERSION >= (0, 7, 0)))
             if sol is not None:
                 return sol
@@ -227,7 +227,7 @@ def _sos_struct_lift_for_six(coeff: 'Coeff', real=True):
     for mul, tail in multipliers:
         diff = compute_diff(coeff, lifted_sym, mul, tail)
         # print(diff.as_poly((a,b,c)).as_expr())
-        sol_diff = _sos_struct_dense_symmetric(diff)
+        sol_diff = _structsos_dense_symmetric(diff)
         if sol_diff is not None:
             return Add(
                 CyclicSum(lifted_sym * tail),
@@ -235,8 +235,8 @@ def _sos_struct_lift_for_six(coeff: 'Coeff', real=True):
             ) / mul
 
 
-@sos_struct_handle_uncentered
-def sos_struct_liftfree_for_six(coeff: 'Coeff', real=True):
+@structsos_handle_uncentered
+def structsos_liftfree_for_six(coeff: 'Coeff', real=True):
     """
     Solve high-degree (dense) symmetric inequalities without
     lifting the degree. This will be tried in prior because
@@ -273,7 +273,7 @@ def sos_struct_liftfree_for_six(coeff: 'Coeff', real=True):
 
     div2 = div[0].div(Poly([1,-2,1], a, domain=sym.domain))
     if div2[1].is_zero:
-        return _sos_struct_liftfree_for_six_ord4(coeff, div2[0], real=real)
+        return _structsos_liftfree_for_six_ord4(coeff, div2[0], real=real)
 
     # subtract some s(a^n*b^m*c^m*(a-b)*(a-c)*(a + (b+c))) + p(a-b)^2*...
     # so that the symmetric axis of the remaining part is a multiple of (a-1)^4
@@ -324,12 +324,12 @@ def sos_struct_liftfree_for_six(coeff: 'Coeff', real=True):
         # subtract s(a^n*b^m*c^m*(u2*a*(b+c)/2 + v2*b*c)*(a-b)*(a-c)) + p(a-b)^2*...
         subtractor = u2 * _subtractor2(n+1, m) + v2 * _subtractor1(n, m+1)
     rem_poly = coeff - coeff.from_poly(subtractor.doit().as_poly(a,b,c,domain=coeff.domain))
-    solution = _sos_struct_liftfree_for_six_ord4(rem_poly, real=real)
+    solution = _structsos_liftfree_for_six_ord4(rem_poly, real=real)
     if solution is not None:
         return subtractor + solution
 
 
-def _sos_struct_liftfree_for_six_ord4(coeff: 'Coeff', div2=None, real=True):
+def _structsos_liftfree_for_six_ord4(coeff: 'Coeff', div2=None, real=True):
     """
     Solve a high-degree (dense) symmetric inequality where (a-1)^4 is a factor
     of the symmetric axis. Such polynomial can be seen as:
@@ -360,7 +360,7 @@ def _sos_struct_liftfree_for_six_ord4(coeff: 'Coeff', div2=None, real=True):
     poly = coeff.as_poly()
     diff = poly - CyclicSum((a-b)**2*(a-c)**2*lifted_sym).doit().as_poly(a, b, c, domain=coeff.domain)
     diff = diff.div(CyclicProduct((a-b)**2).doit().as_poly(a, b, c, domain=coeff.domain))[0]
-    sol_diff = _sos_struct_dense_symmetric(coeff.from_poly(diff))
+    sol_diff = _structsos_dense_symmetric(coeff.from_poly(diff))
     if sol_diff is not None:
         return CyclicSum(lifted_sym * (a-b)**2*(a-c)**2) + CyclicProduct((a-b)**2) * sol_diff
 
@@ -397,7 +397,7 @@ def _conjugate_factor(poly: Poly, conj):
         odd_factors[conj_f] = 0
     return const, even_factors
 
-def _sos_struct_complex_factorizable(coeff: 'Coeff', test=True, modp=True):
+def _structsos_complex_factorizable(coeff: 'Coeff', test=True, modp=True):
     """
     Solve a cyclic ternary polynomial inequality if it is
     factorizable over Q[sqrt(-3)].
@@ -424,7 +424,7 @@ def _sos_struct_complex_factorizable(coeff: 'Coeff', test=True, modp=True):
                 return None
 
     if modp and (coeff.domain.is_QQ or coeff.domain.is_ZZ):
-        return _sos_struct_complex_factorizable_fp(coeff)
+        return _structsos_complex_factorizable_fp(coeff)
 
     dom0 = coeff.domain
     dom = dom0.unify(QQ.algebraic_field(sqrt(-3)))
@@ -496,7 +496,7 @@ def _complex_factorizable_from_AB(coeff: 'Coeff', A: Poly, B: Poly, const, k=3):
     return const*sqa + k*const*sqb
 
 
-def _sos_struct_complex_factorizable_fp(coeff: 'Coeff'):
+def _structsos_complex_factorizable_fp(coeff: 'Coeff'):
     """
     Solve a homogeneous inequality F(a,b,c) = const*(A^2 + 3*B^2) >= 0
     where const in QQ and (F, A, B) in QQ[a,b,c] by computing on
@@ -652,8 +652,8 @@ def _sqf_complex_factorizable_fp(poly: Poly, p: Optional[int]=None):
 #
 #####################################################################
 
-@sos_struct_reorder_symmetry(groups=(2, 1))
-def sos_struct_ternary_dense_partial_symmetric(coeff: 'Coeff', real=True):
+@structsos_reorder_symmetry(groups=(2, 1))
+def structsos_ternary_dense_partial_symmetric(coeff: 'Coeff', real=True):
     """
     Solve a homogeneous 3-var inequality `f(a,b,c) >= 0` where
     `f(a, b, c) == f(b, a, c)`.

--- a/triples/core/structsos/ternary/dense_symmetric.py
+++ b/triples/core/structsos/ternary/dense_symmetric.py
@@ -16,9 +16,7 @@ from ....utils import verify_symmetry, poly_reduce_by_symmetry
 from ....utils.polytools import dmp_gf_factor, FLINT_VERSION
 
 if TYPE_CHECKING:
-    from .utils import (
-        Coeff,
-    )
+    from .utils import Coeff
     from sympy import Expr
 
 

--- a/triples/core/structsos/ternary/dense_symmetric.py
+++ b/triples/core/structsos/ternary/dense_symmetric.py
@@ -666,7 +666,8 @@ def sos_struct_ternary_dense_partial_symmetric(coeff: 'Coeff', real=True):
 
     => s(a4(a-b)(a-c))+2a4(a-c)2+2b4(b-c)2
     """
-    if all(v >= 0 for v in coeff.coeffs()):
+    wrap = coeff.wrap
+    if all(wrap(v) >= 0 for v in coeff.coeffs()):
         return coeff.as_poly().as_expr()
     if coeff.total_degree() <= 1:
         return None

--- a/triples/core/structsos/ternary/nonic.py
+++ b/triples/core/structsos/ternary/nonic.py
@@ -1,7 +1,7 @@
 import sympy as sp
 from sympy import Poly, Symbol, Rational, Add
 
-from .sextic_symmetric import _sos_struct_sextic_hexagram_symmetric, _sos_struct_sextic_tree
+from .sextic_symmetric import _structsos_sextic_hexagram_symmetric, _structsos_sextic_tree
 from .utils import (
     CommonExpr,
     sum_y_exprs, rationalize_func, inverse_substitution, align_cyclic_group
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
         Coeff
     )
 
-def sos_struct_nonic(coeff, real = True):
+def structsos_nonic(coeff, real = True):
     """
     Nonics are polynomials of degree 9.
 
@@ -34,28 +34,28 @@ def sos_struct_nonic(coeff, real = True):
     if not any(coeff(_) for _ in ((9,0,0),(8,1,0),(7,2,0),(2,7,0),(7,1,1))):
         if not any(coeff(_) for _ in ((6,3,0),(3,6,0),(1,8,0))):
             if all(coeff((i,j,k)) == coeff((j,i,k)) for (i,j,k) in ((5,4,0),(6,2,1),(5,3,1),(4,3,2))):
-                return _sos_struct_nonic_hexagram_symmetric(coeff)
+                return _structsos_nonic_hexagram_symmetric(coeff)
             if (coeff((5,4,0)) == 0 and coeff((6,1,2)) == 0) or (coeff((4,5,0)) == 0 and coeff((6,2,1)) == 0):
-                return _sos_struct_nonic_gear(coeff)
+                return _structsos_nonic_gear(coeff)
 
         if not any(coeff(_) for _ in ((6,2,1),(2,6,1),(5,4,0),(4,5,0))):
             if all(coeff((i,j,k)) == coeff((j,i,k)) for (i,j,k) in ((6,0,3),(5,3,1),(4,3,2))):
-                return _sos_struct_nonic_hexagon_symmetric(coeff)
+                return _structsos_nonic_hexagon_symmetric(coeff)
 
     if not any(coeff(_) for _ in
         ((8,1,0),(7,2,0),(5,4,0),(5,0,4),(8,0,1),(7,0,2),
          (6,2,1),(6,1,2),(5,3,1),(5,1,3),(4,3,2),(4,2,3))
     ):
         if coeff((9,0,0)) > 0 and all(coeff((i,j,k)) == coeff((j,i,k)) for (i,j,k) in ((9,0,0),(6,3,0))):
-            return _sos_struct_nonic_symmetric_tree(coeff)
+            return _structsos_nonic_symmetric_tree(coeff)
 
     return None
 
 
-def _sos_struct_nonic_symmetric_tree(coeff: 'Coeff'):
+def _structsos_nonic_symmetric_tree(coeff: 'Coeff'):
     """
     Solve problems with similar structure as `s(a3-abc)s(a2+xab)s((a-b)2(a+b-xc)2)`.
-    See details at `_sos_struct_sextic_tree`.
+    See details at `_structsos_sextic_tree`.
 
     The idea is to subtract `(x >= 1)`:
     `G(x) = s(a3-abc)/2s(a2+xab)s((a-b)2(a+b-xc)2)+(w-x3+3x-1)s(a(ab-c2)2(ac-b2)2)`
@@ -135,14 +135,14 @@ def _sos_struct_nonic_symmetric_tree(coeff: 'Coeff'):
             (6,0,0): c6_, (3,3,0): c33_, (4,1,1): c411_,
             (2,2,2): (-c6_-c33_-c411_)*3 + poly111
         }
-        tree_solution = _sos_struct_sextic_tree(coeff.from_dict(tree_coeffs))
+        tree_solution = _structsos_sextic_tree(coeff.from_dict(tree_coeffs))
         if tree_solution is not None:
             return solution + tree_solution * CyclicProduct(a)
 
     return None
 
 
-def _sos_struct_nonic_hexagon_symmetric(coeff: 'Coeff'):
+def _structsos_nonic_hexagon_symmetric(coeff: 'Coeff'):
     """
     Solve problems like s(a6b3+a3b6) + p(a)(...).
 
@@ -176,7 +176,7 @@ def _sos_struct_nonic_hexagon_symmetric(coeff: 'Coeff'):
                     (4,1,1): c411_, (3,3,0): c33_, (3,2,1): c321_, (2,3,1): c321_,
                     (2,2,2): (-c411_-c33_-c321_*2)*3 + coeff.poly111()
                 }
-                hexagram_solution = _sos_struct_sextic_hexagram_symmetric(coeff.from_dict(hexagram_coeffs_))
+                hexagram_solution = _structsos_sextic_hexagram_symmetric(coeff.from_dict(hexagram_coeffs_))
                 if hexagram_solution is not None:
                     return solution + CyclicProduct(a) * hexagram_solution
 
@@ -228,7 +228,7 @@ def _sos_struct_nonic_hexagon_symmetric(coeff: 'Coeff'):
         return solution + rest_solution
 
 
-def _sos_struct_nonic_hexagram_symmetric(coeff: 'Coeff'):
+def _structsos_nonic_hexagram_symmetric(coeff: 'Coeff'):
     """
     Observe that
     f(a,b,c) = s(c5(a-b)4) + x^2s(a2b2c(a-b)4) - 2xp(a)s(3a4b2-4a4bc+3a4c2-4a3b3+2a2b2c2) >= 0
@@ -280,7 +280,7 @@ def _sos_struct_nonic_hexagram_symmetric(coeff: 'Coeff'):
 
     def _compute_hexagram_discriminant(z):
         # We will check whether the hexagram is positive by discriminant
-        # For details see _sos_struct_sextic_hexagram_symmetric
+        # For details see _structsos_sextic_hexagram_symmetric
 
         w, c4_, c5_, c6_ = _compute_hexagram_coeffs(z)
         if w < 0 or c4_ < 0 or c5_ < 0:
@@ -314,7 +314,7 @@ def _sos_struct_nonic_hexagram_symmetric(coeff: 'Coeff'):
         (3,1,2): c6_,
         (2,2,2): c7_,
     }
-    hexagram = _sos_struct_sextic_hexagram_symmetric(coeff.from_dict(hexgram_coeffs_))
+    hexagram = _structsos_sextic_hexagram_symmetric(coeff.from_dict(hexgram_coeffs_))
     if hexagram is None:
         return None
 
@@ -359,7 +359,7 @@ def _sos_struct_nonic_hexagram_symmetric(coeff: 'Coeff'):
     return solution
 
 
-def _sos_struct_nonic_gear(coeff: 'Coeff'):
+def _structsos_nonic_gear(coeff: 'Coeff'):
     """
     Solve problems like
     s(ac^2(a-b)^4(b-c)^2)-5p(a-b)^2p(a) >= 0
@@ -381,7 +381,7 @@ def _sos_struct_nonic_gear(coeff: 'Coeff'):
 
     if not (coeff((5,4,0)) == 0 and coeff((6,1,2)) == 0):
         # reflect the polynomial
-        sol = _sos_struct_nonic_gear(coeff.reflect())
+        sol = _structsos_nonic_gear(coeff.reflect())
         return align_cyclic_group(sol, coeff.gens)
 
     if coeff((4,5,0)) == 0 or coeff((6,2,1)) == 0:
@@ -486,7 +486,7 @@ def _sos_struct_nonic_gear(coeff: 'Coeff'):
                 (4,1,1): c41_, (3,3,0): c33_, (3,2,1): c32_, (2,3,1): c32_, (3,1,2): c32_,
                 (2,2,2): (-c41_-c33_-c32_*2)*3 + coeff.poly111()/c1
             }
-            hexagram_solution = _sos_struct_sextic_hexagram_symmetric(coeff.from_dict(hexagram_coeffs_))
+            hexagram_solution = _structsos_sextic_hexagram_symmetric(coeff.from_dict(hexagram_coeffs_))
             if hexagram_solution is not None:
                 def _get_ker(z, vertex, as_coeff_Mul = True):
                     u, v, x = vertex[0]

--- a/triples/core/structsos/ternary/octic.py
+++ b/triples/core/structsos/ternary/octic.py
@@ -1,4 +1,4 @@
-from .octic_symmetric import sos_struct_octic_symmetric
+from .octic_symmetric import structsos_octic_symmetric
 
 from .utils import inverse_substitution
 from typing import TYPE_CHECKING
@@ -7,9 +7,9 @@ if TYPE_CHECKING:
     from .utils import Coeff
 
 
-def sos_struct_octic(coeff: "Coeff", real = True):
+def structsos_octic(coeff: "Coeff", real = True):
     # first try symmetric case
-    solution = sos_struct_octic_symmetric(coeff, real=real)
+    solution = structsos_octic_symmetric(coeff, real=real)
     if solution is not None:
         return solution
 

--- a/triples/core/structsos/ternary/octic_symmetric.py
+++ b/triples/core/structsos/ternary/octic_symmetric.py
@@ -56,7 +56,7 @@ def _solve_inverse_quartic(coeff: 'Coeff', m, p, n, r):
             return sum_y_exprs(y, exprs)
 
 
-def sos_struct_octic_symmetric(coeff, real=True):
+def structsos_octic_symmetric(coeff, real=True):
     if not all(coeff((i,j,k)) == coeff((j,i,k)) for (i,j,k) in ((7,1,0),(6,2,0),(5,3,0),(5,2,1),(4,3,1))):
         return
 
@@ -65,13 +65,13 @@ def sos_struct_octic_symmetric(coeff, real=True):
 
     if coeff((8,0,0)) == 0 and coeff((7,1,0)) == 0:
         if coeff((6,2,0)) == 0 and coeff((5,3,0)) == 0:
-            return _sos_struct_octic_symmetric_hexagram(coeff)
-        return _sos_struct_octic_symmetric_hexagon(coeff)
+            return _structsos_octic_symmetric_hexagram(coeff)
+        return _structsos_octic_symmetric_hexagon(coeff)
 
     if coeff((8,0,0)) != 0:
-        return _sos_struct_octic_symmetric_quadratic_form(coeff.as_poly(), coeff)
+        return _structsos_octic_symmetric_quadratic_form(coeff.as_poly(), coeff)
 
-def _sos_struct_octic_symmetric_hexagon_sdp(coeff: 'Coeff'):
+def _structsos_octic_symmetric_hexagon_sdp(coeff: 'Coeff'):
     """
     Solve symmetric hexagons for real numbers by subtracting r * s((a-b)^2(ab(a+b)+xc(a^2+b^2)+..)^2)
     so that the remaining part is a quadratic form with respect to
@@ -87,7 +87,7 @@ def _sos_struct_octic_symmetric_hexagon_sdp(coeff: 'Coeff'):
     The first and the third can be reduced to M00 - M01 >= 0 and M00 + M01 >= 0.
     The second automatically holds as long as M00 + M01 > 0 STRICTLY with the fourth.
 
-    See similar methods in _sos_struct_sextic_full_sdp.
+    See similar methods in _structsos_sextic_full_sdp.
 
     TODO: 1. Handle w1 == 0. 2. Handle c620 +- 2c611 == 0.
 
@@ -536,7 +536,7 @@ def _sos_struct_octic_symmetric_hexagon_sdp(coeff: 'Coeff'):
             return _sol_to_result(_degenerated_hessian_degen_w1())
 
 
-def _sos_struct_octic_symmetric_hexagon(coeff: 'Coeff'):
+def _structsos_octic_symmetric_hexagon(coeff: 'Coeff'):
     """
     Try to solve symmetric octic hexagon, without terms a^8, a^7b and a^7c.
 
@@ -547,7 +547,7 @@ def _sos_struct_octic_symmetric_hexagon(coeff: 'Coeff'):
     if c1 < 0 or 2*c1 + c3 < 0:
         return None
 
-    solution = _sos_struct_octic_symmetric_hexagon_sdp(coeff)
+    solution = _structsos_octic_symmetric_hexagon_sdp(coeff)
     if solution is not None:
         return solution
 
@@ -597,12 +597,12 @@ def _sos_struct_octic_symmetric_hexagon(coeff: 'Coeff'):
 
 
     if coeff((6,2,0)) == 0 and coeff((5,3,0)) == 0:
-        return _sos_struct_octic_symmetric_hexagram(coeff)
+        return _structsos_octic_symmetric_hexagram(coeff)
 
     return None
 
 
-def _sos_struct_octic_symmetric_hexagram(coeff: 'Coeff'):
+def _structsos_octic_symmetric_hexagram(coeff: 'Coeff'):
     """
     Solve octic symmetric hexagram, where all terms are inside the triangle (a^6bc,...) and (a^4b^4,...).
 
@@ -759,7 +759,7 @@ def _sos_struct_octic_symmetric_hexagram(coeff: 'Coeff'):
             return sum_y_exprs(y, exprs) / multiplier
 
 
-def _sos_struct_octic_symmetric_quadratic_form(poly, coeff: 'Coeff'):
+def _structsos_octic_symmetric_quadratic_form(poly, coeff: 'Coeff'):
     """
     Let F0 = s(a2(s(a2+ab)-bc)2(a-b)(a-c)).
     Then we have
@@ -770,7 +770,7 @@ def _sos_struct_octic_symmetric_quadratic_form(poly, coeff: 'Coeff'):
     For more general septic symmetric polynomials, we can first decompose its symmetric axis
     into several F_{x,y} and then combine them together.
 
-    For a more primary case, see `_sos_struct_sextic_symmetric_quadratic_form`.
+    For a more primary case, see `_structsos_sextic_symmetric_quadratic_form`.
 
     Examples
     --------

--- a/triples/core/structsos/ternary/quadratic.py
+++ b/triples/core/structsos/ternary/quadratic.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .utils import Coeff
 
-def sos_struct_quadratic(coeff: "Coeff", real = True):
+def structsos_quadratic(coeff: "Coeff", real = True):
     """
     Solve cyclic quadratic problems.
     It must be in the form CyclicSum(a**2 + x*a*b) where x >= -1.
@@ -22,7 +22,7 @@ def sos_struct_quadratic(coeff: "Coeff", real = True):
     return CommonExpr.quadratic(coeff((2,0,0)), coeff((1,1,0)), coeff.gens)
 
 
-def sos_struct_acyclic_quadratic(coeff: "Coeff", real = True):
+def structsos_acyclic_quadratic(coeff: "Coeff", real = True):
     """
     Solve quadratic acyclic 3-var polynomial inequalities.
 

--- a/triples/core/structsos/ternary/quartic.py
+++ b/triples/core/structsos/ternary/quartic.py
@@ -5,7 +5,7 @@ from sympy import Poly, Symbol, Rational, Integer, Float, Add
 from sympy import MutableDenseMatrix as Matrix
 
 from .utils import (
-    sos_struct_reorder_symmetry,
+    structsos_reorder_symmetry,
     congruence, sum_y_exprs, quadratic_weighting,
     nroots, rationalize, rationalize_bound, rationalize_func,
     univariate_intervals, common_region_of_conics
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     )
     from sympy import Expr
 
-def sos_struct_quartic(coeff, real = True):
+def structsos_quartic(coeff, real = True):
     """
     Solve cyclic quartic problems.
 
@@ -43,9 +43,9 @@ def sos_struct_quartic(coeff, real = True):
 
     => 4s(a)s(2a3-a2b-a2c)
     """
-    return  _sos_struct_quartic_uncentered(coeff)
+    return  _structsos_quartic_uncentered(coeff)
 
-def _sos_struct_quartic_core(coeff: 'Coeff'):
+def _structsos_quartic_core(coeff: 'Coeff'):
     """
     Main theorem: For a nondegenerated cyclic quartic with zero `(1,1,1)`:
     `f(a,b,c) = s(a4 + pa3b + na2b2 + qab3 - (1+p+n+q)a2bc)`
@@ -76,7 +76,7 @@ def _sos_struct_quartic_core(coeff: 'Coeff'):
     """
     m, p, n, q, r = [coeff((4,0,0)), coeff((3,1,0)), coeff((2,2,0)), coeff((1,3,0)), coeff((2,1,1))]
     if m == 0:
-        return _sos_struct_quartic_degenerate(coeff)
+        return _structsos_quartic_degenerate(coeff)
     rem = (m + n + p + q + r)/3
     n2 = n - rem # coefficient of a^2b^2 after subtracting rem*s(ab)^2
     det = (3*m*(m + n2) - (p**2 + p*q + q**2)) # discriminant after subtracting rem*s(ab)^2
@@ -97,7 +97,7 @@ def _sos_struct_quartic_core(coeff: 'Coeff'):
     return sum_y_exprs(y, exprs)
 
 
-def _sos_struct_quartic_quadratic_border(coeff: 'Coeff'):
+def _structsos_quartic_quadratic_border(coeff: 'Coeff'):
     """
     Solve `s(a4 - 2t(a3b - ab3) + (t^2 - 2)(a2b2 - a2bc) - a2bc) >= 0`
     in the field of coeff by lifting the degree. The inequality
@@ -144,7 +144,7 @@ def _sos_struct_quartic_quadratic_border(coeff: 'Coeff'):
     return None
 
 
-def _sos_struct_quartic_biased(coeff: 'Coeff'):
+def _structsos_quartic_biased(coeff: 'Coeff'):
     """
     Theorem:
     If `f(a,b,c) = s(a4 + pa3b + na2b2 + qab3 - (1+p+n+q)a2bc) >= 0` holds for all `a,b,c >= 0`,
@@ -174,7 +174,7 @@ def _sos_struct_quartic_biased(coeff: 'Coeff'):
 
     if p == -q:
         # handle some special case in advance
-        solution = _sos_struct_quartic_quadratic_border(coeff)
+        solution = _structsos_quartic_quadratic_border(coeff)
         if solution is not None:
             return solution
 
@@ -247,14 +247,14 @@ def _sos_struct_quartic_biased(coeff: 'Coeff'):
 
             subs = {(3,1,0): y, (2,2,0): -2*u*y, (1,3,0): u**2*y, (2,1,1): rem - (u-1)**2*y}
             new_coeff = coeff - coeff.from_dict(subs)
-            new_solution = _sos_struct_quartic_core(new_coeff)
+            new_solution = _structsos_quartic_core(new_coeff)
             if new_solution is not None:
                 return solution + new_solution
 
     return None
 
 
-def _sos_struct_quartic_degenerate(coeff: 'Coeff'):
+def _structsos_quartic_degenerate(coeff: 'Coeff'):
     """
     Given the solution to f(a,b,c) = s(pa3b + na2b2 + qab3 + ra2bc) >= 0.
     Note that the coefficient of a^4 is zero in this case.
@@ -301,7 +301,7 @@ def _sos_struct_quartic_degenerate(coeff: 'Coeff'):
     return None
 
 
-def _sos_struct_quartic_uncentered_real(coeff: 'Coeff'):
+def _structsos_quartic_uncentered_real(coeff: 'Coeff'):
     """
     Solve cyclic quartic problems which do not necessarily have zeros at (1,1,1) on
     the real number field.
@@ -328,7 +328,7 @@ def _sos_struct_quartic_uncentered_real(coeff: 'Coeff'):
     and that `m2 >= 0`. The latter is equivalent to `9*(1 - w)^2 - s` >= 0.
 
     When the leading coefficient of eq is nonpositive, it can be shown that we can
-    subtract `(..)*CyclicSum(a*b)^2` instead and it should be handled by the `_sos_struct_quartic_core` function.
+    subtract `(..)*CyclicSum(a*b)^2` instead and it should be handled by the `_structsos_quartic_core` function.
     So we only need to assume the leading coefficient of the cubic is strictly positive.
 
     Noting that `eq(1) = 2*s^2 >= 0`, `eq(1 - sqrt(9/s)) <= 0` and `eq(1 + sqrt(9/s)) >= 0` (the latter
@@ -369,7 +369,7 @@ def _sos_struct_quartic_uncentered_real(coeff: 'Coeff'):
     m, p, n, q, r = [coeff((4,0,0)), coeff((3,1,0)), coeff((2,2,0)), coeff((1,3,0)), coeff((2,1,1))]
     if m == 0:
         if p == 0 and q == 0 and n >= 0 and n + r >= 0 and r <= 2*n:
-            return _sos_struct_quartic_degenerate(coeff)
+            return _structsos_quartic_degenerate(coeff)
         return None # not nonnegative on R
     elif m < 0:
         return None
@@ -392,7 +392,7 @@ def _sos_struct_quartic_uncentered_real(coeff: 'Coeff'):
 
     if a3 <= 0 or s == 0:
         # this is equivalent to 2*m**2 + 2*m*n - m*p - m*q - m*r - p**2 - p*q - q**2 >= 0
-        return _sos_struct_quartic_core(coeff)
+        return _structsos_quartic_core(coeff)
 
     def is_valid(w):
         return sp.sign(eq(w)) * sp.sign(w - 1) <= 0 and (9*(1 - w)**2 - s) >= 0
@@ -428,7 +428,7 @@ def _sos_struct_quartic_uncentered_real(coeff: 'Coeff'):
                     (2,2,0): w**2+2, (1,3,0): -2*w, (2,1,1): 2*w*(w-1)})
             new_coeff = coeff - z * subs
 
-            new_solution = _sos_struct_quartic_core(new_coeff)
+            new_solution = _structsos_quartic_core(new_coeff)
             if new_solution is not None:
                 return solution + new_solution
 
@@ -437,7 +437,7 @@ def _sos_struct_quartic_uncentered_real(coeff: 'Coeff'):
     return None
 
 
-def _sos_struct_quartic_uncentered(coeff: 'Coeff'):
+def _structsos_quartic_uncentered(coeff: 'Coeff'):
     """
     Solve general cyclic quartic problems on positive orthant.
     It also tries to solve the problem on the real number field if possible.
@@ -461,7 +461,7 @@ def _sos_struct_quartic_uncentered(coeff: 'Coeff'):
 
     [2] https://tieba.baidu.com/p/8241977884
     """
-    solution = _sos_struct_quartic_uncentered_real(coeff)
+    solution = _structsos_quartic_uncentered_real(coeff)
     if solution is not None:
         return solution
 
@@ -470,7 +470,7 @@ def _sos_struct_quartic_uncentered(coeff: 'Coeff'):
     if not (m >= 0 and rem >= 0):
         return None
     if m == 0:
-        return _sos_struct_quartic_degenerate(coeff)
+        return _structsos_quartic_degenerate(coeff)
 
     a, b, c = coeff.gens
     CyclicSum = coeff.cyclic_sum
@@ -482,12 +482,12 @@ def _sos_struct_quartic_uncentered(coeff: 'Coeff'):
         # then it is directly handled by the core function after subtracting enough s(a^2bc)
         # (so that the remaining polynomial has zero at (1,1,1))
         new_coeff = coeff.from_dict({(4,0,0):m, (3,1,0):p, (2,2,0):n, (1,3,0):q, (2,1,1):-(m+p+n+q)})
-        return _sos_struct_quartic_core(new_coeff) + rem * CyclicSum(a**2*b*c)
+        return _structsos_quartic_core(new_coeff) + rem * CyclicSum(a**2*b*c)
 
     # assume the inequality holds, then on the border it must >= 0
     if 2*p + q >= 0 or 2*q + p >= 0 or (2*p+q)*(2*q+p) - 9*m**2 <= 0:
         # then it falls to the biased case
-        return _sos_struct_quartic_biased(coeff)
+        return _structsos_quartic_biased(coeff)
 
     # standardize
     p, n, q, r = [p/m, n/m, q/m, r/m]
@@ -576,7 +576,7 @@ def _sos_struct_quartic_uncentered(coeff: 'Coeff'):
             x_ = coeff.convert(x_)
             new_coeffs_ = {(4,0,0): coeff((4,0,0)), (3,1,0): coeff((3,1,0)),
                         (2,2,0): coeff((2,2,0)), (1,3,0): coeff((1,3,0)), (2,1,1): x_ * m}
-            solution = _sos_struct_quartic_uncentered_real(coeff.from_dict(new_coeffs_))
+            solution = _structsos_quartic_uncentered_real(coeff.from_dict(new_coeffs_))
             if solution is not None:
                 solution += ((r - x_) * m) * CyclicSum(a**2*b*c)
                 return solution
@@ -603,16 +603,16 @@ def _sos_struct_quartic_uncentered(coeff: 'Coeff'):
 #
 #####################################################################
 
-def sos_struct_acyclic_quartic(coeff, real = True):
+def structsos_acyclic_quartic(coeff, real = True):
     """
     Solve acyclic quartic problems.
     """
-    return _sos_struct_acyclic_quartic_symmetric(coeff)
-    return _sos_struct_acyclic_quartic_real(coeff)
+    return _structsos_acyclic_quartic_symmetric(coeff)
+    return _structsos_acyclic_quartic_real(coeff)
 
 
-@sos_struct_reorder_symmetry(groups=(2, 1))
-def _sos_struct_acyclic_quartic_symmetric(coeff: 'Coeff', real = True):
+@structsos_reorder_symmetry(groups=(2, 1))
+def _structsos_acyclic_quartic_symmetric(coeff: 'Coeff', real = True):
     """
     Solve acyclic quartic polynomials that are symmetric with respect to two variables.
     If it is nonnegative over R, it must be sum of squares by Hilbert's 17th problem, we can write it in
@@ -867,7 +867,7 @@ class _quadratic_minimization():
         roots = [((self.symmetric_axis(r), r), v) for r, v in candidates if v == minimum]
         return roots
 
-def _sos_struct_acyclic_quartic_real(coeff: 'Coeff'):
+def _structsos_acyclic_quartic_real(coeff: 'Coeff'):
     """
     Solve acyclic quartic problems over a,b,c in R.
 
@@ -892,7 +892,7 @@ def _sos_struct_acyclic_quartic_real(coeff: 'Coeff'):
     => (20a4-94a3b-12a3c+171a2b2+28a2bc+4a2c2-151ab3-11ab2c-8abc2+77b4-21b3c+7b2c2) # doctest:+SKIP
     """
     poly = coeff.as_poly()
-    roots = _sos_struct_acyclic_quartic_real_findroots(coeff, poly)
+    roots = _structsos_acyclic_quartic_real_findroots(coeff, poly)
     if roots is None:
         return None
 
@@ -978,7 +978,7 @@ def _sos_struct_acyclic_quartic_real(coeff: 'Coeff'):
         return base_mat + addition
 
 
-def _sos_struct_acyclic_quartic_real_findroots(
+def _structsos_acyclic_quartic_real_findroots(
         coeff: 'Coeff', poly = None
     ) -> List[Tuple[Tuple[Float, Float, Float], Float, 'Expr']]:
     """

--- a/triples/core/structsos/ternary/quartic.py
+++ b/triples/core/structsos/ternary/quartic.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     )
     from sympy import Expr
 
-def structsos_quartic(coeff, real = True):
+def structsos_quartic(coeff, real = 1):
     """
     Solve cyclic quartic problems.
 
@@ -43,7 +43,7 @@ def structsos_quartic(coeff, real = True):
 
     => 4s(a)s(2a3-a2b-a2c)
     """
-    return  _structsos_quartic_uncentered(coeff)
+    return  _structsos_quartic_uncentered(coeff, real=real)
 
 def _structsos_quartic_core(coeff: 'Coeff'):
     """
@@ -437,7 +437,7 @@ def _structsos_quartic_uncentered_real(coeff: 'Coeff'):
     return None
 
 
-def _structsos_quartic_uncentered(coeff: 'Coeff'):
+def _structsos_quartic_uncentered(coeff: 'Coeff', real = 1):
     """
     Solve general cyclic quartic problems on positive orthant.
     It also tries to solve the problem on the real number field if possible.
@@ -477,6 +477,8 @@ def _structsos_quartic_uncentered(coeff: 'Coeff'):
 
     # if we reach here, it means that the inequality does not hold for all real numbers
     # we can subtract as many s(a^2bc) as possible
+    if int(real) >= 2:
+        return None
     if 3*m*(m + n) - (p**2 + p*q + q**2) >= 0:
         # Case 1. 3m(m+n) - (p^2+pq+q^2) >= 0,
         # then it is directly handled by the core function after subtracting enough s(a^2bc)

--- a/triples/core/structsos/ternary/quintic.py
+++ b/triples/core/structsos/ternary/quintic.py
@@ -3,9 +3,9 @@ from typing import Tuple, List, Optional, TYPE_CHECKING
 from sympy import Poly, Expr, Symbol, Integer, Rational, Float, Add, sqrt, im
 import numpy as np
 
-from .cubic import sos_struct_cubic
-from .quartic import sos_struct_quartic
-from .quintic_symmetric import sos_struct_quintic_symmetric
+from .cubic import structsos_cubic
+from .quartic import structsos_quartic
+from .quintic_symmetric import structsos_quintic_symmetric
 from ..univariate import prove_univariate
 from .utils import (
     sum_y_exprs, nroots, rationalize, rationalize_bound, rationalize_func,
@@ -66,19 +66,19 @@ def _prove_quintic_from_border(coeff: 'Coeff', border: Poly) -> Optional[List[Ex
 
 
 
-def sos_struct_quintic(coeff, real = True):
+def structsos_quintic(coeff, real = True):
     """
     Solve quintic inequalities.
     """
 
     # first try symmetric solution
     if coeff((4,1,0)) == coeff((1,4,0)) and coeff((3,2,0)) == coeff((2,3,0)):
-        return sos_struct_quintic_symmetric(coeff)
+        return structsos_quintic_symmetric(coeff)
 
     if coeff((5,0,0)) == 0:
-        return _sos_struct_quintic_hexagon(coeff)
+        return _structsos_quintic_hexagon(coeff)
     else:
-        return _sos_struct_quintic_full(coeff)
+        return _structsos_quintic_full(coeff)
     return None
 
 
@@ -105,7 +105,7 @@ def _solve_sa2minusab_mul_cubic(coeff: 'Coeff', x, y, mul = 1):
     CyclicSum = coeff.cyclic_sum
     if x >= 0 and y >= 0:
         cubic_poly = coeff.from_dict({(3,0,0): 1, (2,1,0): x, (1,2,0): y, (1,1,1): -3*(x+y+1)})
-        return Rational(1,2) * mul * CyclicSum((a-b)**2) * sos_struct_cubic(cubic_poly)
+        return Rational(1,2) * mul * CyclicSum((a-b)**2) * structsos_cubic(cubic_poly)
 
     def _solve_t(t):
         return (1/t**2) * CyclicSum(a*(t*a - (t-1)*b - c)**2*(t*b - (t-1)*c - a)**2)
@@ -214,7 +214,7 @@ def _solve_uvxy(coeff: 'Coeff'):
     return u, v, x, y
 
 
-def _sos_struct_quintic_full(coeff: 'Coeff'):
+def _structsos_quintic_full(coeff: 'Coeff'):
     """
     Try to solve quintic with nonzero a^5 coefficient by subtracting something.
 
@@ -310,7 +310,7 @@ def _sos_struct_quintic_full(coeff: 'Coeff'):
                     (3,1,1): (z - (2*u**2*x - 2*u**2 + 2*u*v*x - 2*u*v*y + 2*u*v - 2*v**2*x)) * m,
                     (2,2,1): (w - (-u**2*y - 2*u*v*x + 2*u*v*y - 4*u*x + 2*u*y + 2*u + 2*v**2*x - v**2*y - v**2 + 2*v*y + 2*x - 2*y)) * m,
                 }
-                solution = _sos_struct_quintic_hexagon(coeff.from_dict(_new_coeffs))
+                solution = _structsos_quintic_hexagon(coeff.from_dict(_new_coeffs))
                 if solution is not None:
                     xu, xv = x*u, x*v
                     solution = m * CyclicSum(
@@ -342,7 +342,7 @@ def _solve_trivial_quintic_full(coeff: 'Coeff'):
     In most ideal case, the remaining poly should have discriminant == 0,
     and we can solve for the exact minimum t that ensures the remaining polynomial
     nonnegative.
-    See more details at _sos_struct_quintic_hexagon.
+    See more details at _structsos_quintic_hexagon.
     """
     coeff500 = coeff((5,0,0))
     x0, y0 = coeff((4,1,0)) / coeff500 + 1, coeff((1,4,0)) / coeff500 + 1
@@ -381,7 +381,7 @@ def _solve_trivial_quintic_full(coeff: 'Coeff'):
             (3,1,1): z0 - 8*t0,
             (2,2,1): -(-6*t0+p+q+z0) + coeff.poly111() / 3 / coeff500
         }
-        p2 = _sos_struct_quintic_hexagon(coeff.from_dict(hexagon_coeffs))
+        p2 = _structsos_quintic_hexagon(coeff.from_dict(hexagon_coeffs))
 
         if p2 is not None:
             return p1 + coeff500 * p2
@@ -413,7 +413,7 @@ def _build_quintic_full_solution(coeff: 'Coeff', mul: Rational, params: List[Rat
     quartic_coeffs = {
         (4,0,0): m, (3,1,0): p, (2,2,0): n, (1,3,0): q, (2,1,1): -(m+p+n+q)
     }
-    rest = sos_struct_quartic(coeff.from_dict(quartic_coeffs), None)
+    rest = structsos_quartic(coeff.from_dict(quartic_coeffs), None)
     rest += coeff.poly111() * (1 + mul) * CyclicSum(a**2*b*c)
     rest = coeff500 * CyclicProduct(a) * rest
     return (coeff500 * sol_main + coeff500 * border_proof + rest) / multiplier
@@ -660,7 +660,7 @@ def _solve_quintic_full_final(coeff: 'Coeff', uv = None):
 #
 #########################################################
 
-def _sos_struct_quintic_windmill(coeff: 'Coeff'):
+def _structsos_quintic_windmill(coeff: 'Coeff'):
     """
     Give solution to s(a3b2+?a2b3+?ab4+?a3bc+?a2b2c) >= 0,
 
@@ -726,7 +726,7 @@ def _sos_struct_quintic_windmill(coeff: 'Coeff'):
 
     if coeff((4,1,0)) != 0:
         # reflect the polynomial so that coeff((4,1,0)) == 0
-        sol = _sos_struct_quintic_windmill(coeff.reflect())
+        sol = _structsos_quintic_windmill(coeff.reflect())
         return align_cyclic_group(sol, coeff.gens)
 
     a = coeff.gens[0]
@@ -735,21 +735,21 @@ def _sos_struct_quintic_windmill(coeff: 'Coeff'):
     if coeff((1,4,0)) < 0:
         return None
     elif coeff((1,4,0)) == 0:
-        return _sos_struct_quintic_windmill_degenerated(coeff)
+        return _structsos_quintic_windmill_degenerated(coeff)
 
     c320 = coeff((3,2,0))
     if c320 == 0:
         if coeff((2,3,0)) >= 0:
-            solution = _sos_struct_quintic_uncentered(coeff)
+            solution = _structsos_quintic_uncentered(coeff)
         return solution
     elif c320 < 0:
         return None
 
 
     _solvers = [
-        _sos_struct_quintic_windmill_trivial,
-        _sos_struct_quintic_windmill_trivial2,
-        _sos_struct_quintic_windmill_quadratic # now we have to lift the degree
+        _structsos_quintic_windmill_trivial,
+        _structsos_quintic_windmill_trivial2,
+        _structsos_quintic_windmill_quadratic # now we have to lift the degree
     ]
     for _solver in _solvers:
         solution = _solver(coeff)
@@ -842,12 +842,12 @@ def _sos_struct_quintic_windmill(coeff: 'Coeff'):
                 v_ = _compute_v(u_)
 
         else:
-            return _sos_struct_quintic_windmill_border(coeff)
+            return _structsos_quintic_windmill_border(coeff)
 
 
     # Now we call the solver to solve the problem at (u, v).
     u, v = u_, v_
-    main_solution = _sos_struct_quintic_windmill_uv(coeff, u, v)
+    main_solution = _structsos_quintic_windmill_uv(coeff, u, v)
 
     if main_solution is not None:
         multiplier, main_solution = main_solution
@@ -860,7 +860,7 @@ def _sos_struct_quintic_windmill(coeff: 'Coeff'):
             (2,2,1): coeff((2,2,1)) / c320 - (-u**3 + 2*u**2*v + 2*u**2 - u*v**2 + u*v - 4*u + v**2 + 1) / denom
         }
 
-        rest_solution = _sos_struct_quintic_windmill(coeff.from_dict(_new_coeffs))
+        rest_solution = _structsos_quintic_windmill(coeff.from_dict(_new_coeffs))
         if rest_solution is not None:
             ker = c320 / 2 / denom
             return (ker * main_solution + c320 * multiplier * rest_solution) / multiplier
@@ -868,7 +868,7 @@ def _sos_struct_quintic_windmill(coeff: 'Coeff'):
     return None
 
 
-def _sos_struct_quintic_windmill_degenerated(coeff: 'Coeff'):
+def _structsos_quintic_windmill_degenerated(coeff: 'Coeff'):
     """
     coeff((4,1,0)) == coeff((1,4,0)) == 0
     now if we change variables a -> 1/a, b -> 1/b, c -> 1/c, it will be quartic
@@ -903,7 +903,7 @@ def _sos_struct_quintic_windmill_degenerated(coeff: 'Coeff'):
         return sum_y_exprs(y, exprs)
 
 
-def _sos_struct_quintic_windmill_trivial(coeff: 'Coeff'):
+def _structsos_quintic_windmill_trivial(coeff: 'Coeff'):
     """
     Solve very simple cases without lifting the degree using several ideas.
     """
@@ -1029,7 +1029,7 @@ def _sos_struct_quintic_windmill_trivial(coeff: 'Coeff'):
                     return sum_y_exprs(y, exprs) + rem
 
 
-def _sos_struct_quintic_windmill_trivial2(coeff: 'Coeff'):
+def _structsos_quintic_windmill_trivial2(coeff: 'Coeff'):
     """
     Try subtracting `s(c(a2-ab-u(ac-ab)+v(bc-ab))2)`
     and the rest does not have `s(ab^4)` term.
@@ -1073,7 +1073,7 @@ def _sos_struct_quintic_windmill_trivial2(coeff: 'Coeff'):
                 (3,1,1): 2*u*v - 2*u + 2*v + z + 2,
                 (2,2,1): coeff((2,2,1)) / c140 + ((u - v)**2 - 2*v - 1)
             }
-            solution = _sos_struct_quintic_windmill(coeff.from_dict(_new_coeffs))
+            solution = _structsos_quintic_windmill(coeff.from_dict(_new_coeffs))
             if solution is not None:
                 a, b, c = coeff.gens
                 CyclicSum = coeff.cyclic_sum
@@ -1081,7 +1081,7 @@ def _sos_struct_quintic_windmill_trivial2(coeff: 'Coeff'):
                     + c140 * CyclicSum(c*(a**2+(u-v-1)*a*b-u*a*c+v*b*c)**2)
 
 
-def _sos_struct_quintic_windmill_quadratic(coeff: 'Coeff'):
+def _structsos_quintic_windmill_quadratic(coeff: 'Coeff'):
     """
     First try whether we can handle neat cases.
     Theorem 1.1:
@@ -1162,12 +1162,12 @@ def _sos_struct_quintic_windmill_quadratic(coeff: 'Coeff'):
             (2,2,1): c221 - c1*(2 - w**2),
         }
 
-        solution = _sos_struct_quintic_windmill(coeff.from_dict(_new_coeffs))
+        solution = _structsos_quintic_windmill(coeff.from_dict(_new_coeffs))
         if solution is not None:
             return (2*c1*CyclicSum(a*(a-b)**2*(w*a*b-(2+2*w)*b*c+w*c**2+a*c+b**2)**2) + solution * multiplier) / multiplier
 
 
-def _sos_struct_quintic_windmill_uv(coeff: 'Coeff', u, v):
+def _structsos_quintic_windmill_uv(coeff: 'Coeff', u, v):
     """
     Given (u,v), solve the inequality
     `f(a,b,c) = s((b-a+(2u-1)c)(a^2-b^2+u(ab-ac)+v(bc-ab))^2) >= 0`.
@@ -1318,7 +1318,7 @@ def _sos_struct_quintic_windmill_uv(coeff: 'Coeff', u, v):
                 return multiplier, sum_y_exprs(y, exprs)
 
 
-def _sos_struct_quintic_windmill_border(coeff: 'Coeff'):
+def _structsos_quintic_windmill_border(coeff: 'Coeff'):
     """
     Case Special. when y_ < 0 and y_^2 = 4x_, then there is a root on the border
     then perturbation has no chance,
@@ -1386,7 +1386,7 @@ def _sos_struct_quintic_windmill_border(coeff: 'Coeff'):
         return sum_y_exprs(y, exprs) / multiplier
 
 
-def _sos_struct_quintic_uncentered(coeff: 'Coeff'):
+def _structsos_quintic_uncentered(coeff: 'Coeff'):
     """
     Give the solution to s(ab4+?a2b3-?a3bc+?a2b2c) >= 0,
     which might have equality not at (1,1,1) but elsewhere.
@@ -1417,7 +1417,7 @@ def _sos_struct_quintic_uncentered(coeff: 'Coeff'):
     if rem < 0:
         return None
     if rem == 0 and coeff((2,3,0)) == 0:
-        return _sos_struct_quintic_windmill_special(coeff)
+        return _structsos_quintic_windmill_special(coeff)
 
     u, v = Symbol('u'), Symbol('v')
     t = coeff((1,4,0))
@@ -1617,7 +1617,7 @@ def _sos_struct_quintic_uncentered(coeff: 'Coeff'):
     return None
 
 
-def _sos_struct_quintic_windmill_special(coeff: 'Coeff'):
+def _structsos_quintic_windmill_special(coeff: 'Coeff'):
     """
     Give the solution to `s(ab4-a2b2c) >= wabcs(a2-ab)`
     here optimal `w = 3.581412179607289955451719993913205662648` is the root of `x**3-8*x**2+39*x-83`
@@ -1747,7 +1747,7 @@ def _solve_quintic_hexagon_pqz(coeff: 'Coeff', p, q, z, mul = 1):
 #
 #########################################################
 
-def _sos_struct_quintic_hexagon(coeff: 'Coeff'):
+def _structsos_quintic_hexagon(coeff: 'Coeff'):
     """
     Try solving quintics without s(a^5).
 
@@ -1789,7 +1789,7 @@ def _sos_struct_quintic_hexagon(coeff: 'Coeff'):
     if coeff((5,0,0)) != 0 or coeff((4,1,0)) < 0 or coeff((1,4,0)) < 0:
         return None
     if coeff((4,1,0)) == 0 or coeff((1,4,0)) == 0:
-        return _sos_struct_quintic_windmill(coeff)
+        return _structsos_quintic_windmill(coeff)
 
     rem = sum(coeff(_) for _ in [(4,1,0),(3,2,0),(2,3,0),(1,4,0),(3,1,1),(2,2,1)])
     if rem < 0:

--- a/triples/core/structsos/ternary/quintic.py
+++ b/triples/core/structsos/ternary/quintic.py
@@ -413,7 +413,7 @@ def _build_quintic_full_solution(coeff: 'Coeff', mul: Rational, params: List[Rat
     quartic_coeffs = {
         (4,0,0): m, (3,1,0): p, (2,2,0): n, (1,3,0): q, (2,1,1): -(m+p+n+q)
     }
-    rest = structsos_quartic(coeff.from_dict(quartic_coeffs), None)
+    rest = structsos_quartic(coeff.from_dict(quartic_coeffs))
     rest += coeff.poly111() * (1 + mul) * CyclicSum(a**2*b*c)
     rest = coeff500 * CyclicProduct(a) * rest
     return (coeff500 * sol_main + coeff500 * border_proof + rest) / multiplier

--- a/triples/core/structsos/ternary/quintic_symmetric.py
+++ b/triples/core/structsos/ternary/quintic_symmetric.py
@@ -657,7 +657,7 @@ def _structsos_quintic_symmetric_border(coeff: 'Coeff'):
     quartic = {
         (4,0,0): m_, (3,1,0): p_, (2,2,0): n_, (1,3,0): p_, (3,0,1): p_, (2,1,1): -m_-p_*2-n_
     }
-    quartic_solution = structsos_quartic(coeff.from_dict(quartic), None)
+    quartic_solution = structsos_quartic(coeff.from_dict(quartic))
     if quartic_solution is None: # not expected to happen
         return None
     solution = main_solution + (quartic_solution + rem * CyclicSum(a*b) * multiplier) * CyclicProduct(a)

--- a/triples/core/structsos/ternary/quintic_symmetric.py
+++ b/triples/core/structsos/ternary/quintic_symmetric.py
@@ -1,6 +1,6 @@
 from sympy import Integer, Rational, Float, Add
 
-from .quartic import sos_struct_quartic
+from .quartic import structsos_quartic
 from .utils import (
     CommonExpr,
     sum_y_exprs, nroots, rationalize, rationalize_bound
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
         Coeff
     )
 
-def sos_struct_quintic_symmetric(coeff: 'Coeff', real = True):
+def structsos_quintic_symmetric(coeff: 'Coeff', real = True):
     """
     The function solves symmetric quintic problems with `s(a^5)` term in an
     incomplete attempt.
@@ -93,10 +93,10 @@ def sos_struct_quintic_symmetric(coeff: 'Coeff', real = True):
         return None
 
     if coeff((5,0,0)) == 0:
-        return _sos_struct_quintic_symmetric_hexagon(coeff)
+        return _structsos_quintic_symmetric_hexagon(coeff)
 
     # try simple case where we do not lift the degree
-    solution = _sos_struct_quintic_symmetric_sdp(coeff)
+    solution = _structsos_quintic_symmetric_sdp(coeff)
     if solution is not None:
         return solution
 
@@ -292,17 +292,17 @@ def sos_struct_quintic_symmetric(coeff: 'Coeff', real = True):
                 return sum_y_exprs(y, exprs) / multiplier
 
         if du == 0:
-            return _sos_struct_quintic_symmetric_border(coeff)
-        return _sos_struct_quintic_symmetric_final(coeff)
+            return _structsos_quintic_symmetric_border(coeff)
+        return _structsos_quintic_symmetric_final(coeff)
 
 
     return None
 
 
-def _sos_struct_quintic_symmetric_sdp(coeff: 'Coeff'):
+def _structsos_quintic_symmetric_sdp(coeff: 'Coeff'):
     """
     Try subtracting some `s(a(a2-xab-xac-yb2-yc2+(2x+2y-1)bc)2)` so that
-    the rest is positive. See criterion at `_sos_struct_quintic_symmetric_hexagon`.
+    the rest is positive. See criterion at `_structsos_quintic_symmetric_hexagon`.
 
     This solver does not attempt to lift the degree of the polynomial and can only
     solve inequalities that are SOS without degree lifting.
@@ -377,7 +377,7 @@ def _sos_struct_quintic_symmetric_sdp(coeff: 'Coeff'):
             (3,1,1): m*v2,
             (2,2,1): (coeff((2,2,1)) + m*(4*x**2 - 4*x*y - 6*y**2 + 4*y - 1))
         }
-        solution = _sos_struct_quintic_symmetric_hexagon(coeff.from_dict(_new_coeffs))
+        solution = _structsos_quintic_symmetric_hexagon(coeff.from_dict(_new_coeffs))
         if solution is not None:
             CyclicSum = coeff.cyclic_sum
             m, x, y = [coeff.to_sympy(_) for _ in [m, x, y]]
@@ -387,7 +387,7 @@ def _sos_struct_quintic_symmetric_sdp(coeff: 'Coeff'):
             return solution
 
 
-def _sos_struct_quintic_symmetric_final(coeff: 'Coeff'):
+def _structsos_quintic_symmetric_final(coeff: 'Coeff'):
     """
     Note that (u,v) should be over the following curve: (t >= 3 and z <= -3)
     ```
@@ -411,7 +411,7 @@ def _sos_struct_quintic_symmetric_final(coeff: 'Coeff'):
     du = u - (z**2 + 2*z + 5)/4 # ensure the border is positive
     if du == 0:
         # Case a. there is a root on the border
-        return _sos_struct_quintic_symmetric_border(coeff)
+        return _structsos_quintic_symmetric_border(coeff)
 
     a, b, c = coeff.gens
     CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
@@ -584,7 +584,7 @@ def _sos_struct_quintic_symmetric_final(coeff: 'Coeff'):
             return sum_y_exprs(y, exprs) / multiplier
 
 
-def _sos_struct_quintic_symmetric_border(coeff: 'Coeff'):
+def _structsos_quintic_symmetric_border(coeff: 'Coeff'):
     """
     Solve symmetric quintic inequalities with one root on the border.
     The coefficient should satisfy `u = (z**2 + 2*z + 5)/4`.
@@ -657,14 +657,14 @@ def _sos_struct_quintic_symmetric_border(coeff: 'Coeff'):
     quartic = {
         (4,0,0): m_, (3,1,0): p_, (2,2,0): n_, (1,3,0): p_, (3,0,1): p_, (2,1,1): -m_-p_*2-n_
     }
-    quartic_solution = sos_struct_quartic(coeff.from_dict(quartic), None)
+    quartic_solution = structsos_quartic(coeff.from_dict(quartic), None)
     if quartic_solution is None: # not expected to happen
         return None
     solution = main_solution + (quartic_solution + rem * CyclicSum(a*b) * multiplier) * CyclicProduct(a)
     return solution / multiplier
 
 
-def _sos_struct_quintic_symmetric_hexagon(coeff: 'Coeff'):
+def _structsos_quintic_symmetric_hexagon(coeff: 'Coeff'):
     """
     Prove symmetric quintic without s(a5).
     TODO: It should also handle cases when (1,1,1) is not a root in the future.

--- a/triples/core/structsos/ternary/septic.py
+++ b/triples/core/structsos/ternary/septic.py
@@ -48,7 +48,7 @@ def _fast_solve_quartic(coeff: Coeff, m, p, n, q, rem = 0, mul_abc = True):
     coeffs_ = {
         (4,0,0): m, (3,1,0): p, (2,2,0): n, (1,3,0): q, (2,1,1): (rem - m - p - n - q)
     }
-    solution = structsos_quartic(coeff.from_dict(coeffs_), None)
+    solution = structsos_quartic(coeff.from_dict(coeffs_))
     if mul_abc and solution is not None:
         solution = solution * CyclicProduct(a)
     return solution

--- a/triples/core/structsos/ternary/septic.py
+++ b/triples/core/structsos/ternary/septic.py
@@ -1,11 +1,11 @@
 from sympy import Poly, Rational, Float, Add, sqrt
 
-from .quartic import sos_struct_quartic
-from .septic_symmetric import sos_struct_septic_symmetric
+from .quartic import structsos_quartic
+from .septic_symmetric import structsos_septic_symmetric
 from .utils import (
     Coeff, nroots, rationalize_bound,
     zip_longest, align_cyclic_group, congruence_solve,
-    sos_struct_handle_uncentered
+    structsos_handle_uncentered
 )
 
 def repeated_div(p: Poly, q: Poly):
@@ -48,28 +48,28 @@ def _fast_solve_quartic(coeff: Coeff, m, p, n, q, rem = 0, mul_abc = True):
     coeffs_ = {
         (4,0,0): m, (3,1,0): p, (2,2,0): n, (1,3,0): q, (2,1,1): (rem - m - p - n - q)
     }
-    solution = sos_struct_quartic(coeff.from_dict(coeffs_), None)
+    solution = structsos_quartic(coeff.from_dict(coeffs_), None)
     if mul_abc and solution is not None:
         solution = solution * CyclicProduct(a)
     return solution
 
 
-def sos_struct_septic(coeff, real = True):
+def structsos_septic(coeff, real = True):
     if all(coeff((i,j,k)) == coeff((j,i,k)) for (i,j,k) in ((6,1,0),(5,2,0),(4,3,0),(4,2,1))):
-        return sos_struct_septic_symmetric(coeff, real = real)
+        return structsos_septic_symmetric(coeff, real = real)
 
     if coeff((7,0,0)) == 0 and coeff((6,1,0)) == 0 and coeff((6,0,1)) == 0:
         if coeff((5,2,0)) == 0 and coeff((5,0,2)) == 0:
             # star
-            return _sos_struct_septic_star(coeff)
+            return _structsos_septic_star(coeff)
         else:
             # hexagon
-            return _sos_struct_septic_hexagon(coeff)
+            return _structsos_septic_hexagon(coeff)
 
     return None
 
 
-def _sos_struct_septic_biased(coeff: Coeff):
+def _structsos_septic_biased(coeff: Coeff):
     """
     Solve septic hexagons without s(a5b2) and s(a4b3)
 
@@ -98,7 +98,7 @@ def _sos_struct_septic_biased(coeff: Coeff):
 
     if coeff((5,2,0)) or coeff((4,3,0)):
         # reflect the polynomial so that coeff((5,2,0)) == 0
-        sol = _sos_struct_septic_biased(coeff.reflect())
+        sol = _structsos_septic_biased(coeff.reflect())
         return align_cyclic_group(sol, coeff.gens)
 
     if coeff((5,2,0)) or coeff((4,3,0)):
@@ -107,7 +107,7 @@ def _sos_struct_septic_biased(coeff: Coeff):
     return None
 
 
-def _sos_struct_septic_hexagon(coeff: Coeff):
+def _structsos_septic_hexagon(coeff: Coeff):
     """
     Solve septic without s(a7), s(a6b), s(a6c).
 
@@ -132,7 +132,7 @@ def _sos_struct_septic_hexagon(coeff: Coeff):
         return None
 
     if (coeff((5,2,0)) == 0 and coeff((4,3,0)) == 0) or (coeff((3,4,0)) == 0 and coeff((2,5,0)) == 0):
-        solution = _sos_struct_septic_biased(coeff)
+        solution = _structsos_septic_biased(coeff)
         if solution is not None:
             return solution
 
@@ -142,24 +142,24 @@ def _sos_struct_septic_hexagon(coeff: Coeff):
 
     if coeff((5,2,0)) == coeff((2,5,0)):
         if coeff((5,2,0)) == 0 and coeff((2,5,0)) == 0:
-            return _sos_struct_septic_star(coeff)
+            return _structsos_septic_star(coeff)
 
-        solution = _sos_struct_septic_hexagon_subtract_quintic(coeff)
+        solution = _structsos_septic_hexagon_subtract_quintic(coeff)
         if solution is not None:
             return solution
 
-    return _sos_struct_septic_hexagon_sdp(coeff)
+    return _structsos_septic_hexagon_sdp(coeff)
 
 
-def _sos_struct_septic_star(coeff: Coeff):
-    return _sos_struct_septic_star_sdp(coeff)
+def _structsos_septic_star(coeff: Coeff):
+    return _structsos_septic_star_sdp(coeff)
 
 
-def _sos_struct_septic_hexagon_subtract_quintic(coeff: Coeff):
+def _structsos_septic_hexagon_subtract_quintic(coeff: Coeff):
     """
     Solve easy cases of septic hexagons by subtracting a quintic polynomial * s(ab):
     `s(ab)s(c(a^2-b^2+u(ab-ac)+v(bc-ab))^2)` to eliminate the border
-    See more details in `_sos_struct_quintic_hexagon`
+    See more details in `_structsos_quintic_hexagon`
 
 
     Theorem 1.
@@ -283,8 +283,8 @@ def _sos_struct_septic_hexagon_subtract_quintic(coeff: Coeff):
             return main_solution + remain_solution
 
 
-@sos_struct_handle_uncentered
-def _sos_struct_septic_hexagon_sdp(coeff: Coeff):
+@structsos_handle_uncentered
+def _structsos_septic_hexagon_sdp(coeff: Coeff):
     """
     Assume `F(a,b,c) = CyclicSum(a * vec' * M * vec) + a*b*c*g` where `g`
     has degree 4,
@@ -448,8 +448,8 @@ def _sos_struct_septic_hexagon_sdp(coeff: Coeff):
             return sol
 
 
-@sos_struct_handle_uncentered
-def _sos_struct_septic_star_sdp(coeff: Coeff):
+@structsos_handle_uncentered
+def _structsos_septic_star_sdp(coeff: Coeff):
     """
     Solve `F(a,b,c) = s(ua4b3 + va3b4) + abcf(a,b,c) >= 0` where f is degree 4.
 

--- a/triples/core/structsos/ternary/septic_symmetric.py
+++ b/triples/core/structsos/ternary/septic_symmetric.py
@@ -6,8 +6,8 @@ from sympy import oo as Infinity
 from .utils import (
     CommonExpr, DomainExpr, quadratic_weighting, rationalize_func
 )
-from .cubic import _sos_struct_cubic_symmetric
-from .quartic import sos_struct_quartic
+from .cubic import _structsos_cubic_symmetric
+from .quartic import structsos_quartic
 from .sextic_symmetric import _restructure_quartic_polynomial
 from ..univariate import prove_univariate
 from typing import TYPE_CHECKING
@@ -18,22 +18,22 @@ if TYPE_CHECKING:
     )
 
 
-def sos_struct_septic_symmetric(coeff, real=False):
+def structsos_septic_symmetric(coeff, real=False):
     if not all(coeff((i,j,k)) == coeff((j,i,k)) for (i,j,k) in ((6,1,0),(5,2,0),(4,3,0),(4,2,1))):
         return None
 
-    from .dense_symmetric import sos_struct_liftfree_for_six
-    solution = sos_struct_liftfree_for_six(coeff)
+    from .dense_symmetric import structsos_liftfree_for_six
+    solution = structsos_liftfree_for_six(coeff)
     if solution is not None:
         return solution
 
     if coeff((7,0,0)) == 0 and coeff((6,1,0)) == 0:
-        return _sos_struct_septic_symmetric_hexagon(coeff)
+        return _structsos_septic_symmetric_hexagon(coeff)
 
-    return _sos_struct_septic_symmetric_quadratic_form(coeff)
+    return _structsos_septic_symmetric_quadratic_form(coeff)
 
 
-def _sos_struct_septic_symmetric_quadratic_form(coeff: 'Coeff'):
+def _structsos_septic_symmetric_quadratic_form(coeff: 'Coeff'):
     """
     Let `F0 = s(a7+a6b+a6c+a5bc-2a4b3-2a4c3)` and `G0 = s((b+c)(a2+a(b+c)+2bc)2(a-b)(a-c))`.
     Let `f(a,b,c) = g(a,b,c) = s(xa^2+yab)`.
@@ -47,7 +47,7 @@ def _sos_struct_septic_symmetric_quadratic_form(coeff: 'Coeff'):
     For more general septic symmetric polynomials, we first decompose its symmetric axis
     into several `F_{x,y}, G_{x,y}` and then combine them together.
 
-    For a more primary case of degree 6, see `_sos_struct_sextic_symmetric_quadratic_form`.
+    For a more primary case of degree 6, see `_structsos_sextic_symmetric_quadratic_form`.
 
     Examples
     --------
@@ -278,7 +278,7 @@ class _septic_sym_axis(DomainExpr):
                     det2 * CyclicProduct((a-b)**2) * CyclicSum(a) * CyclicProduct(a)
                 )
                 # multiplier = CyclicSum(a*(a-b)*(a-c) + u*a*(b-c)**2)
-                multiplier = _sos_struct_cubic_symmetric(
+                multiplier = _structsos_cubic_symmetric(
                     self._coeff.from_dict({(3,0,0):1, (2,1,0): u-1, (1,2,0): u-1, (1,1,1):3-6*u}))
                 return sol / multiplier, ker_coeff
         return None, 0
@@ -434,14 +434,14 @@ class _septic_sym_axis(DomainExpr):
                     )
 
 
-def _sos_struct_septic_symmetric_hexagon(coeff: 'Coeff'):
+def _structsos_septic_symmetric_hexagon(coeff: 'Coeff'):
     """
     Solve septic hexagons without s(a7), s(a6b) by
     subtracting some `(a-b)**2*(b-c)**2*(c-a)**2*(a+b+c)` so that it does not contain
     s(a5b2). Then it subtracts some `s(a*(b-c)**2*(a*b + a*c - t*b*c)**2)` so that
     the remaining quartic is nonnegative.
 
-    This is also the symmetric case of `sos_struct_septic_star_sdp`.
+    This is also the symmetric case of `structsos_septic_star_sdp`.
 
     Examples
     --------
@@ -508,7 +508,7 @@ def _sos_struct_septic_symmetric_hexagon(coeff: 'Coeff'):
         (4,0,0): c4, (3,1,0): c31, (2,2,0): c22, (3,0,1): c31,
         (1,3,0): c31, (2,1,1): c211,
     })
-    quartic_sol = sos_struct_quartic(quartic, real=False)
+    quartic_sol = structsos_quartic(quartic, real=False)
     if quartic_sol is None:
         return None
 

--- a/triples/core/structsos/ternary/sextic.py
+++ b/triples/core/structsos/ternary/sextic.py
@@ -1,11 +1,11 @@
 from sympy import Poly, Expr, Rational, Float, Add
 from sympy import MutableDenseMatrix as Matrix
 
-from .cubic import sos_struct_cubic
+from .cubic import structsos_cubic
 from .sextic_symmetric import (
-    _sos_struct_sextic_hexagon_symmetric,
-    _sos_struct_sextic_hexagram_symmetric,
-    sos_struct_sextic_symmetric_ultimate
+    _structsos_sextic_hexagon_symmetric,
+    _structsos_sextic_hexagram_symmetric,
+    structsos_sextic_symmetric_ultimate
 )
 from .utils import (
     CommonExpr,
@@ -20,20 +20,20 @@ if TYPE_CHECKING:
         Coeff
     )
 
-def sos_struct_sextic(coeff, real = True):
+def structsos_sextic(coeff, real = True):
     if coeff((5,1,0)) == coeff((1,5,0)) and coeff((4,2,0)) == coeff((2,4,0)) and coeff((3,2,1)) == coeff((3,1,2)):
-        return sos_struct_sextic_symmetric_ultimate(coeff, real = real)
+        return structsos_sextic_symmetric_ultimate(coeff, real = real)
 
     if coeff((6,0,0)) == 0 and coeff((5,1,0)) == 0 and coeff((5,0,1)) == 0:
-        return _sos_struct_sextic_hexagon(coeff, real = real)
+        return _structsos_sextic_hexagon(coeff, real = real)
 
     if coeff((6,0,0)) != 0:
-        return _sos_struct_sextic_full_sdp(coeff)
+        return _structsos_sextic_full_sdp(coeff)
 
     return None
 
 
-def _sos_struct_sextic_hexagram(coeff: 'Coeff'):
+def _structsos_sextic_hexagram(coeff: 'Coeff'):
     """
     Solve s(a3b3+xa4bc+ya3b2c+za2b3c+wa2b2c2) >= 0. The structure is known as hexagrams.
     Typically we multiply `s(a)` to solve it.
@@ -87,14 +87,14 @@ def _sos_struct_sextic_hexagram(coeff: 'Coeff'):
     if coeff((3,3,0)) == 0:
         # degenerates to cubic
         new_coeffs_ = {(3,0,0): coeff((4,1,1)), (2,1,0): coeff((3,2,1)), (1,2,0): coeff((2,3,1)), (1,1,1): coeff((2,2,2))}
-        solution = sos_struct_cubic(coeff.from_dict(new_coeffs_))
+        solution = structsos_cubic(coeff.from_dict(new_coeffs_))
         if solution is not None:
             return solution * CyclicProduct(a)
         return None
     if coeff((4,1,1)) == 0:
         # degenerates to inverse cubic
         new_coeffs_ = {(3,0,0): coeff((3,3,0)), (2,1,0): coeff((2,3,1)), (1,2,0): coeff((3,2,1)), (1,1,1): coeff((2,2,2))}
-        solution = sos_struct_cubic(coeff.from_dict(new_coeffs_))
+        solution = structsos_cubic(coeff.from_dict(new_coeffs_))
         if solution is not None:
             solution = inverse_substitution(coeff, solution, factor_degree = 0)
         return solution
@@ -102,7 +102,7 @@ def _sos_struct_sextic_hexagram(coeff: 'Coeff'):
 
     if coeff((3,2,1)) == coeff((2,3,1)):
         # call symmetric solution in priority
-        solution = _sos_struct_sextic_hexagram_symmetric(coeff)
+        solution = _structsos_sextic_hexagram_symmetric(coeff)
         if solution is not None:
             return solution
 
@@ -393,7 +393,7 @@ def _sos_struct_sextic_hexagram(coeff: 'Coeff'):
     return None
 
 
-def _sos_struct_sextic_hexagon(coeff: 'Coeff', real = True):
+def _structsos_sextic_hexagon(coeff: 'Coeff', real = True):
     """
     Solve hexagon s(a4b2+xa2b4+ya3b3+za4bc+wa3b2c+ua2b3c+...a2b2c2)
 
@@ -419,13 +419,13 @@ def _sos_struct_sextic_hexagon(coeff: 'Coeff', real = True):
     if coeff((4,2,0)) == coeff((4,0,2)) and coeff((3,2,1)) == coeff((2,3,1)):
         # symmetric
         # this case must be handled before (?)
-        return _sos_struct_sextic_hexagon_symmetric(coeff)
+        return _structsos_sextic_hexagon_symmetric(coeff)
 
     if coeff((4,2,0)) == 0 or coeff((4,0,2)) == 0:
         if coeff((4,2,0)) == 0 and coeff((4,0,2)) == 0:
-            return _sos_struct_sextic_hexagram(coeff)
+            return _structsos_sextic_hexagram(coeff)
         if coeff((3,3,0)) == 0 and coeff((4,1,1)) == 0:
-            return _sos_struct_sextic_rotated_tree(coeff)
+            return _structsos_sextic_rotated_tree(coeff)
 
     c420, c240, c330, c411 = [coeff(_) for _ in ((4,2,0),(2,4,0),(3,3,0),(4,1,1))]
     # The hexagon might be positive over a,b,c in R.
@@ -435,18 +435,18 @@ def _sos_struct_sextic_hexagon(coeff: 'Coeff', real = True):
     if can_be_real:
         if real:
             solvers = [
-                _sos_struct_sextic_hexagon_sdp,
-                _sos_struct_sextic_hexagon_sdp2,
-                _sos_struct_sextic_hexagon_to_hexagram
+                _structsos_sextic_hexagon_sdp,
+                _structsos_sextic_hexagon_sdp2,
+                _structsos_sextic_hexagon_to_hexagram
             ]
         else:
             solvers = [
-                _sos_struct_sextic_hexagon_sdp,
-                _sos_struct_sextic_hexagon_to_hexagram,
-                _sos_struct_sextic_hexagon_sdp2,
+                _structsos_sextic_hexagon_sdp,
+                _structsos_sextic_hexagon_to_hexagram,
+                _structsos_sextic_hexagon_sdp2,
             ]
     else:
-        solvers = [_sos_struct_sextic_hexagon_to_hexagram]
+        solvers = [_structsos_sextic_hexagon_to_hexagram]
 
     for solver in solvers:
         solution = solver(coeff)
@@ -454,11 +454,11 @@ def _sos_struct_sextic_hexagon(coeff: 'Coeff', real = True):
             return solution
 
 
-def _sos_struct_sextic_rotated_tree(coeff: 'Coeff'):
+def _structsos_sextic_rotated_tree(coeff: 'Coeff'):
     """
     Solve s(a2b4+ua3b2c+va3bc2-(1+u+v)a2b2c2) >= 0.
     Note that this structure is a rotated version of the symmetric tree.
-    See `_sos_struct_sextic_tree` for details.
+    See `_structsos_sextic_tree` for details.
 
     Examples
     --------
@@ -479,7 +479,7 @@ def _sos_struct_sextic_rotated_tree(coeff: 'Coeff'):
 
     if coeff((4,2,0)) != 0:
         # reflect the polynomial so that coeff((4,2,0)) == 0
-        sol = _sos_struct_sextic_rotated_tree(coeff.reflect())
+        sol = _structsos_sextic_rotated_tree(coeff.reflect())
         return align_cyclic_group(sol, coeff.gens)
 
     a, b, c = coeff.gens
@@ -571,7 +571,7 @@ def _sos_struct_sextic_rotated_tree(coeff: 'Coeff'):
     return None
 
 
-def _sos_struct_sextic_hexagon_full(coeff):
+def _structsos_sextic_hexagon_full(coeff):
     """
     Still in development
 
@@ -608,14 +608,14 @@ def _sos_struct_sextic_hexagon_full(coeff):
 
 
 
-def _sos_struct_sextic_hexagon_sdp(coeff: 'Coeff'):
+def _structsos_sextic_hexagon_sdp(coeff: 'Coeff'):
     """
-    This function is a special case of _sos_struct_sextic_full_sdp
+    This function is a special case of _structsos_sextic_full_sdp
     when coefficients of s(a^6), s(a^5b), s(a^5c) are zero.
 
     We subtract some s((a2b-ac2-x(a2b-b2c)+y(a2c-ab2))^2) so that
     the rest of the polynomial is a quadratic form with respect to
-    s(a^2b-abc) and s(ab^2-abc). See further details at _sos_struct_sextic_full.
+    s(a^2b-abc) and s(ab^2-abc). See further details at _structsos_sextic_full.
 
     The case is degenerated and actually there is no degree of freedom.
 
@@ -663,9 +663,9 @@ def _sos_struct_sextic_hexagon_sdp(coeff: 'Coeff'):
         return quad_form_sol + solution + poly111 * CyclicProduct(a**2)
 
 
-def _sos_struct_sextic_hexagon_sdp2(coeff: 'Coeff'):
+def _structsos_sextic_hexagon_sdp2(coeff: 'Coeff'):
     """
-    This function is a generalization of `_sos_struct_sextic_hexagon_sdp`
+    This function is a generalization of `_structsos_sextic_hexagon_sdp`
     that performs sum-of-squares on the octic `f_2(a,b,c) = f(a,b,c) * s(a^2-ab)`.
 
     """
@@ -728,7 +728,7 @@ def _sos_struct_sextic_hexagon_sdp2(coeff: 'Coeff'):
     #     print('GCD =', discriminant_gcd)
 
 
-def _sos_struct_sextic_hexagon_to_hexagram(coeff: 'Coeff'):
+def _structsos_sextic_hexagon_to_hexagram(coeff: 'Coeff'):
     """
     Solve hexagons by subtracting some `s(c1(a^2b-abc) - c2(ab^2-abc))^2`
     so that the remaing part is a hexagram.
@@ -809,7 +809,7 @@ def _sos_struct_sextic_hexagon_to_hexagram(coeff: 'Coeff'):
         c3 = rationalize_func(eq, _check_valid, validation_initial = lambda x: x >= 0, direction = -1)
 
     if c3 is not None:
-        remain_solution = _sos_struct_sextic_hexagram(_compute_subtracted_params(c3, return_func = True))
+        remain_solution = _structsos_sextic_hexagram(_compute_subtracted_params(c3, return_func = True))
         if remain_solution is not None:
             a, b, c = coeff.gens
             CyclicSum = coeff.cyclic_sum
@@ -819,7 +819,7 @@ def _sos_struct_sextic_hexagon_to_hexagram(coeff: 'Coeff'):
             return main_solution + remain_solution
 
 
-def _sos_struct_sextic_full_sdp(coeff: 'Coeff'):
+def _structsos_sextic_full_sdp(coeff: 'Coeff'):
     """
     Heuristically solve full sextics with the method of unknown coefficients.
     Idea: Let `f(a,b,c) = a^3-b^3+ua^2b+vb^2c-(u+v)ac^2+xab^2+ya^2c-(x+y)bc^2`.

--- a/triples/core/structsos/ternary/sextic_symmetric.py
+++ b/triples/core/structsos/ternary/sextic_symmetric.py
@@ -2086,7 +2086,7 @@ def _structsos_sextic_symmetric_ultimate_1root(coeff: 'Coeff', poly, roots, real
                     .as_poly(a,b,c, domain=poly.domain).mul_ground(coeff6)
                 solution = _structsos_sextic_iran96(coeff.from_poly(poly2), real = real)
                 if solution is not None:
-                    if x_ == Rational(3,2):
+                    if 2*x_ == 3:
                         solution += coeff6 / 4 * CyclicProduct((a+b-2*c)**2)
                     elif x_ == 1:
                         solution += coeff6 * CyclicSum(a*(a-b)*(a-c))**2
@@ -2181,7 +2181,7 @@ def _structsos_sextic_symmetric_ultimate_1root(coeff: 'Coeff', poly, roots, real
                 ((2, 1, 1), 2*z0*z1 + 2*z0*z2 + z1**2 + 2*z1*z2 + 3*z2**2 + 2*z2*z3)
             ]
 
-            quartic_solution = structsos_quartic(coeff.from_dict(dict(quartic)), None)
+            quartic_solution = structsos_quartic(coeff.from_dict(dict(quartic)))
             if quartic_solution is not None:
                 multiplier = CommonExpr.quadratic(2*(2*z0 + z3), 2*(z1 + 2*z2), (a,b,c))
                 p1 = quartic_solution * CyclicSum((a-b)**2*(a+b-x_*c)**2)

--- a/triples/core/structsos/ternary/sextic_symmetric.py
+++ b/triples/core/structsos/ternary/sextic_symmetric.py
@@ -5,9 +5,9 @@ from sympy import Poly, Expr, Symbol, Integer, Rational, Add
 from sympy import oo as Infinity
 from sympy.polys.polyerrors import CoercionFailed
 
-from .quartic import sos_struct_quartic
+from .quartic import structsos_quartic
 from .utils import (
-    DomainExpr, CommonExpr, sos_struct_handle_uncentered,
+    DomainExpr, CommonExpr, structsos_handle_uncentered,
     sum_y_exprs, nroots, rationalize_func, quadratic_weighting
 )
 from ..univariate import prove_univariate
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 #####################################################################
 
 
-def sos_struct_sextic_symmetric_ultimate(coeff, real = True):
+def structsos_sextic_symmetric_ultimate(coeff, real = True):
     """
     Solve symmetric sextics.
     """
@@ -35,14 +35,14 @@ def sos_struct_sextic_symmetric_ultimate(coeff, real = True):
         return None
     elif coeff6 == 0:
         # degenerated
-        return _sos_struct_sextic_iran96(coeff, real = real)
+        return _structsos_sextic_iran96(coeff, real = real)
     elif coeff6 < 0:
         return None
 
     if coeff((5,1,0)) == 0 and coeff((4,2,0)) == 0 and coeff((3,2,1)) == 0 and coeff6 != 0:
-        return _sos_struct_sextic_tree(coeff)
+        return _structsos_sextic_tree(coeff)
 
-    return _sos_struct_sextic_symmetric_ultimate(coeff, real = real)
+    return _structsos_sextic_symmetric_ultimate(coeff, real = real)
 
 
 def _restructure_quartic_polynomial(poly: Poly):
@@ -117,7 +117,7 @@ def _restructure_quartic_polynomial(poly: Poly):
     return t, s, x, y, rem, r
 
 
-def _sos_struct_sextic_hexagon_symmetric_sdp(coeff: 'Coeff'):
+def _structsos_sextic_hexagon_symmetric_sdp(coeff: 'Coeff'):
     """
     Solve symmetric hexagons on real numbers without raising the degree.
     The idea is to subtract some CyclicSum(f(a,b,c)**2) so that the remainder
@@ -137,7 +137,7 @@ def _sos_struct_sextic_hexagon_symmetric_sdp(coeff: 'Coeff'):
     where l22 = poly(1,1,1) > 0. To ensure det >= 0, we find u that maximizes the Schur complement:
     u = argmax {l22 - [M02, M02] * [M00, M01; M01, M00]^-1 * [M02, M02]}
 
-    See similar methods at _sos_struct_sextic_hexagon_sdp and _sos_struct_octic_symmetric_hexagon_sdp.
+    See similar methods at _structsos_sextic_hexagon_sdp and _structsos_octic_symmetric_hexagon_sdp.
     """
     a, b, c = coeff.gens
     CyclicSum, CyclicProduct = coeff.cyclic_sum, coeff.cyclic_product
@@ -234,7 +234,7 @@ def _sos_struct_sextic_hexagon_symmetric_sdp(coeff: 'Coeff'):
     return _compute_sol(u)
 
 
-def _sos_struct_sextic_hexagon_symmetric(coeff: 'Coeff', real = False):
+def _structsos_sextic_hexagon_symmetric(coeff: 'Coeff', real = False):
     """
     Solve symmetric hexagons without `a^6, a^5b` terms.
     Although we can subtract `p(a-b)^2` to make the polynomial a positive hexagram on R+,
@@ -307,7 +307,7 @@ def _sos_struct_sextic_hexagon_symmetric(coeff: 'Coeff', real = False):
     """
     if coeff((4,2,0)) <= 0:
         if coeff((4,2,0)) == 0:
-            return _sos_struct_sextic_hexagram_symmetric(coeff)
+            return _structsos_sextic_hexagram_symmetric(coeff)
         return None
 
     rem = (coeff((4,2,0)) + coeff((3,2,1))) * 6 + (coeff((3,3,0)) + coeff((4,1,1))) * 3 + coeff((2,2,2))
@@ -316,7 +316,7 @@ def _sos_struct_sextic_hexagon_symmetric(coeff: 'Coeff', real = False):
 
     # although subtracting p(a-b)2 always succeeds,
     # we can handle cases for real numbers and cases where raising the degree is not necessary
-    solution = _sos_struct_sextic_hexagon_symmetric_sdp(coeff)
+    solution = _structsos_sextic_hexagon_symmetric_sdp(coeff)
     if solution is not None:
         return solution
 
@@ -444,14 +444,14 @@ def _sos_struct_sextic_hexagon_symmetric(coeff: 'Coeff', real = False):
             (2,2,2): coeff((2,2,2)) + 6 * t
         }
 
-        solution = _sos_struct_sextic_hexagram_symmetric(coeff.from_dict(new_coeffs_))
+        solution = _structsos_sextic_hexagram_symmetric(coeff.from_dict(new_coeffs_))
         if solution is not None:
             return solution + coeff((4,2,0)) * CyclicProduct((a-b)**2)
 
     return None
 
 
-def _sos_struct_sextic_hexagram_symmetric(coeff: 'Coeff'):
+def _structsos_sextic_hexagram_symmetric(coeff: 'Coeff'):
     """
     Solve s(a3b3+xa4bc+ya3b2c+ya2b3c+wa2b2c2) >= 0
 
@@ -597,7 +597,7 @@ def _sos_struct_sextic_hexagram_symmetric(coeff: 'Coeff'):
     return None
 
 
-def _sos_struct_sextic_tree(coeff: 'Coeff'):
+def _structsos_sextic_tree(coeff: 'Coeff'):
     """
     Solve s(a6 + ua3b3 + va4bc - (1+u+v)a2b2c2) >= 0
 
@@ -700,7 +700,7 @@ def _sos_struct_sextic_tree(coeff: 'Coeff'):
     return None
 
 
-def _sos_struct_sextic_symmetric_schur_split(coeff: 'Coeff', real = False):
+def _structsos_sextic_symmetric_schur_split(coeff: 'Coeff', real = False):
     """
     Try solving sextics by rewriting them as sum of squares of Schur polynomials.
 
@@ -804,13 +804,13 @@ def _sos_struct_sextic_symmetric_schur_split(coeff: 'Coeff', real = False):
     # lifted_coeff = coeff * (a+b+c).as_poly(a,b,c, domain=coeff.domain)
     lifted_coeff = coeff * coeff.from_dict({(1,0,0):1,(0,1,0):1,(0,0,1):1}).as_poly()
 
-    from .dense_symmetric import sos_struct_liftfree_for_six
-    solution = sos_struct_liftfree_for_six(lifted_coeff)
+    from .dense_symmetric import structsos_liftfree_for_six
+    solution = structsos_liftfree_for_six(lifted_coeff)
     if solution is not None:
         return solution / CyclicSum(a)
 
 
-def _sos_struct_sextic_iran96(coeff: 'Coeff', real = False):
+def _structsos_sextic_iran96(coeff: 'Coeff', real = False):
     """
     Solve `s(a5b+ab5-x(a4b2+a2b4)+ya3b3-za4bc+w(a3b2c+a2b3c)+..a2b2c2) >= 0`
 
@@ -900,10 +900,10 @@ def _sos_struct_sextic_iran96(coeff: 'Coeff', real = False):
         return None
     elif c51 == 0:
         # only perform sum of squares for real numbers when explicitly inquired
-        return _sos_struct_sextic_hexagon_symmetric(coeff, real = real)
+        return _structsos_sextic_hexagon_symmetric(coeff, real = real)
 
     # solve easy cases
-    solution = _sos_struct_sextic_iran96_trivial(coeff)
+    solution = _structsos_sextic_iran96_trivial(coeff)
     if solution is not None:
         return solution
 
@@ -973,7 +973,7 @@ def _sos_struct_sextic_iran96(coeff: 'Coeff', real = False):
     ) / sa
 
 
-def _sos_struct_sextic_iran96_trivial(coeff: 'Coeff'):
+def _structsos_sextic_iran96_trivial(coeff: 'Coeff'):
     """
     Solve easy cases of Iran96 type inequalities where degree
     lifting is not needed.
@@ -986,9 +986,9 @@ def _sos_struct_sextic_iran96_trivial(coeff: 'Coeff'):
         return None
     elif m == 0:
         # only perform sum of squares for real numbers when explicitly inquired
-        return _sos_struct_sextic_hexagon_symmetric(coeff)
+        return _structsos_sextic_hexagon_symmetric(coeff)
 
-    solution = _sos_struct_sextic_symmetric_schur_split(coeff)
+    solution = _structsos_sextic_symmetric_schur_split(coeff)
     if solution is not None:
         return solution
 
@@ -1133,7 +1133,7 @@ def _sos_struct_sextic_iran96_trivial(coeff: 'Coeff'):
                 return sum_y_exprs(y, exprs)
 
 
-def _sos_struct_sextic_symmetric_full_sdp(coeff: 'Coeff'):
+def _structsos_sextic_symmetric_full_sdp(coeff: 'Coeff'):
     """
     Assume `f(1,1,1) = 0`. Represent `f` as
     ```
@@ -1292,7 +1292,7 @@ def _sos_struct_sextic_symmetric_full_sdp(coeff: 'Coeff'):
         return _get_solution(u0)
 
 
-def _sos_struct_sextic_symmetric_quadratic_form(poly, coeff: 'Coeff'):
+def _structsos_sextic_symmetric_quadratic_form(poly, coeff: 'Coeff'):
     """
     Theorem:
     Let `F0 = s(a^6+a^5b+a^5c+a^4bc-2a^3b^2c-2a^3bc^2)` and `f(a,b,c) = s(xa^2 + yab)`.
@@ -1875,8 +1875,8 @@ class _sextic_sym_axis(DomainExpr):
             return solutions[0]
 
 
-@sos_struct_handle_uncentered
-def _sos_struct_sextic_symmetric_ultimate(coeff: 'Coeff', real = True):
+@structsos_handle_uncentered
+def _structsos_sextic_symmetric_ultimate(coeff: 'Coeff', real = True):
     """
     Handle nondegenerated symmetric sextic polynomial inequalities.
 
@@ -1951,14 +1951,14 @@ def _sos_struct_sextic_symmetric_ultimate(coeff: 'Coeff', real = True):
                     n * (a**2*b**2 + b**2*c**2 + c**2*a**2) +
                     (u - m - 2*p - n) * (a**2*b*c + b**2*c*a + c**2*a*b)
                 ).as_poly(a,b,c, domain=coeff.domain)
-                solution = sos_struct_quartic(coeff.from_poly(poly_div_quad))
+                solution = structsos_quartic(coeff.from_poly(poly_div_quad))
                 if solution is not None:
                     solution = Rational(1,2) * CyclicSum((a-b)**2) * solution
                     return solution
                 return None
 
         # try full sdp
-        solution = _sos_struct_sextic_symmetric_full_sdp(coeff)
+        solution = _structsos_sextic_symmetric_full_sdp(coeff)
         if solution is not None:
             return solution
 
@@ -1967,14 +1967,14 @@ def _sos_struct_sextic_symmetric_ultimate(coeff: 'Coeff', real = True):
         poly = coeff.as_poly()
         if coeff.is_rational:
             try:
-                solution = _sos_struct_sextic_symmetric_quadratic_form(poly, coeff)
+                solution = _structsos_sextic_symmetric_quadratic_form(poly, coeff)
                 if solution is not None:
                     return solution
             except Exception as e:
                 raise e
                 pass
 
-    solution = _sos_struct_sextic_symmetric_schur_split(coeff, real = real)
+    solution = _structsos_sextic_symmetric_schur_split(coeff, real = real)
     if solution is not None:
         return solution
 
@@ -2026,13 +2026,13 @@ def _sos_struct_sextic_symmetric_ultimate(coeff: 'Coeff', real = True):
     sum_of_roots = sum((len(_) > 0) for _ in roots)
 
     if sum_of_roots == 1:
-        return _sos_struct_sextic_symmetric_ultimate_1root(coeff, poly, roots, real = real)
+        return _structsos_sextic_symmetric_ultimate_1root(coeff, poly, roots, real = real)
     elif sum_of_roots == 2:
-        return _sos_struct_sextic_symmetric_ultimate_2roots(coeff, poly, roots)
+        return _structsos_sextic_symmetric_ultimate_2roots(coeff, poly, roots)
 
     return None
 
-def _sos_struct_sextic_symmetric_ultimate_1root(coeff: 'Coeff', poly, roots, real = True):
+def _structsos_sextic_symmetric_ultimate_1root(coeff: 'Coeff', poly, roots, real = True):
     """
     Examples
     -------
@@ -2084,7 +2084,7 @@ def _sos_struct_sextic_symmetric_ultimate_1root(coeff: 'Coeff', poly, roots, rea
             if coeff((5,1,0)) >= -2 * x_:
                 poly2 = poly - ((a**3+b**3+c**3-3*a*b*c-x_*(a*a*(b+c)+b*b*(c+a)+c*c*(a+b)-6*a*b*c))**2)\
                     .as_poly(a,b,c, domain=poly.domain).mul_ground(coeff6)
-                solution = _sos_struct_sextic_iran96(coeff.from_poly(poly2), real = real)
+                solution = _structsos_sextic_iran96(coeff.from_poly(poly2), real = real)
                 if solution is not None:
                     if x_ == Rational(3,2):
                         solution += coeff6 / 4 * CyclicProduct((a+b-2*c)**2)
@@ -2181,7 +2181,7 @@ def _sos_struct_sextic_symmetric_ultimate_1root(coeff: 'Coeff', poly, roots, rea
                 ((2, 1, 1), 2*z0*z1 + 2*z0*z2 + z1**2 + 2*z1*z2 + 3*z2**2 + 2*z2*z3)
             ]
 
-            quartic_solution = sos_struct_quartic(coeff.from_dict(dict(quartic)), None)
+            quartic_solution = structsos_quartic(coeff.from_dict(dict(quartic)), None)
             if quartic_solution is not None:
                 multiplier = CommonExpr.quadratic(2*(2*z0 + z3), 2*(z1 + 2*z2), (a,b,c))
                 p1 = quartic_solution * CyclicSum((a-b)**2*(a+b-x_*c)**2)
@@ -2193,7 +2193,7 @@ def _sos_struct_sextic_symmetric_ultimate_1root(coeff: 'Coeff', poly, roots, rea
     return None
 
 
-def _sos_struct_sextic_symmetric_ultimate_2roots(coeff: 'Coeff', poly, roots):
+def _structsos_sextic_symmetric_ultimate_2roots(coeff: 'Coeff', poly, roots):
     """
 
     Examples
@@ -2297,7 +2297,7 @@ def _sos_struct_sextic_symmetric_ultimate_2roots(coeff: 'Coeff', poly, roots):
 
         if diffpoly is not None:
             new_poly = poly - diffpoly.mul_ground(coeff6)
-            rest_solution = _sos_struct_sextic_iran96(coeff.from_poly(new_poly))
+            rest_solution = _structsos_sextic_iran96(coeff.from_poly(new_poly))
             if rest_solution is not None:
                 return (solution + rest_solution).together()
 

--- a/triples/core/structsos/ternary/solver.py
+++ b/triples/core/structsos/ternary/solver.py
@@ -3,40 +3,40 @@ from typing import Union, Dict, Optional, TYPE_CHECKING
 from sympy import Function
 from sympy.core.symbol import uniquely_named_symbol
 
-from .sparse  import sos_struct_sparse, sos_struct_heuristic
-from .dense_symmetric import sos_struct_ternary_dense_partial_symmetric
-from .quadratic import sos_struct_quadratic, sos_struct_acyclic_quadratic
-from .cubic   import sos_struct_cubic, sos_struct_acyclic_cubic
-from .quartic import sos_struct_quartic, sos_struct_acyclic_quartic
-from .quintic import sos_struct_quintic
-from .sextic  import sos_struct_sextic
-from .septic  import sos_struct_septic
-from .octic   import sos_struct_octic
-from .nonic   import sos_struct_nonic
-from .acyclic import sos_struct_acyclic_sparse
+from .sparse  import structsos_sparse, structsos_heuristic
+from .dense_symmetric import structsos_ternary_dense_partial_symmetric
+from .quadratic import structsos_quadratic, structsos_acyclic_quadratic
+from .cubic   import structsos_cubic, structsos_acyclic_cubic
+from .quartic import structsos_quartic, structsos_acyclic_quartic
+from .quintic import structsos_quintic
+from .sextic  import structsos_sextic
+from .septic  import structsos_septic
+from .octic   import structsos_octic
+from .nonic   import structsos_nonic
+from .acyclic import structsos_acyclic_sparse
 
 from ..utils import Coeff, PolynomialNonpositiveError, PolynomialUnsolvableError
-from ..sparse import sos_struct_common, sos_struct_degree_specified_solver
+from ..sparse import structsos_common, structsos_degree_specified_solver
 from ..solution import SolutionStructural
 
 if TYPE_CHECKING:
     from sympy import Poly, Expr
 
 SOLVERS = {
-    2: sos_struct_quadratic,
-    3: sos_struct_cubic,
-    4: sos_struct_quartic,
-    5: sos_struct_quintic,
-    6: sos_struct_sextic,
-    7: sos_struct_septic,
-    8: sos_struct_octic,
-    9: sos_struct_nonic,
+    2: structsos_quadratic,
+    3: structsos_cubic,
+    4: structsos_quartic,
+    5: structsos_quintic,
+    6: structsos_sextic,
+    7: structsos_septic,
+    8: structsos_octic,
+    9: structsos_nonic,
 }
 
 SOLVERS_ACYCLIC = {
-    2: sos_struct_acyclic_quadratic,
-    3: sos_struct_acyclic_cubic,
-    4: sos_struct_acyclic_quartic
+    2: structsos_acyclic_quadratic,
+    3: structsos_acyclic_cubic,
+    4: structsos_acyclic_quartic
 }
 
 
@@ -51,10 +51,10 @@ def _structural_sos_3vars_cyclic(
     if not isinstance(coeff, Coeff):
         coeff = Coeff(coeff)
 
-    return sos_struct_common(coeff,
-        sos_struct_sparse,
-        sos_struct_degree_specified_solver(SOLVERS, homogeneous=True),
-        sos_struct_heuristic,
+    return structsos_common(coeff,
+        structsos_sparse,
+        structsos_degree_specified_solver(SOLVERS, homogeneous=True),
+        structsos_heuristic,
         real=real
     )
 
@@ -69,10 +69,10 @@ def _structural_sos_3vars_acyclic(
     if not isinstance(coeff, Coeff):
         coeff = Coeff(coeff)
 
-    return sos_struct_common(coeff,
-        sos_struct_acyclic_sparse,
-        sos_struct_degree_specified_solver(SOLVERS_ACYCLIC, homogeneous=True),
-        sos_struct_ternary_dense_partial_symmetric,
+    return structsos_common(coeff,
+        structsos_acyclic_sparse,
+        structsos_degree_specified_solver(SOLVERS_ACYCLIC, homogeneous=True),
+        structsos_ternary_dense_partial_symmetric,
         real=real
     )
 

--- a/triples/core/structsos/ternary/solver.py
+++ b/triples/core/structsos/ternary/solver.py
@@ -144,9 +144,14 @@ def structural_sos_3vars(
         dod = {i: {m.index(1): v for m, v in ineq.rep.terms()}
                for i, ineq in enumerate(linear_ineqs)}
         mat = rep_matrix_from_dict(dod, (len(dod), nvars), dom)
-        if mat._rep.rank() == nvars:
+
+        if len(mat._rep.to_field().rref()[1]) == nvars:
+            # use rref rather DomainMatrix.rank for version compatibility
+
             if mat.shape[0] == nvars:
-                if mat._rep.nnz() == nvars:
+                if len(mat._rep.to_dok()) == nvars:
+                    # use to_dok rather nnz for version compatibility
+
                     # permutation matrix
                     # TODO: flip the sign of the entries so
                     # that all entries are nonnegative

--- a/triples/core/structsos/ternary/solver.py
+++ b/triples/core/structsos/ternary/solver.py
@@ -17,7 +17,7 @@ from .acyclic import structsos_acyclic_sparse
 
 from ..utils import Coeff, PolynomialNonpositiveError, PolynomialUnsolvableError
 from ..sparse import structsos_common, structsos_degree_specified_solver
-from ..solution import SolutionStructural
+from ...solution import extract_undetermined_exprs
 
 if TYPE_CHECKING:
     from sympy import Poly, Expr
@@ -124,7 +124,7 @@ def structural_sos_3vars(
     ####################################################################
     func_name = uniquely_named_symbol('G', poly.gens + tuple(ineq_constraints.values()))
     func = Function(func_name)
-    solution = SolutionStructural._extract_nonnegative_exprs(solution, func_name=func_name)
+    solution = extract_undetermined_exprs(solution, func)
     if solution is None:
         return None
 

--- a/triples/core/structsos/ternary/solver.py
+++ b/triples/core/structsos/ternary/solver.py
@@ -21,6 +21,7 @@ from ..solution import SolutionStructural
 
 if TYPE_CHECKING:
     from sympy import Poly, Expr
+    from ...problem import InequalityProblem
 
 SOLVERS = {
     2: structsos_quadratic,
@@ -76,14 +77,17 @@ def _structural_sos_3vars_acyclic(
         real=real
     )
 
+
 def structural_sos_3vars(
-    poly,
-    ineq_constraints: Dict["Poly", "Expr"] = {},
-    eq_constraints: Dict["Poly", "Expr"] = {}
+    problem: "InequalityProblem"
 ) -> Optional["Expr"]:
     """
     Main function of structural SOS for 3-var homogeneous polynomials.
     """
+    poly: "Poly" = problem.expr
+    ineq_constraints = problem.ineq_constraints
+    # eq_constraints = problem.eq_constraints
+
     if len(poly.gens) != 3: # should not happen
         raise ValueError("structural_sos_3vars only supports 3-var polynomials.")
 
@@ -91,15 +95,20 @@ def structural_sos_3vars(
     if not is_hom: # should not happen
         raise ValueError("structural_sos_3vars only supports homogeneous polynomials.")
 
+    # check whether the variables are in the nonnegative orthant
+    signs = problem.get_symbol_signs()
+    is_pos = lambda x: (x is not None) and x >= 0
+    r_plus = all(is_pos(signs.get(x, (-1, -1))[0]) for x in poly.gens)
+
+    if (not r_plus) and poly.total_degree() % 2 == 1:
+        # TODO: try to disprove the problem
+        return None
+
+
     coeff_poly = Coeff(poly)
     is_cyc = coeff_poly.is_cyclic()
-    if len(ineq_constraints) == 0 and len(eq_constraints) == 0 and poly.total_degree() % 2 == 1:
-        return
-
-    if is_cyc:
-        func = _structural_sos_3vars_cyclic
-    else:
-        func = _structural_sos_3vars_acyclic
+    func = _structural_sos_3vars_cyclic if is_cyc\
+        else _structural_sos_3vars_acyclic
 
     try:
         solution = func(coeff_poly, real = 1)
@@ -119,10 +128,7 @@ def structural_sos_3vars(
     if solution is None:
         return None
 
-    replacement = {}
-    for k, v in ineq_constraints.items():
-        if len(k.free_symbols) == 1 and k.is_monomial and k.LC() >= 0:
-            replacement[func(k.free_symbols.pop())] = v/k.LC()
+    replacement = {func(x): v for x, (sgn, v) in signs.items() if is_pos(sgn)}
     solution = solution.xreplace(replacement)
 
     if solution.has(func):

--- a/triples/core/structsos/ternary/solver.py
+++ b/triples/core/structsos/ternary/solver.py
@@ -140,7 +140,7 @@ def structural_sos_3vars(
         dom = next(iter(linear_ineqs)).domain.get_field()
         for ineq in linear_ineqs:
             dom = dom.unify(ineq.domain)
-        linear_ineqs = {ineq.set_domain(dom) for ineq in linear_ineqs}
+        linear_ineqs = {ineq.set_domain(dom): v for ineq, v in linear_ineqs.items()}
         dod = {i: {m.index(1): v for m, v in ineq.rep.terms()}
                for i, ineq in enumerate(linear_ineqs)}
         mat = rep_matrix_from_dict(dod, (len(dod), nvars), dom)
@@ -159,11 +159,26 @@ def structural_sos_3vars(
                         mat2 = permute_matrix_rows(mat, [0, 2, 1])
                         if _is_cyclic_mat(mat2):
                             mat = mat2
+                            ll = list(linear_ineqs.items())
+                            ll[1], ll[2] = ll[2], ll[1]
+                            linear_ineqs = dict(ll)
 
                     inv_mat = mat._fromrep(mat._rep.inv())
-                    # TODO: try not to change the variable first
-                    dot = lambda i, j: sum(ik * jk for ik, jk in zip(i, j))
+                    dot = lambda u, v: sum(uk * vk for uk, vk in zip(u, v))
 
+                    # try not to change the variables first
+                    new_ineqs = {}
+                    if all(entry >= 0 for entry in inv_mat):
+                        # this implies a, b, c >= 0
+                        new_ineqs = {g.as_poly(gens): dot(row, linear_ineqs.values())
+                                     for g, row in zip(gens, inv_mat.tolist())}
+                    new_problem = problem.new(poly, new_ineqs)
+                    solution = structural_sos_3vars(new_problem)
+                    if solution is not None:
+                        return solution
+
+
+                    # change the variables
                     new_problem, restore = problem.transform(
                         {g: dot(row, gens) for g, row in zip(gens, inv_mat.tolist())},
                         {g: dot(row, gens) for g, row in zip(gens, mat.tolist())}

--- a/triples/core/structsos/ternary/solver.py
+++ b/triples/core/structsos/ternary/solver.py
@@ -43,11 +43,21 @@ SOLVERS_ACYCLIC = {
 
 def _structural_sos_3vars_cyclic(
     coeff: Union["Poly", Coeff, Dict],
-    real: bool = True
+    real: int = 1
 ) -> Optional["Expr"]:
     """
-    Internal function to solve a 3-var homogeneous cyclic polynomial using structural SOS.
-    It does not check the homogeneous / cyclic property of the polynomial to save time.
+    Internal function to solve a 3-var homogeneous cyclic polynomial 
+    using structural SOS. It does not check the homogeneous / cyclic
+    property of the polynomial to save time.
+
+    Parameters
+    ----------
+    coeff : Union["Poly", Coeff, Dict]
+        The polynomial to solve.
+    real : int, optional
+        If 2, it demands only solutions with variables in R.
+        If 1, it demands solutions with variables in R in prior.
+        If 0, it demands solutions with variables in R+.
     """
     if not isinstance(coeff, Coeff):
         coeff = Coeff(coeff)
@@ -61,11 +71,21 @@ def _structural_sos_3vars_cyclic(
 
 def _structural_sos_3vars_acyclic(
     coeff: Union["Poly", Coeff, Dict],
-    real: bool = True
+    real: int = 1
 ) -> Optional["Expr"]:
     """
-    Internal function to solve a 3-var homogeneous acyclic polynomial using structural SOS.
-    It does not check the homogeneous / cyclic property of the polynomial to save time.
+    Internal function to solve a 3-var homogeneous acyclic polynomial 
+    using structural SOS. It does not check the homogeneous / cyclic
+    property of the polynomial to save time.
+
+    Parameters
+    ----------
+    coeff : Union["Poly", Coeff, Dict]
+        The polynomial to solve.
+    real : int, optional
+        If 2, it demands only solutions with variables in R.
+        If 1, it demands solutions with variables in R in prior.
+        If 0, it demands solutions with variables in R+.
     """
     if not isinstance(coeff, Coeff):
         coeff = Coeff(coeff)
@@ -111,7 +131,8 @@ def structural_sos_3vars(
         else _structural_sos_3vars_acyclic
 
     try:
-        solution = func(coeff_poly, real = 1)
+        param_real = 1 if r_plus else 2
+        solution = func(coeff_poly, real = 2)
     except (PolynomialNonpositiveError, PolynomialUnsolvableError):
         return None
 

--- a/triples/core/structsos/ternary/solver.py
+++ b/triples/core/structsos/ternary/solver.py
@@ -18,6 +18,7 @@ from .acyclic import structsos_acyclic_sparse
 from ..utils import Coeff, PolynomialNonpositiveError, PolynomialUnsolvableError
 from ..sparse import structsos_common, structsos_degree_specified_solver
 from ...solution import extract_undetermined_exprs
+from ....sdp.arithmetic import rep_matrix_from_dict, permute_matrix_rows
 
 if TYPE_CHECKING:
     from sympy import Poly, Expr
@@ -41,12 +42,24 @@ SOLVERS_ACYCLIC = {
 }
 
 
+def _is_cyclic_mat(M):
+    if M.shape[0] != M.shape[1]:
+        return False
+    ddm = M._rep.rep.to_ddm()
+    n = M.shape[0]
+    for i in range(n):
+        for j in range(n):
+            if ddm[i][j] != ddm[(i+1)%n][(j+1)%n]:
+                return False
+    return True
+
+
 def _structural_sos_3vars_cyclic(
     coeff: Union["Poly", Coeff, Dict],
     real: int = 1
 ) -> Optional["Expr"]:
     """
-    Internal function to solve a 3-var homogeneous cyclic polynomial 
+    Internal function to solve a 3-var homogeneous cyclic polynomial
     using structural SOS. It does not check the homogeneous / cyclic
     property of the polynomial to save time.
 
@@ -74,7 +87,7 @@ def _structural_sos_3vars_acyclic(
     real: int = 1
 ) -> Optional["Expr"]:
     """
-    Internal function to solve a 3-var homogeneous acyclic polynomial 
+    Internal function to solve a 3-var homogeneous acyclic polynomial
     using structural SOS. It does not check the homogeneous / cyclic
     property of the polynomial to save time.
 
@@ -105,15 +118,63 @@ def structural_sos_3vars(
     Main function of structural SOS for 3-var homogeneous polynomials.
     """
     poly: "Poly" = problem.expr
+    gens = problem.gens
     ineq_constraints = problem.ineq_constraints
     # eq_constraints = problem.eq_constraints
 
-    if len(poly.gens) != 3: # should not happen
-        raise ValueError("structural_sos_3vars only supports 3-var polynomials.")
+    if len(gens) != 3: # should not happen
+        return None
+    if poly.domain.is_EX or poly.domain.is_EXRAW:
+        return None
 
     is_hom = poly.is_homogeneous
     if not is_hom: # should not happen
-        raise ValueError("structural_sos_3vars only supports homogeneous polynomials.")
+        return None
+
+
+    # get linear constraints and stack them as a matrix
+    nvars = len(gens) # == 3
+    linear_ineqs: Dict["Poly", "Expr"] = {k: v for k, v in ineq_constraints.items()
+                    if k.total_degree() == 1 and k.coeff_monomial((0,)*nvars) == 0}
+    if linear_ineqs:
+        dom = next(iter(linear_ineqs)).domain.get_field()
+        for ineq in linear_ineqs:
+            dom = dom.unify(ineq.domain)
+        linear_ineqs = {ineq.set_domain(dom) for ineq in linear_ineqs}
+        dod = {i: {m.index(1): v for m, v in ineq.rep.terms()}
+               for i, ineq in enumerate(linear_ineqs)}
+        mat = rep_matrix_from_dict(dod, (len(dod), nvars), dom)
+        if mat._rep.rank() == nvars:
+            if mat.shape[0] == nvars:
+                if mat._rep.nnz() == nvars:
+                    # permutation matrix
+                    # TODO: flip the sign of the entries so
+                    # that all entries are nonnegative
+                    pass
+                else:
+                    # change the variables
+
+                    # try to rearrange the matrix so that it is cyclic
+                    if not _is_cyclic_mat(mat):
+                        mat2 = permute_matrix_rows(mat, [0, 2, 1])
+                        if _is_cyclic_mat(mat2):
+                            mat = mat2
+
+                    inv_mat = mat._fromrep(mat._rep.inv())
+                    # TODO: try not to change the variable first
+                    dot = lambda i, j: sum(ik * jk for ik, jk in zip(i, j))
+
+                    new_problem, restore = problem.transform(
+                        {g: dot(row, gens) for g, row in zip(gens, inv_mat.tolist())},
+                        {g: dot(row, gens) for g, row in zip(gens, mat.tolist())}
+                    )
+                    new_problem = new_problem.remove_redundancy().polylize()
+                    return restore(structural_sos_3vars(new_problem))
+            else:
+                # TODO: handle the case when mat.shape[0] > 3:
+                # e.g., use LP to determine the active linear constraints
+                pass
+
 
     # check whether the variables are in the nonnegative orthant
     signs = problem.get_symbol_signs()
@@ -132,7 +193,7 @@ def structural_sos_3vars(
 
     try:
         param_real = 1 if r_plus else 2
-        solution = func(coeff_poly, real = 2)
+        solution = func(coeff_poly, real = param_real)
     except (PolynomialNonpositiveError, PolynomialUnsolvableError):
         return None
 

--- a/triples/core/structsos/ternary/sparse.py
+++ b/triples/core/structsos/ternary/sparse.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from .utils import Coeff
     from sympy import Rational
 
-def structsos_sparse(coeff, real = True):
+def structsos_sparse(coeff, real=1):
     """
     Solver to very sparse inequalities like AM-GM.
 
@@ -47,7 +47,7 @@ def structsos_sparse(coeff, real = True):
         elif degree == 4:
             # quartic should be handled by _structsos_quartic
             # because it presents proof for real numbers
-            return structsos_quartic(coeff, None)
+            return structsos_quartic(coeff, real=real)
 
     if len(coeff) <= 6:
         return _structsos_sparse_amgm(coeff)

--- a/triples/core/structsos/ternary/sparse.py
+++ b/triples/core/structsos/ternary/sparse.py
@@ -6,17 +6,17 @@ from sympy import Poly, Expr, Integer, Add, Mul
 from sympy.combinatorics import CyclicGroup
 
 from .utils import DomainExpr, CyclicSum
-from .dense_symmetric import sos_struct_dense_symmetric
-from .quadratic import sos_struct_quadratic
-from .cubic import sos_struct_cubic
-from .quartic import sos_struct_quartic
+from .dense_symmetric import structsos_dense_symmetric
+from .quadratic import structsos_quadratic
+from .cubic import structsos_cubic
+from .quartic import structsos_quartic
 from ..univariate import prove_univariate
 
 if TYPE_CHECKING:
     from .utils import Coeff
     from sympy import Rational
 
-def sos_struct_sparse(coeff, real = True):
+def structsos_sparse(coeff, real = True):
     """
     Solver to very sparse inequalities like AM-GM.
 
@@ -41,16 +41,16 @@ def sos_struct_sparse(coeff, real = True):
             v = coeff((1,0,0))
             return v * CyclicSum(a) if v >= 0 else None
         elif degree == 2:
-            return sos_struct_quadratic(coeff)
+            return structsos_quadratic(coeff)
         elif degree == 3:
-            return sos_struct_cubic(coeff)
+            return structsos_cubic(coeff)
         elif degree == 4:
-            # quartic should be handled by _sos_struct_quartic
+            # quartic should be handled by _structsos_quartic
             # because it presents proof for real numbers
-            return sos_struct_quartic(coeff, None)
+            return structsos_quartic(coeff, None)
 
     if len(coeff) <= 6:
-        return _sos_struct_sparse_amgm(coeff)
+        return _structsos_sparse_amgm(coeff)
 
 
 
@@ -393,7 +393,7 @@ class AMGM3(DomainExpr):
             if sol1 is not None and sol2 is not None:
                 return sol1 + sol2
 
-def _sos_struct_sparse_amgm(coeff):
+def _structsos_sparse_amgm(coeff):
     """
     Solve
     sum coeff(large) * a^u*b^v*c^w + sum coeff(small) * a^x*b^y*c^z >= 0
@@ -664,7 +664,7 @@ class Hnmr(DomainExpr):
 
 
 
-def sos_struct_heuristic(coeff: 'Coeff', real=True):
+def structsos_heuristic(coeff: 'Coeff', real=True):
     """
     Solve high-degree but sparse inequalities by heuristic method.
     It subtracts some structures from the inequality and calls
@@ -684,7 +684,7 @@ def sos_struct_heuristic(coeff: 'Coeff', real=True):
     if degree <= 6:
         return None
     if True:
-        solution = sos_struct_dense_symmetric(coeff, real = real)
+        solution = structsos_dense_symmetric(coeff, real = real)
         if solution is not None:
             return solution
 

--- a/triples/core/structsos/ternary/tests/test_ternary.py
+++ b/triples/core/structsos/ternary/tests/test_ternary.py
@@ -1,6 +1,11 @@
 from .....testing.doctest_parser import run_doctest_examples, discover_functions_from_scope
 
-from sympy.abc import a, b, c
+from sympy import Function
+from sympy.abc import a, b, c, u, v, w
+
+from ...structsos import StructuralSOS
+from .....utils import pl, CyclicSum
+from .....testing.doctest_parser import solution_checker
 
 import pytest
 
@@ -13,7 +18,6 @@ ternary_funcs = discover_functions_from_scope("triples.core.structsos.ternary")
     ids = [f"{_[0]}:{_[1]}" for _ in ternary_funcs]
 )
 def test_doc_structsos_ternary(func):
-    from ...structsos import StructuralSOS
     solver = lambda *args, **kwargs: \
         StructuralSOS(*args, **kwargs, raise_exception=True)
 
@@ -25,3 +29,22 @@ def test_doc_structsos_ternary(func):
             "return_type": "poly",
         }
     )
+
+
+def test_structsos_ternary_linear_substitution():
+    F = Function("F")
+
+    sol = StructuralSOS(pl("s(a5(a-b)(a-c))"), [b+c-a,c+a-b,a+b-c])
+    assert solution_checker(sol) and sol.solution.has(CyclicSum)
+
+    sol = StructuralSOS(pl("s(a(b+c)(a-b)(a-c))"), {b+c-a: u, c+a-b: v, a+b-c: w})
+    assert solution_checker(sol)
+
+    sol = StructuralSOS(pl("s(a(b+c)(a-b)(a-c))"), {b+c-a: F(a), c+a-b: F(b), a+b-c: F(c)})
+    assert solution_checker(sol) and sol.solution.has(CyclicSum)
+
+    sol = StructuralSOS(pl("s(a(b+c)(a-b)(a-c))"), [b+c-a,c+a-b,a+b-c])
+    assert solution_checker(sol) and sol.solution.has(CyclicSum)
+
+    sol = StructuralSOS(pl("s((b+c-3a)3(a-b)(a-c))"), {b+c-3*a: u, c+a-3*b: v, a+b-3*c: w})
+    assert solution_checker(sol)

--- a/triples/core/structsos/ternary/utils.py
+++ b/triples/core/structsos/ternary/utils.py
@@ -6,7 +6,7 @@ from sympy import Poly, Add, Mul, Pow
 from sympy.combinatorics import CyclicGroup
 
 from ..utils import (
-    Coeff, DomainExpr, sos_struct_reorder_symmetry,
+    Coeff, DomainExpr, structsos_reorder_symmetry,
     radsimp, sum_y_exprs, rationalize_func, quadratic_weighting, zip_longest,
     congruence, congruence_solve,
     StructuralSOSError, PolynomialNonpositiveError, PolynomialUnsolvableError
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from sympy import Expr, Symbol
 
 (
-    Coeff, DomainExpr, sos_struct_reorder_symmetry,
+    Coeff, DomainExpr, structsos_reorder_symmetry,
     radsimp, sum_y_exprs, rationalize_func, quadratic_weighting, zip_longest,
     congruence, congruence_solve,
     StructuralSOSError, PolynomialNonpositiveError, PolynomialUnsolvableError
@@ -98,7 +98,7 @@ def inverse_substitution(coeff: Coeff, expr: "Expr", factor_degree: int = 0) -> 
     return expr
 
 
-def sos_struct_handle_uncentered(solver: Callable) -> Callable:
+def structsos_handle_uncentered(solver: Callable) -> Callable:
     """
     A decorator for structural SOS with uncentered polynomial handling.
     It only supports cyclic polynomials.

--- a/triples/core/structsos/utils.py
+++ b/triples/core/structsos/utils.py
@@ -314,7 +314,7 @@ def block_partition(blocks: List[int], groups: Tuple[int, ...]) -> List[int]:
     return result
 
 
-def sos_struct_reorder_symmetry(groups: Tuple[int, ...]) -> Callable:
+def structsos_reorder_symmetry(groups: Tuple[int, ...]) -> Callable:
     """
     Decorator for the solver function to reorder the generators
     so that they are in the given symmetry.

--- a/triples/core/structsos/utils.py
+++ b/triples/core/structsos/utils.py
@@ -14,9 +14,7 @@ from ...utils.roots import nroots, rationalize_bound
 
 if TYPE_CHECKING:
     from sympy import MutableDenseMatrix as Matrix
-    from sympy import (
-        Symbol
-    )
+    from sympy import Symbol
 
 # use imports to keep linter happy
 (uniquely_named_symbol, Coeff, CyclicSum, CyclicProduct)
@@ -240,40 +238,12 @@ def clear_free_symbols(poly: Poly, ineq_constraints: Dict[Poly, Expr] = {}, eq_c
     even though it is not in the polynomial, as it is correlated with "x".
     """
     from ..problem import InequalityProblem
+    from warnings import warn
+    warn("clear_free_symbols is deprecated. Please use remove_redundancy instead.",
+         stacklevel=2, category=DeprecationWarning)
     pro = InequalityProblem(poly, ineq_constraints, eq_constraints)
     pro.remove_redundancy()
     return pro.expr, pro.ineq_constraints, pro.eq_constraints
-
-    # # Construct the "correlation" graph of the free symbols: symbols that are path-connected to free
-    # # vars in the polynomial are considered as active symbols.
-    # gens = poly.gens
-    # ufs = dict((gen, gen) for i, gen in enumerate(gens))
-    # def ufsunion(ufs: dict, p):
-    #     v = p.free_symbols
-    #     if len(v):
-    #         x0 = v.pop()
-    #         y0 = ufsfind(ufs, x0)
-    #         for x in v:
-    #             ufs[ufsfind(ufs, x)] = y0
-    # ufsunion(ufs, poly)
-    # for p in ineq_constraints:
-    #     ufsunion(ufs, p)
-    # for p in eq_constraints:
-    #     ufsunion(ufs, p)
-
-    # # Using .free_symbols is not the same as .gens. Because free_symbols exclude 0-degree gens.
-    # active_gens = set(ufsfind(ufs, gen) for gen in poly.free_symbols)
-    # active_gens = [x for x in gens if ufsfind(ufs, x) in active_gens]
-    # if len(active_gens) == 0:
-    #     active_gens = (gens[0],) # the polynomial is a constant, but we need a gen to create a poly
-
-    # def is_active(p):
-    #     return len(p.free_symbols.intersection(active_gens))
-
-    # poly = poly.as_poly(active_gens)
-    # ineq_constraints = {p.as_poly(active_gens): e for p, e in ineq_constraints.items() if is_active(p)}
-    # eq_constraints = {p.as_poly(active_gens): e for p, e in eq_constraints.items() if is_active(p)}
-    # return poly, ineq_constraints, eq_constraints
 
 
 def block_partition(blocks: List[int], groups: Tuple[int, ...]) -> List[int]:

--- a/triples/core/sum_of_squares.py
+++ b/triples/core/sum_of_squares.py
@@ -55,6 +55,7 @@ def sum_of_squares(
     ----------
     The function relies on SymPy for symbolic computation. First, import necessary items:
 
+        >>> from triples import sum_of_squares
         >>> from sympy.abc import x, y, a, b, c
         >>> from sympy import Expr, Function
 

--- a/triples/core/sum_of_squares.py
+++ b/triples/core/sum_of_squares.py
@@ -101,7 +101,7 @@ def sum_of_squares(
         Σ(x - y)**2*G(z)
 
 
-    ### Assumptions
+    ### Assumptions (newly added in 0.2.0.dev)
 
     Currently, all SymPy symbol assumptions are ignored by default and symbols are treated as
     real variables. To claim nonnegativity of symbols, just add them to `ineq_constraints`.

--- a/triples/testing/doctest_parser.py
+++ b/triples/testing/doctest_parser.py
@@ -466,16 +466,28 @@ def collect_doctest_examples(doc: str, configs: dict = {}, skip: bool = True) ->
     return _collect_doctest_examples_raw(doc, set_environ, single_parser, skip=skip)
 
 
-def solution_checker(solution, expr, ineq_constraints, eq_constraints,
-        *args, **kwargs) -> bool:
+def solution_checker(solution, expr=None, ineq_constraints=None, eq_constraints=None,
+        **kwargs) -> bool:
     if solution is None:
         return False
     if hasattr(solution, 'solution'):
+        expr = solution.expr if expr is None else expr
+        ineq_constraints = solution.ineq_constraints \
+            if ineq_constraints is None else ineq_constraints
+        eq_constraints = solution.eq_constraints \
+            if eq_constraints is None else eq_constraints
         solution = solution.solution
 
     from sympy import sympify, Eq
     expr = sympify(expr).as_expr()
     sol = solution
+
+    if isinstance(ineq_constraints, dict):
+        sol = sol.xreplace({v: k.as_expr()
+                for k, v in ineq_constraints.items() if v != k.as_expr()})
+    if isinstance(eq_constraints, dict):
+        sol = sol.xreplace({v: k.as_expr()
+                for k, v in eq_constraints.items() if v != k.as_expr()})
 
     fs1 = expr.free_symbols
     fs2 = sol.free_symbols

--- a/triples/testing/tests/test_code_quality.py
+++ b/triples/testing/tests/test_code_quality.py
@@ -1,3 +1,8 @@
+def _project_path():
+    from os.path import dirname, abspath
+    return dirname(dirname(dirname(abspath(__file__))))
+
+
 def test_dependency():
     """
     Test to ensure all import statements in .py files under a target directory only use allowed libraries.
@@ -7,7 +12,7 @@ def test_dependency():
     import os
 
     # path to the parent directory
-    base_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    base_path = _project_path()
 
     # modules to be checked
     modules = ["utils", "core", "sdp"]
@@ -64,3 +69,29 @@ def test_dependency():
         assert False, (
             f"Forbidden dependencies detected: {message}."
         )
+
+
+def test_ruff():
+    """
+    Execute ruff on the project.
+    """
+    import subprocess
+
+    # Get the project root directory
+    project_root = _project_path()
+
+    try:
+        # Run ruff on the project
+        result = subprocess.run(
+            ["ruff", "check", project_root],
+            capture_output=True,
+            text=True
+        )
+    except FileNotFoundError:
+        # pytest.skip("Ruff is not installed in the environment")
+        return
+
+    # Assert that ruff passes without errors
+    assert result.returncode == 0, (
+        f"Ruff found issues:\n{result.stdout}\n{result.stderr}"
+    )

--- a/triples/testing/tests/test_code_quality.py
+++ b/triples/testing/tests/test_code_quality.py
@@ -114,6 +114,4 @@ def test_eof_newline():
                     # print(f"Error reading {file_path}")
                     continue
                 assert not lines.endswith("\n\n"),\
-                    f"EOF multiple newlines found in {
-                        join("triples", relpath(file_path, lib_path))
-                    }"
+                    f"EOF multiple newlines found in {join('triples', relpath(file_path, lib_path))}"

--- a/triples/testing/tests/test_code_quality.py
+++ b/triples/testing/tests/test_code_quality.py
@@ -77,15 +77,22 @@ def test_ruff():
     """
     import subprocess
 
+    from platform import python_version_tuple
+
     # Get the project root directory
     project_root = _project_path()
 
     try:
+        if int(python_version_tuple()[0]) >= 3 and\
+           int(python_version_tuple()[1]) >= 7:
+            kwargs = {"capture_output": True, "text": True}
+        else:
+            kwargs = {}
+
         # Run ruff on the project
         result = subprocess.run(
             ["ruff", "check", project_root],
-            capture_output=True,
-            text=True
+            **kwargs
         )
     except FileNotFoundError:
         # pytest.skip("Ruff is not installed in the environment")

--- a/triples/testing/tests/test_code_quality.py
+++ b/triples/testing/tests/test_code_quality.py
@@ -95,3 +95,25 @@ def test_ruff():
     assert result.returncode == 0, (
         f"Ruff found issues:\n{result.stdout}\n{result.stderr}"
     )
+
+
+def test_eof_newline():
+    # ruff does not check W391 in the stable version
+    # so we use the manual check
+    from os import walk
+    from os.path import join, relpath
+    lib_path = _project_path()
+    for root, dirs, files in walk(lib_path):
+        for file in files:
+            if file.endswith(".py"):
+                file_path = join(root, file)
+                try:
+                    with open(file_path, "r", encoding="utf-8") as f:
+                        lines = f.read()
+                except Exception:
+                    # print(f"Error reading {file_path}")
+                    continue
+                assert not lines.endswith("\n\n"),\
+                    f"EOF multiple newlines found in {
+                        join("triples", relpath(file_path, lib_path))
+                    }"

--- a/triples/utils/__init__.py
+++ b/triples/utils/__init__.py
@@ -24,6 +24,7 @@ from .roots import (
     cancel_denominator,
 )
 
+from .polytools import resultant_bezout
 
 __all__ = [
     'MonomialManager', 'generate_monoms', 'generate_partitions', 'arraylize_np', 'arraylize_sp', 'invarraylize',
@@ -37,5 +38,6 @@ __all__ = [
     'Root', 'RootList', 'univar_realroots', 'kkt', 'optimize_poly', 'numeric_optimize_poly', 'numeric_optimize_skew_symmetry',
     'nroots', 'univariate_intervals', 'rationalize', 'rationalize_array', 'rationalize_bound',
     'rationalize_quadratic_curve', 'common_region_of_conics',
-    'cancel_denominator'
+    'cancel_denominator',
+    'resultant_bezout'
 ]

--- a/triples/utils/expressions/coeff.py
+++ b/triples/utils/expressions/coeff.py
@@ -535,8 +535,8 @@ class Coeff():
 
     def cancel_abc(self) -> Tuple[Tuple[int, ...], 'Coeff']:
         """
-        Assume poly = a^i*b^j*c^k * poly2.
-        Return ((i,j,k), Coeff(poly2)).
+        Assume `poly = a^i*b^j*c^k * poly2`.
+        Return `((i,j,k), Coeff(poly2))`.
         """
         if self.is_zero:
             return ((0,) * self.nvars, self)
@@ -556,9 +556,9 @@ class Coeff():
 
     def cancel_k(self) -> Tuple[int, 'Coeff']:
         """
-        Assume poly = Sum_{uvw}(x_{uvw} * a^{d*u} * b^{d*v} * c^{d*w}).
-        Write poly2 = Sum_{uvw}(x_{uvw} * a^{u} * b^{v} * c^{w}).
-        Return (d, Coeff(poly2))
+        Assume `poly = Sum_{uvw}(x_{uvw} * a^{d*u} * b^{d*v} * c^{d*w})`.
+        Write `poly2 = Sum_{uvw}(x_{uvw} * a^{u} * b^{v} * c^{w})`.
+        Return `(d, Coeff(poly2))`
         """
         from math import gcd
         monoms = self.monoms()

--- a/triples/utils/monomials.py
+++ b/triples/utils/monomials.py
@@ -2,7 +2,7 @@
 This module provides functions to manipulate the group symmetry of a polynomial,
 and also utilities to compute monomial representations under the group symmetry.
 """
-from collections import defaultdict
+from collections import defaultdict, deque
 from typing import (Dict, List, Tuple, Iterable, Callable,
     Union, Optional, Any, overload, TYPE_CHECKING
 )
@@ -887,16 +887,226 @@ def _identify_symmetry_from_blackbox(
     return PermutationGroup(*verified)
 
 
+def _identify_symmetry_by_polynomial_action(
+    lst_of_lsts: List[List[Poly]],
+    G: PermutationGroup,
+    max_orbit: int = 4096,
+) -> PermutationGroup:
+    """Find the common setwise stabilizer of polynomial lists.
+
+    The action of a permutation on a polynomial list is represented by the
+    underlying monomial dictionaries.  This avoids constructing SymPy
+    expressions during the orbit-stabilizer computation.
+    """
+    nvars = G.degree
+
+    def poly_key(poly):
+        rep = poly.rep
+        return rep.dom, tuple(sorted(rep.to_dict().items()))
+
+    initial = []
+    for polys in lst_of_lsts:
+        keys = []
+        for poly in polys:
+            key = poly_key(poly)
+            keys.append(key)
+        initial.append(frozenset(keys))
+    initial = tuple(initial)
+
+    transform_cache = {}
+
+    def transform_key(key, permutation):
+        permutation = tuple(permutation)
+        cache_key = (key, permutation)
+        transformed = transform_cache.get(cache_key)
+        if transformed is None:
+            domain, terms = key
+            transformed = (domain, tuple(sorted(
+                (tuple(monomial[i] for i in permutation), coeff)
+                for monomial, coeff in terms
+            )))
+            transform_cache[cache_key] = transformed
+        return transformed
+
+    def transform_state(state, permutation):
+        permutation = permutation.array_form
+        return tuple(frozenset(
+            transform_key(key, permutation) for key in polys
+        ) for polys in state)
+
+    generators = list(G.generators)
+    if all(transform_state(initial, permutation) == initial
+           for permutation in generators):
+        return G
+
+    # Schreier's lemma reconstructs a generating set for the stabilizer from
+    # a breadth-first orbit and its chosen transporters.
+    orbit = {initial: Permutation(list(range(nvars)))}
+    queue = deque([initial])
+    edges = []
+    while queue:
+        state = queue.popleft()
+        transporter = orbit[state]
+        for permutation in generators:
+            next_state = transform_state(state, permutation)
+            next_transporter = permutation * transporter
+            if next_state not in orbit:
+                if len(orbit) >= max_orbit:
+                    return _identify_symmetry_by_backtracking(
+                        lst_of_lsts, G
+                    )
+                orbit[next_state] = next_transporter
+                queue.append(next_state)
+            edges.append((transporter, permutation, orbit[next_state]))
+
+    stabilizer_generators = [
+        ~next_transporter * permutation * transporter
+        for transporter, permutation, next_transporter in edges
+    ]
+    if not stabilizer_generators:
+        stabilizer_generators = [Permutation(list(range(nvars)))]
+    return PermutationGroup(*stabilizer_generators)
+
+
+def _identify_symmetry_by_backtracking(
+    lst_of_lsts: List[List[Poly]],
+    G: PermutationGroup,
+) -> PermutationGroup:
+    """Exact fallback based on invariant projections of polynomial lists."""
+    nvars = G.degree
+
+    def poly_key(poly):
+        rep = poly.rep
+        return rep.dom, tuple(sorted(rep.to_dict().items()))
+
+    poly_terms = {}
+    lists = []
+    for polys in lst_of_lsts:
+        keys = set()
+        for poly in polys:
+            key = poly_key(poly)
+            poly_terms[key] = key[1]
+            keys.add(key)
+        lists.append(tuple(keys))
+
+    projection_cache = {}
+
+    def projection(key, indices):
+        indices = tuple(indices)
+        cache_key = (key, indices)
+        result = projection_cache.get(cache_key)
+        if result is not None:
+            return result
+        values = {}
+        for monomial, coeff in poly_terms[key]:
+            projected = tuple(monomial[i] for i in indices)
+            values[projected] = values.get(projected, 0) + coeff
+        result = tuple(sorted(
+            (monomial, coeff) for monomial, coeff in values.items()
+            if coeff != 0
+        ))
+        projection_cache[cache_key] = result
+        return result
+
+    def profile(variable):
+        return tuple(sorted(
+            (projection(key, (variable,)) for key in polys),
+            key=repr
+        ) for polys in lists)
+
+    variable_profiles = [profile(i) for i in range(nvars)]
+    candidates = [
+        [i for i in range(nvars) if variable_profiles[i] == variable_profiles[j]]
+        for j in range(nvars)
+    ]
+
+    pair_profiles = {}
+    for i in range(nvars):
+        for j in range(nvars):
+            pair_profiles[i, j] = tuple(sorted(
+                (projection(key, (i, j)) for key in polys),
+                key=repr
+            ) for polys in lists)
+
+    def partial_match(targets, sources):
+        for polys in lists:
+            source_counts = defaultdict(int)
+            target_counts = defaultdict(int)
+            for key in polys:
+                source_counts[projection(key, sources)] += 1
+                target_counts[projection(key, targets)] += 1
+            if source_counts != target_counts:
+                return False
+        return True
+
+    identity = Permutation(list(range(nvars)))
+    initial = tuple(frozenset(polys) for polys in lists)
+
+    def transformed_key(key, permutation):
+        return (
+            key[0],
+            tuple(sorted(
+                (tuple(monomial[i] for i in permutation.array_form), coeff)
+                for monomial, coeff in key[1]
+            ))
+        )
+
+    def is_valid(permutation):
+        transformed = tuple(frozenset(
+            transformed_key(key, permutation) for key in polys
+        ) for polys in initial)
+        return transformed == initial
+
+    subgroup_generators = []
+    for permutation in getattr(G, 'strong_gens', G.generators):
+        if is_valid(permutation):
+            subgroup_generators.append(permutation)
+    subgroup = PermutationGroup(*(subgroup_generators or [identity]))
+
+    order = sorted(range(nvars), key=lambda i: (len(candidates[i]), i))
+    mapping = [None] * nvars
+    used = set()
+
+    def visit(level, targets):
+        if level == nvars:
+            permutation = Permutation(mapping[:])
+            if permutation in G and is_valid(permutation) and permutation not in subgroup:
+                subgroup_generators.append(permutation)
+                visit.subgroup = PermutationGroup(*subgroup_generators)
+            return
+
+        target = order[level]
+        for source in candidates[target]:
+            if source in used:
+                continue
+            if any(
+                pair_profiles[source, mapping[other]] != pair_profiles[target, other]
+                for other in targets
+            ):
+                continue
+            mapping[target] = source
+            new_targets = targets + [target]
+            if partial_match(new_targets, [mapping[i] for i in new_targets]):
+                used.add(source)
+                visit(level + 1, new_targets)
+                used.remove(source)
+            mapping[target] = None
+
+    visit.subgroup = subgroup
+    visit(0, [])
+    return visit.subgroup
+
+
 def identify_symmetry_from_lists(
     lst_of_lsts: List[List[Poly]],
     G: Optional[PermutationGroup]=None
 ) -> PermutationGroup:
     """
-    Infer a symmetric group so that each list of (list of polynomials)
-    is symmetric with respect to the rule. It only identifies very
-    common groups like complete symmetric and cyclic groups.
+    Infer the common setwise stabilizer of the polynomial lists.
 
-    TODO: Implement a complete algorithm to identify all symmetric groups.
+    The result is the largest subgroup of ``G`` for which every input list
+    is closed under the induced variable permutation action.  If ``G`` is
+    omitted, the ambient group is the full symmetric group.
 
     Parameters
     ----------
@@ -943,20 +1153,17 @@ def identify_symmetry_from_lists(
             if p.gens != gens:
                 raise ValueError("All polynomials should have the same generators.")
 
-    def verify(perm):
-        return all(verify_symmetry(l, perm) for l in lst_of_lsts)
-
     nvars = len(gens)
-    if G is not None:
-        if nvars != 0 and nvars != G.degree:
-            raise ValueError("The degree of the permutation group must"
-                             " be the same as the number of variables.")
-        if nvars == 0:
-            return G
-        if G.is_trivial:
-            return G
-        return _identify_symmetry_from_blackbox(verify, G)
-    return _identify_symmetry_from_blackbox(verify, nvars)
+    if G is None and nvars == 0:
+        return PermutationGroup(Permutation([]))
+    if G is None:
+        G = SymmetricGroup(nvars)
+    elif nvars != 0 and nvars != G.degree:
+        raise ValueError("The degree of the permutation group must"
+                         " be the same as the number of variables.")
+    if nvars == 0 or G.is_trivial:
+        return G
+    return _identify_symmetry_by_polynomial_action(lst_of_lsts, G)
 
 
 def identify_symmetry(poly: Poly, G: Optional[PermutationGroup]=None) -> PermutationGroup:

--- a/triples/utils/monomials.py
+++ b/triples/utils/monomials.py
@@ -814,122 +814,60 @@ def verify_symmetry(
     return True
 
 
-def _identify_symmetry_from_blackbox(
-    f: Callable[[Permutation], bool],
-    G: Union[PermutationGroup, int]
-) -> PermutationGroup:
-    """
-    Identify symmetry by calling a black-box function `f` on each permutation.
-    If `G` is integer, then it implies the degree of the permutation.
-    If `G` is a permutation group, then it finds a subgroup of `G`.
-    """
-    # List a few candidates: symmetric, alternating, cyclic groups...
-    def _rotated(n, start=0):
-        return list(range(start+1, n+start)) + [start]
-    def _reflected(n, start=0):
-        return [start+1, start] + list(range(start+2, n+start))
-
-    verified = [] # storing permutations that fit the input
-    candidates = [] # a list of permutations
-
-    if isinstance(G, int):
-        nvars = G
-        G = SymmetricGroup(nvars)
-    else:
-        nvars = G.degree
-
-    if nvars > 1:
-        candidates.append(_rotated(nvars))
-        if nvars > 2:
-            candidates.append(_reflected(nvars))
-
-    for perm in map(Permutation, candidates):
-        if f(perm):
-            verified.append(perm)
-    if len(verified) == 2:
-        # reflection + cyclic -> complete symmetric group
-        # but it should be a subgroup of G, hence return G
-        return G
-    verified = [arg for arg in verified if arg in G]
-
-    candidates = []
-    # bi-symmetric group etc.
-    if nvars > 3:
-        half = nvars // 2
-        p1 = _rotated(half) + _rotated(half, half)
-        p2 = _reflected(half) + _reflected(half, half)
-        p3 = list(range(half,half*2)) + list(range(half))
-        if nvars % 2 == 1:
-            for p in [p1, p2, p3]:
-                p.append(nvars - 1)
-                candidates.append(p)
-                p = [0] + [_ + 1 for _ in p[:-1]]
-                candidates.append(p)
-        else:
-            for p in [p1, p2, p3]:
-                candidates.append(p)
-
-    if nvars > 2:
-        candidates.append(_rotated(nvars - 1) + [nvars - 1])
-        candidates.append([0] + _rotated(nvars - 1, 1))
-        if nvars > 3:
-            candidates.append(_reflected(nvars - 1) + [nvars - 1])
-            candidates.append([0] + _reflected(nvars - 1, 1))
-
-    is_sym = G._is_sym
-    for perm in map(Permutation, candidates):
-        if (is_sym or (perm in G)) and f(perm):
-            verified.append(perm)
-
-    if len(verified) == 0:
-        verified.append(Permutation(list(range(nvars))))
-
-    return PermutationGroup(*verified)
-
-
-def _identify_symmetry_by_polynomial_action(
-    lst_of_lsts: List[List[Poly]],
+def _identify_symmetry_from_action(
+    lst_of_lsts: List[List[Any]],
     G: PermutationGroup,
+    action: Callable[[Any, Permutation], Any],
+    get_key: Optional[Callable[[Any], Any]]=None,
+    get_projection: Optional[Callable[[Any, Tuple[int, ...]], Any]]=None,
     max_orbit: int = 4096,
 ) -> PermutationGroup:
-    """Find the common setwise stabilizer of polynomial lists.
+    """Find the common setwise stabilizer of lists of acted-on objects.
 
-    The action of a permutation on a polynomial list is represented by the
-    underlying monomial dictionaries.  This avoids constructing SymPy
-    expressions during the orbit-stabilizer computation.
+    ``action`` is a left action compatible with permutation multiplication.
+    ``get_key`` returns a hashable canonical object representation. If
+    ``get_projection`` is supplied, it is used by the exact fallback when
+    the object orbit is large.
     """
     nvars = G.degree
 
-    def poly_key(poly):
-        rep = poly.rep
-        return rep.dom, tuple(sorted(rep.to_dict().items()))
+    if get_key is None:
+        get_key = lambda x: x
 
     initial = []
     for polys in lst_of_lsts:
         keys = []
-        for poly in polys:
-            key = poly_key(poly)
-            keys.append(key)
+        for obj in polys:
+            keys.append(get_key(obj))
         initial.append(frozenset(keys))
     initial = tuple(initial)
+
+    objects = {}
+    for polys in lst_of_lsts:
+        for obj in polys:
+            objects[get_key(obj)] = obj
+
+    def get_object(key, permutation):
+        if key not in objects:
+            raise ValueError(
+                "The action produced an object whose key was not seen "
+                "before. Provide an action closed on the object type."
+            )
+        return action(objects[key], permutation)
 
     transform_cache = {}
 
     def transform_key(key, permutation):
-        permutation = tuple(permutation)
-        cache_key = (key, permutation)
+        cache_key = (key, tuple(permutation.array_form))
         transformed = transform_cache.get(cache_key)
         if transformed is None:
-            domain, terms = key
-            transformed = (domain, tuple(sorted(
-                (tuple(monomial[i] for i in permutation), coeff)
-                for monomial, coeff in terms
-            )))
+            transformed_object = get_object(key, permutation)
+            transformed = get_key(transformed_object)
+            objects[transformed] = transformed_object
             transform_cache[cache_key] = transformed
         return transformed
 
     def transform_state(state, permutation):
-        permutation = permutation.array_form
         return tuple(frozenset(
             transform_key(key, permutation) for key in polys
         ) for polys in state)
@@ -952,9 +890,13 @@ def _identify_symmetry_by_polynomial_action(
             next_transporter = permutation * transporter
             if next_state not in orbit:
                 if len(orbit) >= max_orbit:
-                    return _identify_symmetry_by_backtracking(
-                        lst_of_lsts, G
-                    )
+                    if get_projection is not None:
+                        return _identify_symmetry_by_action_backtracking(
+                            lst_of_lsts, G, action, get_key, get_projection
+                        )
+                    # Without projections there is no general shortcut for
+                    # a black-box action; keep the exact orbit computation
+                    # rather than enumerating every element of S_n.
                 orbit[next_state] = next_transporter
                 queue.append(next_state)
             edges.append((transporter, permutation, orbit[next_state]))
@@ -968,24 +910,23 @@ def _identify_symmetry_by_polynomial_action(
     return PermutationGroup(*stabilizer_generators)
 
 
-def _identify_symmetry_by_backtracking(
-    lst_of_lsts: List[List[Poly]],
+def _identify_symmetry_by_action_backtracking(
+    lst_of_lsts: List[List[Any]],
     G: PermutationGroup,
+    action: Callable[[Any, Permutation], Any],
+    get_key: Callable[[Any], Any],
+    get_projection: Callable[[Any, Tuple[int, ...]], Any],
 ) -> PermutationGroup:
-    """Exact fallback based on invariant projections of polynomial lists."""
+    """Find the stabilizer by exact projection-guided backtracking."""
     nvars = G.degree
 
-    def poly_key(poly):
-        rep = poly.rep
-        return rep.dom, tuple(sorted(rep.to_dict().items()))
-
-    poly_terms = {}
+    objects = {}
     lists = []
     for polys in lst_of_lsts:
         keys = set()
-        for poly in polys:
-            key = poly_key(poly)
-            poly_terms[key] = key[1]
+        for obj in polys:
+            key = get_key(obj)
+            objects[key] = obj
             keys.add(key)
         lists.append(tuple(keys))
 
@@ -997,14 +938,7 @@ def _identify_symmetry_by_backtracking(
         result = projection_cache.get(cache_key)
         if result is not None:
             return result
-        values = {}
-        for monomial, coeff in poly_terms[key]:
-            projected = tuple(monomial[i] for i in indices)
-            values[projected] = values.get(projected, 0) + coeff
-        result = tuple(sorted(
-            (monomial, coeff) for monomial, coeff in values.items()
-            if coeff != 0
-        ))
+        result = get_projection(objects[key], indices)
         projection_cache[cache_key] = result
         return result
 
@@ -1042,18 +976,9 @@ def _identify_symmetry_by_backtracking(
     identity = Permutation(list(range(nvars)))
     initial = tuple(frozenset(polys) for polys in lists)
 
-    def transformed_key(key, permutation):
-        return (
-            key[0],
-            tuple(sorted(
-                (tuple(monomial[i] for i in permutation.array_form), coeff)
-                for monomial, coeff in key[1]
-            ))
-        )
-
     def is_valid(permutation):
         transformed = tuple(frozenset(
-            transformed_key(key, permutation) for key in polys
+            get_key(action(objects[key], permutation)) for key in polys
         ) for polys in initial)
         return transformed == initial
 
@@ -1129,17 +1054,13 @@ def identify_symmetry_from_lists(
     True
 
     >>> identify_symmetry_from_lists([[(a+b+c-3).as_poly(a,b,c)],
-    ... [(2*a+b).as_poly(a,b,c), (2*b+c).as_poly(a,b,c), (2*c+a).as_poly(a,b,c)]])
-    PermutationGroup([
-        (0 1 2)])
+    ... [(2*a+b).as_poly(a,b,c), (2*b+c).as_poly(a,b,c), (2*c+a).as_poly(a,b,c)]]).is_cyclic
+    True
 
     See Also
     ----------
     identify_symmetry
 
-    Reference
-    ----------
-    [1] https://cs.stackexchange.com/questions/64335/how-to-find-the-symmetry-group-of-a-polynomial
     """
     gens = ()
     for l in lst_of_lsts:
@@ -1163,7 +1084,34 @@ def identify_symmetry_from_lists(
                          " be the same as the number of variables.")
     if nvars == 0 or G.is_trivial:
         return G
-    return _identify_symmetry_by_polynomial_action(lst_of_lsts, G)
+    def poly_key(poly):
+        rep = poly.rep
+        return rep.dom, tuple(sorted(rep.to_dict().items()))
+
+    def action(poly, permutation):
+        domain, terms = poly
+        terms = tuple(sorted(
+            (tuple(monomial[permutation(i)] for i in range(len(monomial))), coeff)
+            for monomial, coeff in terms
+        ))
+        return domain, terms
+
+    def get_projection(poly, indices):
+        _, source_terms = poly
+        terms = {}
+        for monomial, coeff in source_terms:
+            projected = tuple(monomial[i] for i in indices)
+            terms[projected] = terms.get(projected, 0) + coeff
+        return tuple(sorted(
+            (monomial, coeff) for monomial, coeff in terms.items()
+            if coeff != 0
+        ))
+
+    keyed_lists = [[poly_key(poly) for poly in polys] for polys in lst_of_lsts]
+    return _identify_symmetry_from_action(
+        keyed_lists, G, action, get_key=lambda x: x,
+        get_projection=get_projection
+    )
 
 
 def identify_symmetry(poly: Poly, G: Optional[PermutationGroup]=None) -> PermutationGroup:

--- a/triples/utils/polytools.py
+++ b/triples/utils/polytools.py
@@ -670,7 +670,17 @@ def resultant_bezout(f, g, x, reduced=False) -> Tuple[Poly, Poly, Poly]:
 
     If `reduced=True`, it tries to remove the gcd part.
     """
-    f, g = f.as_poly(x), g.as_poly(x)
+    def marginalize(p, x):
+        if not (isinstance(p, Poly) and x in p.gens and (not p.domain.is_EX)):
+            return p.as_poly(x)
+        if len(p.gens) == 1:
+            # p is univariate and p.gen == x
+            return p
+        gens = [s for s in p.gens if s != x] + [x]
+        p = p.reorder(*gens)
+        p = p.eject(*p.gens[:-1])
+        return p
+    f, g = marginalize(f, x), marginalize(g, x)
 
     f: Poly
     g: Poly

--- a/triples/utils/polytools.py
+++ b/triples/utils/polytools.py
@@ -1,6 +1,8 @@
 """
 Compatibility & enhancement tools for SymPy polys module.
 """
+from typing import Tuple
+
 from sympy import Poly, ZZ
 from sympy import __version__ as _SYMPY_VERSION
 try:
@@ -653,3 +655,62 @@ def dmp_gf_kron(f, u, K):
     # _dmp_check_degrees(F, u, result)
 
     return lc, result
+
+
+###############################################################################
+#
+#                                 Resultants
+#
+###############################################################################
+
+def resultant_bezout(f, g, x, reduced=False) -> Tuple[Poly, Poly, Poly]:
+    """
+    Return u, v, res such that `u * f + v * g == res`
+    where `res` is the resultant of `f` and `g` in variable `x`.
+
+    If `reduced=True`, it tries to remove the gcd part.
+    """
+    f, g = f.as_poly(x), g.as_poly(x)
+
+    f: Poly
+    g: Poly
+    f, g = f.unify(g)
+
+    r0, r1 = f, g
+    u0, v0 = f.one, f.zero
+    u1, v1 = f.zero, f.one
+
+    while r1.degree() > 0:
+        d = max(0, r0.degree()) - max(0, r1.degree())
+        if d < 0:
+            r0, r1 = r1, r0
+            u0, u1 = u1, u0
+            v0, v1 = v1, v0
+            d = -d
+
+        lc = r1.LC()
+        mult = lc**(d + 1)
+
+        # mult * r0 = q * r1 + r2
+        q, r2 = r0.pdiv(r1)
+
+        u2 = u0.mul_ground(mult) - q * u1
+        v2 = v0.mul_ground(mult) - q * v1
+        r0, r1 = r1, r2
+        u0, u1 = u1, u2
+        v0, v1 = v1, v2
+
+    if r1.is_zero:
+        return r1, r1, r1
+
+    if not reduced:
+        res = f.resultant(g)
+        C = r1.quo(res)
+    else:
+        uvgcd = u1.gcd(v1)
+        C, __, res = uvgcd.cofactors(r1)
+
+    u = u1.quo(C)
+    v = v1.quo(C)
+
+    return u, v, res

--- a/triples/utils/polytools.py
+++ b/triples/utils/polytools.py
@@ -717,7 +717,7 @@ def resultant_bezout(f, g, x, reduced=False) -> Tuple[Poly, Poly, Poly]:
         res = f.resultant(g)
         C = r1.quo(res)
     else:
-        uvgcd = u1.gcd(v1)
+        uvgcd = marginalize(u1.inject().gcd(v1.inject()), x)
         C, __, res = uvgcd.cofactors(r1)
 
     u = u1.quo(C)

--- a/triples/utils/tests/test_monomials.py
+++ b/triples/utils/tests/test_monomials.py
@@ -1,0 +1,59 @@
+from sympy import symbols
+from sympy.combinatorics import CyclicGroup, DihedralGroup
+
+from ..monomials import identify_symmetry_from_lists, verify_symmetry
+
+
+def test_identify_symmetry_from_lists():
+    # S3
+    a, b, c, d, z1, z2, z3, z4, z5 = symbols("a b c d z1 z2 z3 z4 z5")
+    gens = (a, b, c, z1, z2, z3, z4, z5)
+    to_poly = lambda expression: expression.as_poly(*gens)
+    polys = [
+        [z1 - z2 - z3 - z4 + 2*z5],
+        [
+            a*b + a*c + b*c,
+            a**2 + a*b + b**2,
+            z2,
+            a**2 + a*c + c**2,
+            z3,
+            b**2 + b*c + c**2,
+            z4,
+            a**2 + b**2 + c**2,
+            z5,
+            a, b, c
+        ],
+        [
+            a*b + a*c + b*c - z1**2,
+            a**2 + a*b + b**2 - z2**2,
+            a**2 + a*c + c**2 - z3**2,
+            b**2 + b*c + c**2 - z4**2,
+            a**2 + b**2 + c**2 - z5**2,
+        ],
+    ]
+    polys = [[to_poly(poly) for poly in group] for group in polys]
+    symmetry = identify_symmetry_from_lists(polys)
+
+    assert symmetry.order() == 6
+    assert verify_symmetry(polys[1], symmetry)
+    assert verify_symmetry(polys[2], symmetry)
+
+
+    # test the function is independent of the variable name or order
+    polys = [[
+        (2*a + b).as_poly(a, b, c),
+        (2*b + c).as_poly(a, b, c),
+        (2*c + a).as_poly(a, b, c),
+    ]]
+    permuted_polys = [[poly.reorder(b, c, a) for poly in polys[0]]]
+
+    assert identify_symmetry_from_lists(polys).order() == 3
+    assert identify_symmetry_from_lists(permuted_polys).order() == 3
+
+
+    # respect to the ambient group
+    a, b, c, d = symbols("a b c d")
+    polys = [[(a*b).as_poly(a, b, c, d)]]
+
+    assert identify_symmetry_from_lists(polys, DihedralGroup(4)).order() == 2
+    assert identify_symmetry_from_lists(polys, CyclicGroup(4)).order() == 1

--- a/triples/utils/tests/test_monomials.py
+++ b/triples/utils/tests/test_monomials.py
@@ -1,7 +1,11 @@
 from sympy import symbols
-from sympy.combinatorics import CyclicGroup, DihedralGroup
+from sympy.combinatorics import CyclicGroup, DihedralGroup, SymmetricGroup
 
-from ..monomials import identify_symmetry_from_lists, verify_symmetry
+from ..monomials import (
+    _identify_symmetry_from_action,
+    identify_symmetry_from_lists,
+    verify_symmetry,
+)
 
 
 def test_identify_symmetry_from_lists():
@@ -57,3 +61,20 @@ def test_identify_symmetry_from_lists():
 
     assert identify_symmetry_from_lists(polys, DihedralGroup(4)).order() == 2
     assert identify_symmetry_from_lists(polys, CyclicGroup(4)).order() == 1
+
+
+def test_identify_symmetry_from_action():
+    objects = [[
+        (1, 2, 3),
+        (2, 3, 1),
+        (3, 1, 2),
+    ]]
+
+    def action(obj, permutation):
+        return tuple(obj[permutation(i)] for i in range(3))
+
+    symmetry = _identify_symmetry_from_action(
+        objects, SymmetricGroup(3), action
+    )
+
+    assert symmetry.order() == 3


### PR DESCRIPTION
### API changes


* Renamed functions `sos_struct_xxx` to `structsos_xxx`.
* Changed the input type of multiple structural SOS subsolvers to `InequalityProblem`.
* Deprecated the SolutionStructural subclass. Added an `extract_undetermined_exprs` to replace its functionality.
* Changed the input type of `linsos.tangents._get_ineq_constrained_tangents`, which now processes multiple inequalities simultaneously.
* Modified the `InequalityProblem.transform` function to transform the aliases of the constraints also.


### Improvements
* Removed old homogenization algorithms and replaced it with a resultant-based elimination algorithm.
* Removed `_identify_symmetry_from_blackbox` and replaced it with a better algorithm.
* Made `StructuralSOS` check whether the variables are on R or R+ before solving the problem.
* Made `StructuralSOS` handle linear inequality constraints for certain structures.
* Let `testing.doctest_parser.solution_checker` infer the problem expressions and constraints automatically from the solution instance.
* Added time limit checks to functions in `linsos.tangents` to avoid getting stuck.
* Improved the logging.
* Removed the 'skip' decorator before some of the testing problems.
* Integrated the ruff check into pytest.